### PR TITLE
System.Collections.Generic.IReadOnlyDictionary is safe.

### DIFF
--- a/src/D2L.CodeStyle.Analysis/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analysis/MutabilityInspector.cs
@@ -41,6 +41,7 @@ namespace D2L.CodeStyle.Analysis {
 			"System.Collections.Immutable.ImmutableSortedSet",
 			"System.Collections.Immutable.ImmutableStack",
 			"System.Collections.Generic.IReadOnlyList",
+			"System.Collections.Generic.IReadOnlyDictionary",
 			"System.Collections.Generic.IEnumerable",
 		}.ToImmutableHashSet();
 

--- a/src/D2L.CodeStyle.Analysis/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analysis/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("76c3649d-ee9f-45bd-851c-8657ee1cd415")]
 
-[assembly: AssemblyVersion("0.4.1.0")]
-[assembly: AssemblyFileVersion("0.4.1.0")]
+[assembly: AssemblyVersion("0.4.2.0")]
+[assembly: AssemblyFileVersion("0.4.2.0")]
 
 [assembly: InternalsVisibleTo("D2L.CodeStyle.Analysis.UnitTests")]

--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.4.1.0" )]
-[assembly: AssemblyFileVersion( "0.4.1.0" )]
+[assembly: AssemblyVersion( "0.4.2.0" )]
+[assembly: AssemblyFileVersion( "0.4.2.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]

--- a/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("35fe7851-3f76-4057-9754-e883231619d0")]
 
-[assembly: AssemblyVersion("0.4.1.0")]
-[assembly: AssemblyFileVersion("0.4.1.0")]
+[assembly: AssemblyVersion("0.4.2.0")]
+[assembly: AssemblyFileVersion("0.4.2.0")]


### PR DESCRIPTION
IReadOnlyDictionary, althought itself potentially backed by a mutable
dictionary, is to be considered safe. Using ImmutableDictionary itself
is not enough, because it implements the (mutating) IDictionary interface
and simply throws on mutating methods. Grrr.