### PR TITLE
Update the counter to support a list of projects to count from.

### DIFF
--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Counter.cs
@@ -45,7 +45,7 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 		}
 
 		private async Task<AnalyzedResults> AnalyzeProjects() {
-			var projectFiles = Directory.EnumerateFiles( _rootDir, "*.csproj", SearchOption.AllDirectories );
+			var projectFiles = GetProjectPaths();
 
 			var tasks = projectFiles.Select( AnalyzeProject );
 			var results = await Task.WhenAll( tasks );
@@ -56,6 +56,16 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 			var finalResult = new AnalyzedResults( combinedResult );
 			return finalResult;
+		}
+
+		private IEnumerable<string> GetProjectPaths() {
+			if( Directory.Exists( _rootDir ) ) {
+				return Directory.EnumerateFiles( _rootDir, "*.csproj", SearchOption.AllDirectories );
+			} else if ( File.Exists( _rootDir ) ) {
+				return File.ReadAllLines( _rootDir );
+			} else {
+				throw new Exception( $"File or directory does not exist: '{_rootDir}'" );
+			}
 		}
 
 		private void WriteOutputFile( AnalyzedResults results ) {

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Program.cs
@@ -61,12 +61,12 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 			}
 
 			if( string.IsNullOrWhiteSpace( path ) ) {
-				throw new InvalidOperationException( "usage: UnsafeStaticsCounter.exe -d {rootDir} -b {binDir} [-n {concurrency} -o {outputFile}]" );
+				throw new InvalidOperationException( "usage: UnsafeStaticsCounter.exe -d {rootDir|projectListFile} -b {binDir} [-n {concurrency} -o {outputFile}]" );
 			}
 			path = Path.GetFullPath( path );
 
 			if( string.IsNullOrWhiteSpace( binDir ) ) {
-				throw new InvalidOperationException( "usage: UnsafeStaticsCounter.exe -d {rootDir} -b {binDir} [-n {concurrency} -o {outputFile}]" );
+				throw new InvalidOperationException( "usage: UnsafeStaticsCounter.exe -d {rootDir|projectListFile} -b {binDir} [-n {concurrency} -o {outputFile}]" );
 			}
 			binDir = Path.GetFullPath( binDir );
 


### PR DESCRIPTION
The existing option `-d` can be used as either (1) the path to a directory, or (2) the path to a line-separate file with project file paths inside.