### PR TITLE
Exclude projects with the name Test in them.

### DIFF
--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.5.1.0" )]
-[assembly: AssemblyFileVersion( "0.5.1.0" )]
+[assembly: AssemblyVersion( "0.5.2.0" )]
+[assembly: AssemblyFileVersion( "0.5.2.0" )]

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/TestBase.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/TestBase.cs
@@ -3,54 +3,57 @@ using Microsoft.CodeAnalysis.CSharp;
 using NUnit.Framework;
 using System.Collections.Immutable;
 using System.Linq;
+using D2L.CodeStyle.Analyzers.Test.Verifiers;
 
 namespace D2L.CodeStyle.Analyzers.Common {
 
-    public static class RoslynSymbolFactory {
+	public static class RoslynSymbolFactory {
 
-        public static CSharpCompilation Compile( string source ) {
-            var tree = CSharpSyntaxTree.ParseText( source );
-            var compilation = CSharpCompilation.Create(
-                assemblyName: "TestAssembly",
-                syntaxTrees: new[] { tree },
-                references: new[] {
-                    MetadataReference.CreateFromFile( typeof( object ).Assembly.Location ),
-                    MetadataReference.CreateFromFile( typeof( ImmutableArray ).Assembly.Location )
-                }
-            );
-            return compilation;
-        }
+		internal static string TestAssemblyName = DiagnosticVerifier.TestProjectName;
 
-        public static ITypeSymbol Type( string text ) {
-            var source = $"using System; namespace D2L {{ {text} }}";
-            var compilation = Compile( source );
+		public static CSharpCompilation Compile( string source ) {
+			var tree = CSharpSyntaxTree.ParseText( source );
+			var compilation = CSharpCompilation.Create(
+				assemblyName: TestAssemblyName,
+				syntaxTrees: new[] { tree },
+				references: new[] {
+					MetadataReference.CreateFromFile( typeof( object ).Assembly.Location ),
+					MetadataReference.CreateFromFile( typeof( ImmutableArray ).Assembly.Location )
+				}
+			);
+			return compilation;
+		}
 
-            var toReturn = compilation.GetSymbolsWithName(
-                predicate: n => true,
-                filter: SymbolFilter.Type
-            ).OfType<ITypeSymbol>().FirstOrDefault();
-            Assert.IsNotNull( toReturn );
-            Assert.AreNotEqual( TypeKind.Error, toReturn.TypeKind );
-            return toReturn;
-        }
+		public static ITypeSymbol Type( string text ) {
+			var source = $"using System; namespace D2L {{ {text} }}";
+			var compilation = Compile( source );
 
-        public static IFieldSymbol Field( string text ) {
-            var type = Type( "sealed class Fake { " + text + "; }" );
+			var toReturn = compilation.GetSymbolsWithName(
+				predicate: n => true,
+				filter: SymbolFilter.Type
+			).OfType<ITypeSymbol>().FirstOrDefault();
+			Assert.IsNotNull( toReturn );
+			Assert.AreNotEqual( TypeKind.Error, toReturn.TypeKind );
+			return toReturn;
+		}
 
-            var toReturn = type.GetMembers().OfType<IFieldSymbol>().FirstOrDefault();
-            Assert.IsNotNull( toReturn );
-            Assert.AreNotEqual( TypeKind.Error, toReturn.Type.TypeKind );
-            return toReturn;
-        }
+		public static IFieldSymbol Field( string text ) {
+			var type = Type( "sealed class Fake { " + text + "; }" );
 
-        public static IPropertySymbol Property( string text ) {
-            var type = Type( "sealed class Fake { " + text + "; }" );
+			var toReturn = type.GetMembers().OfType<IFieldSymbol>().FirstOrDefault();
+			Assert.IsNotNull( toReturn );
+			Assert.AreNotEqual( TypeKind.Error, toReturn.Type.TypeKind );
+			return toReturn;
+		}
 
-            var toReturn = type.GetMembers().OfType<IPropertySymbol>().FirstOrDefault();
-            Assert.IsNotNull( toReturn );
-            Assert.AreNotEqual( TypeKind.Error, toReturn.Type.TypeKind );
-            return toReturn;
-        }
-    }
+		public static IPropertySymbol Property( string text ) {
+			var type = Type( "sealed class Fake { " + text + "; }" );
+
+			var toReturn = type.GetMembers().OfType<IPropertySymbol>().FirstOrDefault();
+			Assert.IsNotNull( toReturn );
+			Assert.AreNotEqual( TypeKind.Error, toReturn.Type.TypeKind );
+			return toReturn;
+		}
+	}
 
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -23,7 +23,7 @@ namespace D2L.CodeStyle.Analyzers.Test.Verifiers {
         internal static string DefaultFilePathPrefix = "Test";
         internal static string CSharpDefaultFileExt = "cs";
         internal static string VisualBasicDefaultExt = "vb";
-        internal static string TestProjectName = "TestProject";
+        internal static string TestProjectName = "StubProject";
 
         #region  Get Diagnostics
 


### PR DESCRIPTION
In the event that references cannot be resolved, such as when a build has
not yet occurred and approot/bin does not exist, we can use another
heuristic to ignore test projects: the name of the project.
We need this heuristic only because a component-build should be a
requirement for this tool; only source code + references. Unfortunately,
there is no way to deploy references to the correct location without doing
a component-build.