### PR TITLE
Removing System.IEqualityComparer, becuase it's an interface that is probably easily statefully implemented.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -23,7 +23,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			"System.ComponentModel.TypeConverter",
 			"System.DateTime",
 			"System.Guid",
-			"System.IEqualityComparer",
 			"System.Lazy",
 			"System.Reflection.MethodInfo",
 			"System.Reflection.PropertyInfo",

--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.6.0.0" )]
-[assembly: AssemblyFileVersion( "0.6.0.0" )]
+[assembly: AssemblyVersion( "0.7.0.0" )]
+[assembly: AssemblyFileVersion( "0.7.0.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.5.3.0" )]
-[assembly: AssemblyFileVersion( "0.5.3.0" )]
+[assembly: AssemblyVersion( "0.5.4.0" )]
+[assembly: AssemblyFileVersion( "0.5.4.0" )]


### PR DESCRIPTION
`System.StringComparer` remains for now while I verify that we haven't
subclassed it anywhere; if we have, then I will remove that one too and
give the analyzer the ability to allow certain fields/properties that are
safe (e.g., `StringComparer.Ordinal`).