### PR TITLE
Switching counter to count usages of `[Unaudited]` instead.

### DIFF
--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Collections.Generic;
 
 namespace D2L.CodeStyle.UnsafeStaticCounter {
@@ -26,16 +25,6 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 			UnsafeStaticsPerProject = rawResults
 				.GroupBy( r => r.ProjectName )
 				.ToDictionary( g => g.Key, Enumerable.Count );
-		}
-	}
-
-	internal sealed class Aggregation {
-		public readonly string Name;
-		public readonly int UnsafeStaticsCount;
-
-		public Aggregation( string name, int count ) {
-			Name = name;
-			UnsafeStaticsCount = count;
 		}
 	}
 }

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
@@ -5,26 +5,54 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 	internal sealed class AnalyzedResults {
 		public readonly int UnsafeStaticsCount;
+		public readonly IReadOnlyCollection<string> UnanalyzedProjects;
 		public readonly IDictionary<string, int> UnsafeStaticsPerCause;
 		public readonly IDictionary<string, int> UnsafeStaticsPerType;
 		public readonly IDictionary<string, int> UnsafeStaticsPerProject;
-		public readonly IEnumerable<AnalyzedStatic> RawResults;
+		public readonly IReadOnlyCollection<AnalyzedStatic> RawResults;
 
-		public AnalyzedResults( AnalyzedStatic[] rawResults ) {
-			RawResults = rawResults;
-			UnsafeStaticsCount = rawResults.Length;
+		public AnalyzedResults( AnalyzedProject[] projects ) {
+			// grab all results
+			RawResults = projects.SelectMany( p => p.RawResults ).ToArray();
+			UnsafeStaticsCount = RawResults.Count;
 
-			UnsafeStaticsPerCause = rawResults
+			// grab list of unanalyzed projects
+			UnanalyzedProjects = projects
+				.Where( p => !p.IsAnalyzed )
+				.Select( p => p.Name )
+				.ToArray();
+
+			// group results per project
+			UnsafeStaticsPerProject = RawResults
+				.GroupBy( r => r.ProjectName )
+				.ToDictionary( g => g.Key, Enumerable.Count );
+
+			// group results by cause
+			UnsafeStaticsPerCause = RawResults
 				.GroupBy( r => r.Cause )
 				.ToDictionary( g => g.Key, Enumerable.Count );
 
-			UnsafeStaticsPerType = rawResults
+			// group results by type
+			UnsafeStaticsPerType = RawResults
 				.GroupBy( r => r.FieldOrPropType )
 				.ToDictionary( g => g.Key, Enumerable.Count );
 
-			UnsafeStaticsPerProject = rawResults
-				.GroupBy( r => r.ProjectName )
-				.ToDictionary( g => g.Key, Enumerable.Count );
+		}
+	}
+
+	internal sealed class AnalyzedProject {
+		public readonly string Name;
+		public readonly bool IsAnalyzed;
+		public readonly AnalyzedStatic[] RawResults;
+
+		public AnalyzedProject( 
+			string name, 
+			bool isAnalyzed, 
+			AnalyzedStatic[] rawResults 
+		) {
+			Name = name;
+			IsAnalyzed = isAnalyzed;
+			RawResults = rawResults;
 		}
 	}
 }

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
@@ -5,8 +5,9 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 	internal sealed class AnalyzedResults {
 		public readonly int UnsafeStaticsCount;
-		public readonly IEnumerable<AnalyzedType> UnsafeStaticsPerType;
-		public readonly IEnumerable<AnalyzedProject> UnsafeStaticsPerProject;
+		public readonly IEnumerable<Aggregation> UnsafeStaticsPerCause;
+		public readonly IEnumerable<Aggregation> UnsafeStaticsPerType;
+		public readonly IEnumerable<Aggregation> UnsafeStaticsPerProject;
 		public readonly IEnumerable<AnalyzedStatic> RawResults;
 
 		public AnalyzedResults( AnalyzedStatic[] rawResults ) {
@@ -14,46 +15,47 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 			UnsafeStaticsCount = rawResults.Length;
 
-			var unsafeStaticsPerProject = new Dictionary<string, AnalyzedProject>();
-			var unsafeStaticsPerType = new Dictionary<string, AnalyzedType>();
+			var unsafeStaticsPerCause = new Dictionary<string, Aggregation>();
+			var unsafeStaticsPerProject = new Dictionary<string, Aggregation>();
+			var unsafeStaticsPerType = new Dictionary<string, Aggregation>();
 
 			foreach( var result in rawResults ) {
 
 				// increment per project
 				var project = unsafeStaticsPerProject.GetOrAdd(
 						result.ProjectName,
-						() => new AnalyzedProject( result.ProjectName )
+						() => new Aggregation( result.ProjectName )
 					);
 				project.UnsafeStaticsCount++;
 
 				// increment per type
 				var analyzedType = unsafeStaticsPerType.GetOrAdd(
 					result.FieldOrPropType,
-					() => new AnalyzedType( result.FieldOrPropType )
+					() => new Aggregation( result.FieldOrPropType )
 				);
 				analyzedType.UnsafeStaticsCount++;
 
+				// increment per cause
+				var analyzedCause = unsafeStaticsPerCause.GetOrAdd(
+					result.Cause,
+					() => new Aggregation( result.Cause )
+				);
+				analyzedCause.UnsafeStaticsCount++;
+
 			}
 
+			UnsafeStaticsPerCause = unsafeStaticsPerCause.Values;
 			UnsafeStaticsPerProject = unsafeStaticsPerProject.Values;
 			UnsafeStaticsPerType = unsafeStaticsPerType.Values;
 		}
 	}
 
-	internal sealed class AnalyzedProject {
+	internal sealed class Aggregation {
 		public readonly string Name;
 		public int UnsafeStaticsCount;
 
-		public AnalyzedProject( string projectName ) {
-			Name = projectName;
-		}
-	}
-	internal sealed class AnalyzedType {
-		public readonly string Name;
-		public int UnsafeStaticsCount;
-
-		public AnalyzedType( string typeName ) {
-			Name = typeName;
+		public Aggregation( string name ) {
+			Name = name;
 		}
 	}
 }

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedResults.cs
@@ -5,7 +5,6 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 	internal sealed class AnalyzedResults {
 		public readonly int UnsafeStaticsCount;
-		public readonly int UnsafeNonReadonlyStaticsCount;
 		public readonly IEnumerable<AnalyzedType> UnsafeStaticsPerType;
 		public readonly IEnumerable<AnalyzedProject> UnsafeStaticsPerProject;
 		public readonly IEnumerable<AnalyzedStatic> RawResults;
@@ -27,26 +26,12 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 					);
 				project.UnsafeStaticsCount++;
 
-				switch( result.Cause ) {
-
-					// increment per-type
-					case AnalyzedStatic.CAUSE_MUTABLE_TYPE:
-						var analyzedType = unsafeStaticsPerType.GetOrAdd(
-							result.FieldOrPropType,
-							() => new AnalyzedType( result.FieldOrPropType )
-						);
-						analyzedType.UnsafeStaticsCount++;
-						break;
-
-					// increment readonly count
-					case AnalyzedStatic.CAUSE_MUTABLE_DECLARATION:
-						UnsafeNonReadonlyStaticsCount++;
-						break;
-
-					default:
-						throw new InvalidOperationException( $"unknown cause{result.Cause}" );
-
-				}
+				// increment per type
+				var analyzedType = unsafeStaticsPerType.GetOrAdd(
+					result.FieldOrPropType,
+					() => new AnalyzedType( result.FieldOrPropType )
+				);
+				analyzedType.UnsafeStaticsCount++;
 
 			}
 

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedStatic.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedStatic.cs
@@ -24,6 +24,7 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 			LineNumber = lineNumber;
 			FieldOrPropName = name;
 			FieldOrPropType = typeName;
+			Cause = cause;
 		}
 
 		public AnalyzedStatic( IFieldSymbol symbol, string cause ) : this(

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedStatic.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/AnalyzedStatic.cs
@@ -1,12 +1,9 @@
-﻿using D2L.CodeStyle.Analyzers.UnsafeStatics;
+﻿using D2L.CodeStyle.Analyzers.Common;
 using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 	internal sealed class AnalyzedStatic {
-		public const string CAUSE_MUTABLE_DECLARATION = "DeclarationIsMutable";
-		public const string CAUSE_MUTABLE_TYPE = "TypeIsMutable";
-
 		public readonly string ProjectName;
 		public readonly string FilePath;
 		public readonly int LineNumber;
@@ -14,19 +11,37 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 		public readonly string FieldOrPropType;
 		public readonly string Cause;
 
-		public AnalyzedStatic( string projectName, Diagnostic diag ) {
+		public AnalyzedStatic( 
+			string projectName, 
+			string filePath, 
+			int lineNumber, 
+			string name, 
+			string typeName,
+			string cause
+		) {
 			ProjectName = projectName;
-			FilePath = diag.Location.SourceTree.FilePath;
-			LineNumber = diag.Location.GetMappedLineSpan().Span.Start.Line;
-			FieldOrPropName = diag.Properties[UnsafeStaticsAnalyzer.PROPERTY_FIELDORPROPNAME];
-			FieldOrPropType = diag.Properties[UnsafeStaticsAnalyzer.PROPERTY_OFFENDINGTYPE];
-
-			if( FieldOrPropType == "it" ) {
-				FieldOrPropType = null; // analyzer doesn't expose type if declaration is unsafe
-				Cause = CAUSE_MUTABLE_DECLARATION;
-			} else {
-				Cause = CAUSE_MUTABLE_TYPE;
-			}
+			FilePath = filePath;
+			LineNumber = lineNumber;
+			FieldOrPropName = name;
+			FieldOrPropType = typeName;
 		}
+
+		public AnalyzedStatic( IFieldSymbol symbol, string cause ) : this(
+			projectName: symbol.ContainingAssembly.Name,
+			filePath: symbol.Locations[ 0 ].SourceTree.FilePath,
+			lineNumber: symbol.Locations[ 0 ].GetMappedLineSpan().Span.Start.Line,
+			name: symbol.Name,
+			typeName: symbol.Type.GetFullTypeName(),
+			cause: cause
+		) { }
+
+		public AnalyzedStatic( IPropertySymbol symbol, string cause ) : this(
+			projectName: symbol.ContainingAssembly.Name,
+			filePath: symbol.Locations[ 0 ].SourceTree.FilePath,
+			lineNumber: symbol.Locations[ 0 ].GetMappedLineSpan().Span.Start.Line,
+			name: symbol.Name,
+			typeName: symbol.Type.GetFullTypeName(),
+			cause: cause
+		) { }
 	}
 }

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/CountingVisitor.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/CountingVisitor.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace D2L.CodeStyle.UnsafeStaticCounter {
+	internal class CountingVisitor : SymbolVisitor {
+
+		private const string UnauditedAttributeName = "Unaudited";
+		private const string DefaultCause = "none";
+
+		internal readonly ConcurrentBag<AnalyzedStatic> AnalyzedStatics = new ConcurrentBag<AnalyzedStatic>();
+
+		public override void VisitField( IFieldSymbol symbol ) {
+			var unauditedAttribute = symbol
+				.GetAttributes()
+				.FirstOrDefault( a => a.AttributeClass.MetadataName == UnauditedAttributeName );
+			if( unauditedAttribute == null ) {
+				return;
+			}
+
+			var cause = DefaultCause;
+			if( unauditedAttribute.ConstructorArguments.Length > 0 ) {
+				cause = unauditedAttribute.ConstructorArguments[ 0 ].Value.ToString();
+			}
+			AnalyzedStatics.Add( new AnalyzedStatic( symbol, cause ) );
+			Console.WriteLine( $"found one: {symbol}" );
+		}
+
+		public override void VisitProperty( IPropertySymbol symbol ) {
+			var unauditedAttribute = symbol
+				.GetAttributes()
+				.FirstOrDefault( a => a.AttributeClass.MetadataName == UnauditedAttributeName );
+			if( unauditedAttribute == null ) {
+				return;
+			}
+
+			var cause = DefaultCause;
+			if( unauditedAttribute.ConstructorArguments.Length > 0 ) {
+				cause = unauditedAttribute.ConstructorArguments[ 0 ].Value.ToString();
+			}
+			AnalyzedStatics.Add( new AnalyzedStatic( symbol, cause ) );
+			Console.WriteLine( $"found one: {symbol}" );
+		}
+	}
+}

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/CountingVisitor.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/CountingVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using D2L.CodeStyle.Annotations;
 using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.UnsafeStaticCounter {
@@ -10,6 +11,14 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 		private const string DefaultCause = "none";
 
 		internal readonly ConcurrentBag<AnalyzedStatic> AnalyzedStatics = new ConcurrentBag<AnalyzedStatic>();
+
+		private string GetBecauseValue( object o ) {
+			if( o is int ) {
+				var enumObject = Enum.ToObject( typeof( Because ), o );
+				return enumObject.ToString();
+			}
+			return o.ToString();
+		}
 
 		public override void VisitField( IFieldSymbol symbol ) {
 			var unauditedAttribute = symbol
@@ -21,7 +30,7 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 			var cause = DefaultCause;
 			if( unauditedAttribute.ConstructorArguments.Length > 0 ) {
-				cause = unauditedAttribute.ConstructorArguments[ 0 ].Value.ToString();
+				cause = GetBecauseValue( unauditedAttribute.ConstructorArguments[ 0 ].Value );
 			}
 			AnalyzedStatics.Add( new AnalyzedStatic( symbol, cause ) );
 		}
@@ -36,7 +45,7 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 
 			var cause = DefaultCause;
 			if( unauditedAttribute.ConstructorArguments.Length > 0 ) {
-				cause = unauditedAttribute.ConstructorArguments[ 0 ].Value.ToString();
+				cause = GetBecauseValue( unauditedAttribute.ConstructorArguments[ 0 ].Value );
 			}
 			AnalyzedStatics.Add( new AnalyzedStatic( symbol, cause ) );
 		}

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/CountingVisitor.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/CountingVisitor.cs
@@ -24,7 +24,6 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 				cause = unauditedAttribute.ConstructorArguments[ 0 ].Value.ToString();
 			}
 			AnalyzedStatics.Add( new AnalyzedStatic( symbol, cause ) );
-			Console.WriteLine( $"found one: {symbol}" );
 		}
 
 		public override void VisitProperty( IPropertySymbol symbol ) {
@@ -40,7 +39,6 @@ namespace D2L.CodeStyle.UnsafeStaticCounter {
 				cause = unauditedAttribute.ConstructorArguments[ 0 ].Value.ToString();
 			}
 			AnalyzedStatics.Add( new AnalyzedStatic( symbol, cause ) );
-			Console.WriteLine( $"found one: {symbol}" );
 		}
 	}
 }

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.csproj
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/D2L.CodeStyle.UnsafeStaticCounter.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AnalyzedResults.cs" />
     <Compile Include="AnalyzedStatic.cs" />
     <Compile Include="Counter.cs" />
+    <Compile Include="CountingVisitor.cs" />
     <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -114,6 +115,10 @@
     <ProjectReference Include="..\D2L.CodeStyle.Analyzers\D2L.CodeStyle.Analyzers.csproj">
       <Project>{fe7608cd-c8b1-43dd-bbcc-9b1917c9ca73}</Project>
       <Name>D2L.CodeStyle.Analyzers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\D2L.CodeStyle.Annotations\D2L.CodeStyle.Annotations.csproj">
+      <Project>{1812AF7E-59B1-4764-8090-F84446A71C4E}</Project>
+      <Name>D2L.CodeStyle.Annotations</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.UnsafeStaticCounter/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle( "D2L.CodeStyle.UnsafeStaticsCounter" )]
@@ -10,5 +9,5 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "1.0.7.0" )]
-[assembly: AssemblyFileVersion( "1.0.7.0" )]
+[assembly: AssemblyVersion( "1.1.0.0" )]
+[assembly: AssemblyFileVersion( "1.1.0.0" )]


### PR DESCRIPTION
Counter will output usages and causes, but drops knowledge of the old causes of `TypeIsMutable` vs. `DeclarationIsMutable`. I don't think those were super valuable, but if we need them, we can easily add them back (e.g., `IPropertySymbol.IsReadOnly` in `AnalyzedStatic`'s constructor).