### PR TITLE
Bumping version to 0.2.0.0

### DIFF
--- a/src/D2L.CodeStyle.Analysis/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analysis/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("76c3649d-ee9f-45bd-851c-8657ee1cd415")]
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]
 
 [assembly: InternalsVisibleTo("D2L.CodeStyle.Analysis.UnitTests")]

--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.1.0.0" )]
-[assembly: AssemblyFileVersion( "0.1.0.0" )]
+[assembly: AssemblyVersion( "0.2.0.0" )]
+[assembly: AssemblyFileVersion( "0.2.0.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]

--- a/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("35fe7851-3f76-4057-9754-e883231619d0")]
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]


### PR DESCRIPTION
Requires #8 and #9.