### PR TITLE
Unaudited reasons

### DIFF
--- a/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("35fe7851-3f76-4057-9754-e883231619d0")]
 
-[assembly: AssemblyVersion("0.4.4.0")]
-[assembly: AssemblyFileVersion("0.4.4.0")]
+[assembly: AssemblyVersion("0.4.5.0")]
+[assembly: AssemblyFileVersion("0.4.5.0")]

--- a/src/D2L.CodeStyle.Annotations/Statics/Unaudited.cs
+++ b/src/D2L.CodeStyle.Annotations/Statics/Unaudited.cs
@@ -2,10 +2,27 @@
 
 // ReSharper disable once CheckNamespace
 namespace D2L.CodeStyle.Annotations {
+	public enum Because {
+		ItHasntBeenLookedAt,
+		ItsSketchy,
+		ItsStickyDataOhNooo,
+		WeNeedToMakeTheAnalyzerConsiderThisSafe
+	}
+
 	public static partial class Statics {
 		[Obsolete( "Static variables marked as unaudited require auditing. Only use this attribute as a temporary measure in assemblies." )]
 		[AttributeUsage( validOn: AttributeTargets.Field | AttributeTargets.Property )]
 		public sealed class Unaudited : Attribute {
+			public readonly Because m_cuz;
+
+			// extra-legacy parameterless constructor
+			public Unaudited() {
+				m_cuz = Because.ItHasntBeenLookedAt; 
+			}
+
+			public Unaudited( Because why ) {
+				m_cuz = why;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Should look like this:


* `[Statics.Unaudited( Because.ItHasntBeenLookedAt )]` : what we'll do for the automated flagging
* `[Statics.Unaudited( Because.ItsSketchy )]` : this code is fucked in the head and if its safe that's its only saving grace; should improve it
* `[Statics.Unaudited( Because.ItsStickyDataOhNooo )]` : yup
* `[Statics.Unaudited( Because.WeNeedToMakeTheAnalyzerConsiderThisSafe )]` : we have a bunch of these, e.g. `ILocation` needs to be fixed, so we can use this in areas that we expect will be safe when the underlying type is fixed for example