### PR TITLE
Disallowing ValueTypes, and checking for primitive types instead.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -88,16 +88,12 @@ namespace D2L.CodeStyle.Analyzers.Common {
 					+ "are referenced, including transitive dependencies." );
 			}
 
-			if( type.IsValueType ) {
+			if( IsTypeKnownImmutable( type ) ) {
 				return false;
 			}
 
 			if( type.TypeKind == TypeKind.Array ) {
 				return true;
-			}
-
-			if( KnownImmutableTypes.Contains( type.GetFullTypeName() ) ) {
-				return false;
 			}
 
 			if( !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && IsTypeMarkedImmutable( type ) ) {
@@ -197,6 +193,18 @@ namespace D2L.CodeStyle.Analyzers.Common {
 					// we've got a member (event, etc.) that we can't currently be smart about, so fail
 					return true;
 			}
+		}
+
+		private bool IsTypeKnownImmutable( ITypeSymbol type ) {
+			if( type.IsPrimitive() ) {
+				return true;
+			}
+
+			if( KnownImmutableTypes.Contains( type.GetFullTypeName() ) ) {
+				return true;
+			}
+
+			return false;
 		}
 
 		public bool IsTypeMarkedImmutable( ITypeSymbol symbol ) {

--- a/src/D2L.CodeStyle.Analyzers/Common/TypeSymbolExtensions.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/TypeSymbolExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Immutable;
 
 namespace D2L.CodeStyle.Analyzers.Common {
 
@@ -14,6 +15,27 @@ namespace D2L.CodeStyle.Analyzers.Common {
 	}
 
 	public static class TypeSymbolExtensions {
+
+		private readonly static ImmutableArray<SpecialType> PrimitiveTypes = ImmutableArray.Create(
+			SpecialType.System_Enum,
+			SpecialType.System_Boolean,
+			SpecialType.System_Char,
+			SpecialType.System_SByte,
+			SpecialType.System_Byte,
+			SpecialType.System_Int16,
+			SpecialType.System_UInt16,
+			SpecialType.System_Int32,
+			SpecialType.System_UInt32,
+			SpecialType.System_Int64,
+			SpecialType.System_UInt64,
+			SpecialType.System_Decimal,
+			SpecialType.System_Single,
+			SpecialType.System_Double,
+			SpecialType.System_String,
+			SpecialType.System_IntPtr,
+			SpecialType.System_UIntPtr
+		);
+
 		private static readonly SymbolDisplayFormat FullTypeDisplayFormat = new SymbolDisplayFormat(
 			typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces
 		);
@@ -38,6 +60,10 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			return type.GetMembers()
 				.Where( t => !t.IsStatic );
+		}
+
+		public static bool IsPrimitive( this ITypeSymbol symbol ) {
+			return PrimitiveTypes.Contains( symbol.SpecialType );
 		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
@@ -65,8 +65,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		}
 
 		[Test]
-		public void IsTypeMutable_ValueType_False() {
-			var type = Type( "struct random { string hello; }" );
+		public void IsTypeMutable_PrimitiveType_False() {
+			var type = Field( "uint foo" ).Type;
 
 			Assert.IsFalse( m_inspector.IsTypeMutable( type ) );
 		}


### PR DESCRIPTION
ValueTypes are not immutable if they hold references to non-valuetypes.
We instead allow only primitive types instead. We expect this to
break the analyzer in some places.