### PR TITLE
Add an unsafe static counter, to measure our progress

### DIFF
--- a/D2L.CodeStyle.sln
+++ b/D2L.CodeStyle.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.Analyzers", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.Analyzers.Tests", "tests\D2L.CodeStyle.Analyzers.Test\D2L.CodeStyle.Analyzers.Tests.csproj", "{1C54E78A-E12B-45C3-BA6E-31DB5C63B389}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.UnsafeStaticCounter", "src\D2L.CodeStyle.UnsafeStaticCounter\D2L.CodeStyle.UnsafeStaticCounter.csproj", "{9BBEB2F8-0D57-426A-A34B-6E8D30A92EEF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{1C54E78A-E12B-45C3-BA6E-31DB5C63B389}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C54E78A-E12B-45C3-BA6E-31DB5C63B389}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C54E78A-E12B-45C3-BA6E-31DB5C63B389}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BBEB2F8-0D57-426A-A34B-6E8D30A92EEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BBEB2F8-0D57-426A-A34B-6E8D30A92EEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BBEB2F8-0D57-426A-A34B-6E8D30A92EEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BBEB2F8-0D57-426A-A34B-6E8D30A92EEF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.5.0.0" )]
-[assembly: AssemblyFileVersion( "0.5.0.0" )]
+[assembly: AssemblyVersion( "0.5.1.0" )]
+[assembly: AssemblyFileVersion( "0.5.1.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]

--- a/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
@@ -205,9 +205,10 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 			var diagnostic = Diagnostic.Create(
 				Rule,
 				location,
+				properties,
 				fieldOrPropName,
-				offendingType,
-				properties
+				offendingType
+				
 			);
 			return diagnostic;
 		}

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
@@ -20,24 +20,27 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 			foreach( var result in rawResults ) {
 
 				// increment per project
-				if( !unsafeStaticsPerProject.ContainsKey( result.ProjectName ) ) {
-					unsafeStaticsPerProject[result.ProjectName] = new AnalyzedProject( result.ProjectName );
-				}
-				unsafeStaticsPerProject[result.ProjectName].UnsafeStaticsCount++;
-
+				var project = unsafeStaticsPerProject.GetOrAdd(
+						result.ProjectName,
+						() => new AnalyzedProject( result.ProjectName )
+					);
+				project.UnsafeStaticsCount++;
 
 				// increment per-type
 				if( result.FieldOrPropType != null ) {
-					if( !unsafeStaticsPerType.ContainsKey( result.FieldOrPropType ) ) {
-						unsafeStaticsPerType[result.FieldOrPropType] = new AnalyzedType( result.FieldOrPropType );
-					}
-					unsafeStaticsPerType[result.FieldOrPropType].UnsafeStaticsCount++;
+
+					var analyzedType = unsafeStaticsPerType.GetOrAdd(
+							result.FieldOrPropType,
+							() => new AnalyzedType( result.FieldOrPropType )
+						);
+					analyzedType.UnsafeStaticsCount++;
 				}
 			}
 
 			// move `it` to readonly count
-			if( unsafeStaticsPerType.ContainsKey( "it" ) ) {
-				UnsafeNonReadonlyStaticsCount = unsafeStaticsPerType["it"].UnsafeStaticsCount;
+			AnalyzedType itType;
+			if( unsafeStaticsPerType.TryGetValue( "it", out itType ) ) {
+				UnsafeNonReadonlyStaticsCount = itType.UnsafeStaticsCount;
 				unsafeStaticsPerType.Remove( "it" );
 			}
 

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+
+namespace D2L.CodeStyle.UnsafeStaticCounter {
+
+	internal sealed class AnalyzedResults {
+		public readonly int UnsafeStaticsCount;
+		public readonly int UnsafeNonReadonlyStaticsCount;
+		public readonly IEnumerable<AnalyzedType> UnsafeStaticsPerType;
+		public readonly IEnumerable<AnalyzedProject> UnsafeStaticsPerProject;
+		public readonly IEnumerable<AnalyzedStatic> RawResults;
+
+		public AnalyzedResults( AnalyzedStatic[] rawResults ) {
+			RawResults = rawResults;
+
+			UnsafeStaticsCount = rawResults.Length;
+
+			var unsafeStaticsPerProject = new Dictionary<string, AnalyzedProject>();
+			var unsafeStaticsPerType = new Dictionary<string, AnalyzedType>();
+
+			foreach( var result in rawResults ) {
+
+				// increment per project
+				if( !unsafeStaticsPerProject.ContainsKey( result.ProjectName ) ) {
+					unsafeStaticsPerProject[result.ProjectName] = new AnalyzedProject( result.ProjectName );
+				}
+				unsafeStaticsPerProject[result.ProjectName].UnsafeStaticsCount++;
+
+
+				// increment per-type
+				if( result.FieldOrPropType != null ) {
+					if( !unsafeStaticsPerType.ContainsKey( result.FieldOrPropType ) ) {
+						unsafeStaticsPerType[result.FieldOrPropType] = new AnalyzedType( result.FieldOrPropType );
+					}
+					unsafeStaticsPerType[result.FieldOrPropType].UnsafeStaticsCount++;
+				}
+			}
+
+			// move `it` to readonly count
+			if( unsafeStaticsPerType.ContainsKey( "it" ) ) {
+				UnsafeNonReadonlyStaticsCount = unsafeStaticsPerType["it"].UnsafeStaticsCount;
+				unsafeStaticsPerType.Remove( "it" );
+			}
+
+			UnsafeStaticsPerProject = unsafeStaticsPerProject.Values;
+			UnsafeStaticsPerType = unsafeStaticsPerType.Values;
+		}
+	}
+
+	internal sealed class AnalyzedProject {
+		public readonly string Name;
+		public int UnsafeStaticsCount;
+
+		public AnalyzedProject( string projectName ) {
+			Name = projectName;
+		}
+	}
+	internal sealed class AnalyzedType {
+		public readonly string Name;
+		public int UnsafeStaticsCount;
+
+		public AnalyzedType( string typeName ) {
+			Name = typeName;
+		}
+	}
+}

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedStatic.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedStatic.cs
@@ -1,0 +1,30 @@
+﻿using D2L.CodeStyle.Analyzers.UnsafeStatics;
+using Microsoft.CodeAnalysis;
+
+namespace D2L.CodeStyle.UnsafeStaticCounter {
+
+	internal sealed class AnalyzedStatic {
+		public const string CAUSE_MUTABLE_DECLARATION = "DeclarationIsMutable";
+		public const string CAUSE_MUTABLE_TYPE = "TypeIsMutable";
+
+		public readonly string ProjectName;
+		public readonly string FilePath;
+		public readonly string FieldOrPropName;
+		public readonly string FieldOrPropType;
+		public readonly string Cause;
+
+		public AnalyzedStatic( string projectName, Diagnostic diag ) {
+			ProjectName = projectName;
+			FilePath = diag.Location.SourceTree.FilePath;
+			FieldOrPropName = diag.Properties[UnsafeStaticsAnalyzer.PROPERTY_FIELDORPROPNAME];
+			FieldOrPropType = diag.Properties[UnsafeStaticsAnalyzer.PROPERTY_OFFENDINGTYPE];
+
+			if( FieldOrPropType == "it" ) {
+				FieldOrPropType = null; // analyzer doesn't expose type if declaration is unsafe
+				Cause = CAUSE_MUTABLE_DECLARATION;
+			} else {
+				Cause = CAUSE_MUTABLE_TYPE;
+			}
+		}
+	}
+}

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/App.config
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
@@ -26,10 +26,11 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 			_outputFile = options.OutputFile;
 		}
 
-		internal async Task Run() {
+		internal async Task<int> Run() {
 			var results = await AnalyzeProjects();
 			WriteOutputFile( results );
 			Console.WriteLine( "done" );
+			return 0;
 		}
 
 		async Task<AnalyzedResults> AnalyzeProjects() {

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
@@ -27,7 +27,12 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 		}
 
 		internal async Task Run() {
+			var results = await AnalyzeProjects();
+			WriteOutputFile( results );
+			Console.WriteLine( "done" );
+		}
 
+		async Task<AnalyzedResults> AnalyzeProjects() {
 			var projectFiles = Directory.EnumerateFiles( _rootDir, "*.csproj", SearchOption.AllDirectories );
 
 			var tasks = projectFiles.Select( AnalyzeProject );
@@ -38,13 +43,17 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 				.ToArray();
 
 			var finalResult = new AnalyzedResults( combinedResult );
+			return finalResult;
+		}
 
-			var serializer = new JsonSerializer();
+		void WriteOutputFile( AnalyzedResults results ) {
+			var serializer = JsonSerializer.Create( new JsonSerializerSettings {
+				Formatting = Formatting.Indented
+			} );
 			using( var file = File.Open( _outputFile, FileMode.Create ) )
 			using( var stream = new StreamWriter( file ) ) {
-				serializer.Serialize( stream, finalResult );
+				serializer.Serialize( stream, results );
 			}
-			Console.WriteLine( "done" );
 		}
 
 		async Task<AnalyzedStatic[]> AnalyzeProject( string projectFile ) {

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
@@ -14,10 +14,10 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 	internal sealed class Counter {
 
-		private string _rootDir;
-		private string _outputFile;
-		ImmutableArray<DiagnosticAnalyzer> _analyzers;
-		SemaphoreSlim _semaphore;
+		private readonly string _rootDir;
+		private readonly string _outputFile;
+		private readonly ImmutableArray<DiagnosticAnalyzer> _analyzers;
+		private readonly SemaphoreSlim _semaphore;
 
 		public Counter( Options options ) {
 			_analyzers = ImmutableArray.Create<DiagnosticAnalyzer>( new UnsafeStaticsAnalyzer() );

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using D2L.CodeStyle.Analyzers.UnsafeStatics;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.MSBuild;
+using Newtonsoft.Json;
+
+namespace D2L.CodeStyle.UnsafeStaticCounter {
+
+	internal sealed class Counter {
+
+		private string _rootDir;
+		private string _outputFile;
+		ImmutableArray<DiagnosticAnalyzer> _analyzers;
+		SemaphoreSlim _semaphore;
+
+		public Counter( Options options ) {
+			_analyzers = ImmutableArray.Create<DiagnosticAnalyzer>( new UnsafeStaticsAnalyzer() );
+			_semaphore = new SemaphoreSlim( options.MaxConcurrency );
+			_rootDir = options.RootDir;
+			_outputFile = options.OutputFile;
+		}
+
+		internal async Task Run() {
+
+			var projectFiles = Directory.EnumerateFiles( _rootDir, "*.csproj", SearchOption.AllDirectories );
+
+			var tasks = projectFiles.Select( AnalyzeProject );
+			var results = await Task.WhenAll( tasks );
+
+			var combinedResult = results
+				.SelectMany( r => r )
+				.ToArray();
+
+			var finalResult = new AnalyzedResults( combinedResult );
+
+			var serializer = new JsonSerializer();
+			using( var file = File.Open( _outputFile, FileMode.Create ) )
+			using( var stream = new StreamWriter( file ) ) {
+				serializer.Serialize( stream, finalResult );
+			}
+			Console.WriteLine( "done" );
+		}
+
+		async Task<AnalyzedStatic[]> AnalyzeProject( string projectFile ) {
+			try {
+				_semaphore.Wait();
+				using( var workspace = MSBuildWorkspace.Create() ) {
+					var proj = await workspace.OpenProjectAsync( projectFile );
+					Console.WriteLine( $"Analyzing: ${proj.FilePath}" );
+					var compilation = await proj.GetCompilationAsync();
+					var compilationWithAnalzer = compilation.WithAnalyzers( _analyzers );
+
+					var diags = await compilationWithAnalzer.GetAnalyzerDiagnosticsAsync();
+					return diags
+						.Select( d => new AnalyzedStatic( proj.Name, d ) )
+						.ToArray();
+				}
+			} finally {
+				_semaphore.Release();
+			}
+		}
+	}
+}

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
@@ -62,11 +62,11 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 				_semaphore.Wait();
 				using( var workspace = MSBuildWorkspace.Create() ) {
 					var proj = await workspace.OpenProjectAsync( projectFile );
-					Console.WriteLine( $"Analyzing: ${proj.FilePath}" );
+					Console.WriteLine( $"Analyzing: {proj.FilePath}" );
 
 					// ignore projects with analyzer already included -- there are no unsafe statics by definition
 					if( ProjectAlreadyAnalyzed( proj)) {
-						Console.WriteLine( $"...skipping ${proj.FilePath}" );
+						Console.WriteLine( $"...skipping {proj.FilePath}" );
 						return new AnalyzedStatic[0];
 					}
 

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.csproj
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.csproj
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9BBEB2F8-0D57-426A-A34B-6E8D30A92EEF}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>D2L.CodeStyle.UnsafeStaticCounter</RootNamespace>
+    <AssemblyName>D2L.CodeStyle.UnsafeStaticCounter</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.2.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.2.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.0\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AnalyzedResults.cs" />
+    <Compile Include="AnalyzedStatic.cs" />
+    <Compile Include="Counter.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="D2L.CodeStyle.UnsafeStaticCounter.nuspec">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\D2L.CodeStyle.Analyzers\D2L.CodeStyle.Analyzers.csproj">
+      <Project>{fe7608cd-c8b1-43dd-bbcc-9b1917c9ca73}</Project>
+      <Name>D2L.CodeStyle.Analyzers</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.csproj
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AnalyzedResults.cs" />
     <Compile Include="AnalyzedStatic.cs" />
     <Compile Include="Counter.cs" />
+    <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.nuspec
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+
+    <projectUrl>https://github.com/Brightspace/D2L.CodeStyle</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <copyright>$copyright$</copyright>
+    
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System" targetFramework="" />
+    </frameworkAssemblies>
+  </metadata>
+  
+  <files>
+    <file src="*.dll,*.exe" target="tools" />
+  </files>
+</package>

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.nuspec
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.nuspec
@@ -18,6 +18,6 @@
   </metadata>
   
   <files>
-    <file src="*.dll,*.exe" target="tools" />
+    <file src="bin\$configuration$\*" target="tools\" />
   </files>
 </package>

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/DictionaryExtensions.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/DictionaryExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace D2L.CodeStyle.UnsafeStaticCounter {
+
+	internal static class DictionaryExtensions {
+
+		internal static TValue GetOrAdd<TKey, TValue>(
+				this IDictionary<TKey, TValue> dictionary,
+				TKey key,
+				Func<TValue> getter
+			) {
+
+			TValue value;
+			if( dictionary.TryGetValue( key, out value ) ) {
+				return value;
+			}
+
+			value = getter();
+			dictionary.Add( key, value );
+			return value;
+		}
+	}
+}

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
@@ -17,7 +17,7 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 			try {
 				return await AsyncThrowableMain( args );
 			} catch( Exception e ) {
-				LogException( e );
+				Console.Error.WriteLine( e.ToString() );
 				return -1;
 			}
 		}
@@ -27,10 +27,6 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 			var prog = new Counter( options );
 			var result = await prog.Run();
 			return result;
-		}
-
-		private static void LogException( Exception e ) {
-			Console.Error.WriteLine( e.ToString() );
 		}
 
 		private static Options ParseOptions( IEnumerable<string> args ) {

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
@@ -30,12 +30,12 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 			Console.Error.WriteLine( e.ToString() );
 		}
 
-		private static Options ParseOptions( string[] args ) {
-			string path = @"c:\d2l\instances\all\checkout";
+		private static Options ParseOptions( IEnumerable<string> args ) {
+			string path = null;
 			int concurrency = DEFAULT_MAX_CONCURRENCY;
 			string outputFile = "statics.json";
 
-			var enumerator = ( (IEnumerable<string>)args ).GetEnumerator(); // Array has non-generic enumerator only :facepalm:
+			var enumerator = args.GetEnumerator();
 			while( enumerator.MoveNext() ) {
 				switch( enumerator.Current ) {
 					case "-n":

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace D2L.CodeStyle.UnsafeStaticCounter {
+	internal sealed class Program {
+		const int DEFAULT_MAX_CONCURRENCY = 4;
+
+		static void Main( string[] args ) {
+			Task.Run( async () => await AsyncMain( args ) )
+				.GetAwaiter()
+				.GetResult();
+		}
+
+		static async Task AsyncMain( string[] args ) {
+			try {
+				await AsyncThrowableMain( args );
+			} catch( Exception e ) {
+				LogException( e );
+			}
+		}
+
+		static async Task AsyncThrowableMain( string[] args ) {
+			var options = ParseOptions( args );
+			var prog = new Counter( options );
+			await prog.Run();
+		}
+
+		static void LogException( Exception e ) {
+			while( e != null ) {
+				if( e is AggregateException ) {
+					var ae = e as AggregateException;
+					foreach( var ie in ae.InnerExceptions ) {
+						LogException( ie );
+					}
+				} else {
+					Console.WriteLine( $"error: {e.Message}" );
+				}
+				e = e.InnerException;
+			}
+		}
+
+		private static Options ParseOptions( string[] args ) {
+			string path = @"c:\d2l\instances\all\checkout";
+			int concurrency = DEFAULT_MAX_CONCURRENCY;
+			string outputFile = "statics.json";
+
+			var enumerator = ( (IEnumerable<string>)args ).GetEnumerator(); // Array has non-generic enumerator only :facepalm:
+			while( enumerator.MoveNext() ) {
+				switch( enumerator.Current ) {
+					case "-n":
+						enumerator.MoveNext();
+						concurrency = int.Parse( enumerator.Current );
+						break;
+					case "-d":
+						enumerator.MoveNext();
+						path = enumerator.Current;
+						break;
+					case "-o":
+						enumerator.MoveNext();
+						outputFile = enumerator.Current;
+						break;
+				}
+			}
+
+			if( string.IsNullOrWhiteSpace( path ) ) {
+				throw new InvalidOperationException( "usage: UnsafeStaticsCounter.exe -d {rootDir} [-n {concurrency} -o {outputFile}]" );
+			}
+
+			Console.WriteLine( "Using options:" );
+			Console.WriteLine( $"\tPath = {path}" );
+			Console.WriteLine( $"\tMaxConcurrency = {concurrency}" );
+			Console.WriteLine( $"\tOutputFile = {outputFile}" );
+			Console.WriteLine();
+
+			return new Options( path, concurrency, outputFile );
+		}
+	}
+
+	internal sealed class Options {
+		public readonly string RootDir;
+		public readonly int MaxConcurrency;
+		public readonly string OutputFile;
+		public Options( string rootDir, int maxConcurrency, string outputFile ) {
+			RootDir = rootDir;
+			MaxConcurrency = maxConcurrency;
+			OutputFile = outputFile;
+		}
+	}
+
+}

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
@@ -50,6 +50,8 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 						enumerator.MoveNext();
 						outputFile = enumerator.Current;
 						break;
+					default:
+						throw new InvalidOperationException( $"unknown option: {enumerator.Current}" );
 				}
 			}
 

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
@@ -7,23 +7,27 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 		const int DEFAULT_MAX_CONCURRENCY = 4;
 
 		static void Main( string[] args ) {
-			Task.Run( async () => await AsyncMain( args ) )
+			var exitCode = Task.Run( async () => await AsyncMain( args ) )
 				.GetAwaiter()
 				.GetResult();
+			Environment.Exit( exitCode );
 		}
 
-		static async Task AsyncMain( string[] args ) {
+		static async Task<int> AsyncMain( string[] args ) {
 			try {
-				await AsyncThrowableMain( args );
+				return await AsyncThrowableMain( args );
 			} catch( Exception e ) {
 				LogException( e );
+				return -1;
+
 			}
 		}
 
-		static async Task AsyncThrowableMain( string[] args ) {
+		static async Task<int> AsyncThrowableMain( string[] args ) {
 			var options = ParseOptions( args );
 			var prog = new Counter( options );
-			await prog.Run();
+			var result = await prog.Run();
+			return result;
 		}
 
 		static void LogException( Exception e ) {

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
@@ -27,17 +27,7 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 		}
 
 		static void LogException( Exception e ) {
-			while( e != null ) {
-				if( e is AggregateException ) {
-					var ae = e as AggregateException;
-					foreach( var ie in ae.InnerExceptions ) {
-						LogException( ie );
-					}
-				} else {
-					Console.WriteLine( $"error: {e.Message}" );
-				}
-				e = e.InnerException;
-			}
+			Console.Error.WriteLine( e.ToString() );
 		}
 
 		private static Options ParseOptions( string[] args ) {

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
@@ -6,31 +6,30 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 	internal sealed class Program {
 		const int DEFAULT_MAX_CONCURRENCY = 4;
 
-		static void Main( string[] args ) {
-			var exitCode = Task.Run( async () => await AsyncMain( args ) )
+		internal static int Main( string[] args ) {
+			int exitCode = Task.Run( async () => await AsyncMain( args ) )
 				.GetAwaiter()
 				.GetResult();
-			Environment.Exit( exitCode );
+			return exitCode;
 		}
 
-		static async Task<int> AsyncMain( string[] args ) {
+		private static async Task<int> AsyncMain( string[] args ) {
 			try {
 				return await AsyncThrowableMain( args );
 			} catch( Exception e ) {
 				LogException( e );
 				return -1;
-
 			}
 		}
 
-		static async Task<int> AsyncThrowableMain( string[] args ) {
+		private static async Task<int> AsyncThrowableMain( string[] args ) {
 			var options = ParseOptions( args );
 			var prog = new Counter( options );
 			var result = await prog.Run();
 			return result;
 		}
 
-		static void LogException( Exception e ) {
+		private static void LogException( Exception e ) {
 			Console.Error.WriteLine( e.ToString() );
 		}
 

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle( "D2L.CodeStyle.UnsafeStaticsCounter" )]
+[assembly: AssemblyDescription( "D2L.CodeStyle unsafe statics counter" )]
+[assembly: AssemblyCompany( "D2L" )]
+[assembly: AssemblyProduct( "D2L.CodeStyle.UnsafeStaticsCounter" )]
+[assembly: AssemblyCopyright( "Copyright © D2L 2016" )]
+
+[assembly: ComVisible( false )]
+
+[assembly: AssemblyVersion( "0.5.1.0" )]
+[assembly: AssemblyFileVersion( "0.5.1.0" )]

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/packages.config
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/packages.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0" targetFramework="net461" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net461" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net461" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net461" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net461" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net461" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
This adds `D2L.CodeStyle.UnsafeStaticCounter.exe`, to be used post-build to report our progress. It is used as such:

```
D2L.CodeStyle.UnsafeStaticCounter.exe -d {checkoutDir} -n {maxConcurrency} -o {outputFile}
```

...and outputs the following:

```json
{
  "UnsafeStaticsCount": 2951,
  "UnsafeNonReadonlyStaticsCount": 0,
  "UnsafeStaticsPerType": [
    {
      "Name": "System.Xml.Serialization.XmlSerializer",
      "UnsafeStaticsCount": 11
    },
    {
      "Name": "System.StringComparer",
      "UnsafeStaticsCount": 8
    }
  ],
  "UnsafeStaticsPerProject": [
    {
      "Name": "D2L.AP.InsightsSSO",
      "UnsafeStaticsCount": 1
    },
    {
      "Name": "D2L.AW.ETL.IISImport",
      "UnsafeStaticsCount": 15
    }
  ],
  "RawResults": [
    {
      "ProjectName": "D2L.AP.InsightsSSO",
      "FilePath": "c:\\d2l\\instances\\all\\checkout\\ap\\insightsSSO\\D2L.AP.InsightsSSO\\Domain\\Default\\AnalyticsSSOManager.cs",
      "FieldOrPropName": "s_TokenDataSerializer",
      "FieldOrPropType": "System.Xml.Serialization.XmlSerializer",
      "Cause": "TypeIsMutable"
    },
    {
      "ProjectName": "D2L.LP.AppLoader",
      "FilePath": "c:\\d2l\\instances\\all\\checkout\\apploader\\D2L.LP.AppLoader\\AppResolution\\LocalAppRegistry\\ConfigRegistryAppDataProvider.cs",
      "FieldOrPropName": "AppClassComparer",
      "FieldOrPropType": "System.StringComparer",
      "Cause": "TypeIsMutable"
    }
  ]
}
```
