### PR TITLE
Making all dependencies in the UnsafeStaticCounter a dev dependency.

### DIFF
--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.5.4.0" )]
-[assembly: AssemblyFileVersion( "0.5.4.0" )]
+[assembly: AssemblyVersion( "0.5.5.0" )]
+[assembly: AssemblyFileVersion( "0.5.5.0" )]

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/packages.config
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0" targetFramework="net461" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="System.Collections" version="4.0.0" targetFramework="net461" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net461" />
-  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net461" />
-  <package id="System.Globalization" version="4.0.0" targetFramework="net461" />
-  <package id="System.Linq" version="4.0.0" targetFramework="net461" />
-  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net461" />
-  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net461" />
-  <package id="System.Runtime" version="4.0.0" targetFramework="net461" />
-  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net461" />
-  <package id="System.Threading" version="4.0.0" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net461" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
AppVeyor calls `nuget pack` in the csproj's context, which asigns all dependencies in the `packages.config` file as NuGet dependencies in the final NuGet package. This is not necessary, because the tool bundles all dependencies with it. Instead of overwriting AppVeyor's NuGet packing behaviour (and having to pass in all variables to `nuget pack` ourselves), we just mark those dependencies as development dependencies, to prevent them from being required for the final package.