### PR TITLE
Use a declarations initializers type via the semantic model for analysis

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.7.0.0" )]
-[assembly: AssemblyFileVersion( "0.7.0.0" )]
+[assembly: AssemblyVersion( "0.7.1.0" )]
+[assembly: AssemblyFileVersion( "0.7.1.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.5.8.0" )]
-[assembly: AssemblyFileVersion( "0.5.8.0" )]
+[assembly: AssemblyVersion( "0.5.9.0" )]
+[assembly: AssemblyFileVersion( "0.5.9.0" )]


### PR DESCRIPTION
Will add some more tests.

I believe that `GetTypeInfo` doesn't return `null`: (after following some steps) http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Compilation/CSharpSemanticModel.cs,e0a02c903a059c8f