### PR TITLE
Littlefoot/statics/update test analyzers

### DIFF
--- a/src/D2L.CodeStyle.TestAnalyzers/Asserts/AssertsAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/Asserts/AssertsAnalyzer.cs
@@ -19,7 +19,7 @@ namespace D2L.CodeStyle.TestAnalyzers.Asserts {
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);

--- a/src/D2L.CodeStyle.TestAnalyzers/ExpectedException/ExpectedExceptionAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/ExpectedException/ExpectedExceptionAnalyzer.cs
@@ -22,7 +22,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ExpectedException {
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);

--- a/src/D2L.CodeStyle.TestAnalyzers/IgnoreAttribute/IgnoreAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/IgnoreAttribute/IgnoreAttributeAnalyzer.cs
@@ -19,7 +19,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);

--- a/src/D2L.CodeStyle.TestAnalyzers/SourceAttribute/TestCaseSourceAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/SourceAttribute/TestCaseSourceAttributeAnalyzer.cs
@@ -24,7 +24,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);

--- a/src/D2L.CodeStyle.TestAnalyzers/SourceAttribute/ValueSourceAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/SourceAttribute/ValueSourceAttributeAnalyzer.cs
@@ -22,7 +22,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);

--- a/src/D2L.CodeStyle.TestAnalyzers/TestCase/TestCaseAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/TestCase/TestCaseAnalyzer.cs
@@ -19,7 +19,7 @@ namespace D2L.CodeStyle.TestAnalyzers.TestCase {
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);

--- a/src/D2L.CodeStyle.TestAnalyzers/TestCaseData/TestCaseDataAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/TestCaseData/TestCaseDataAnalyzer.cs
@@ -20,7 +20,7 @@ namespace D2L.CodeStyle.TestAnalyzers.TestCaseData {
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);

--- a/src/D2L.CodeStyle.TestAnalyzers/TestContext/TestContextAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/TestContext/TestContextAnalyzer.cs
@@ -20,7 +20,7 @@ namespace D2L.CodeStyle.TestAnalyzers.TestContext {
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/Asserts/AssertsAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/Asserts/AssertsAnalyzerTests.cs
@@ -151,7 +151,7 @@ namespace D2L.CodeStyle.TestAnalyzers.Asserts {
 			return new DiagnosticResult {
 				Id = AssertsAnalyzer.DiagnosticId,
 				Message = AssertsAnalyzer.MessageFormat,
-				Severity = DiagnosticSeverity.Warning,
+				Severity = DiagnosticSeverity.Error,
 				Locations = new[] {
 					new DiagnosticResultLocation( "Test0.cs", line, column )
 				}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/Asserts/AssertsAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/Asserts/AssertsAnalyzerTests.cs
@@ -46,8 +46,8 @@ namespace D2L.CodeStyle.TestAnalyzers.Asserts {
 
 			[Test]
 			public void TestWithTargetAsserts() {
-				string html='tesT';
-				Assert.IsNotNullOrEmpty( html.ToLower(), 'message' );
+				string html=""tesT"";
+				Assert.IsNotNullOrEmpty( html.ToLower(), ""message"" );
 			}
 		}
 	}";
@@ -64,8 +64,8 @@ namespace D2L.CodeStyle.TestAnalyzers.Asserts {
 
 			[Test]
 			public void TestWithTargetAsserts() {
-				string html='tesT';
-				Assert.IsNullOrEmpty( html.ToLower(), 'message' );
+				string html=""tesT"";
+				Assert.IsNullOrEmpty( html.ToLower(), ""message"" );
 			}
 		}
 	}";
@@ -102,7 +102,7 @@ namespace D2L.CodeStyle.TestAnalyzers.Asserts {
 			public void TestWithTargetAsserts() {
 				List<String> ids = new List<string>();
 				foreach( var id in ids ) {
-					Assert.IsNullOrEmpty( id, 'message' );
+					Assert.IsNullOrEmpty( id, ""message"" );
 				}
 			}
 		}
@@ -120,13 +120,13 @@ namespace D2L.CodeStyle.TestAnalyzers.Asserts {
 
 			[Test]
 			public void TestWithTargetAsserts() {
-				string html='tesT';
+				string html=""tesT"";
 				Assert.IsNotNullOrEmpty( html.ToLower() );
 				Assert.IsNullOrEmpty( html );
 				
 				List<String> ids = new List<string>();
 				foreach( var id in ids ) {
-					Assert.IsNullOrEmpty( id, 'message' );
+					Assert.IsNullOrEmpty( id, ""message"" );
 				}
 			}
 		}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/ExpectedException/ExpectedExceptionAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/ExpectedException/ExpectedExceptionAnalyzerTests.cs
@@ -80,7 +80,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ExpectedException {
 		class Test {
 
 			[Test]
-			[ExpectedException( typeof( Exception ), ExpectedMessage = 'Invalid orgId value' )]
+			[ExpectedException( typeof( Exception ), ExpectedMessage = ""Invalid orgId value"" )]
 			public void TestWithException() {
 			}
 
@@ -116,7 +116,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ExpectedException {
 		class Test {
 
 			[Test]
-			[TestCase( '', ExpectedException = typeof(ArgumentNullException), ExpectedMessage = 'Username', MatchType=MessageMatch.Contains)]
+			[TestCase( """", ExpectedException = typeof(ArgumentNullException), ExpectedMessage = ""Username"", MatchType=MessageMatch.Contains)]
 			public void TestWithException(string name) {
 			}
 
@@ -134,8 +134,8 @@ namespace D2L.CodeStyle.TestAnalyzers.ExpectedException {
 		class Test {
 
 			[Test]
-			[TestCase( '', ExpectedException = typeof(ArgumentNullException), ExpectedMessage = 'Username', MatchType=MessageMatch.Contains)]
-			[TestCase( 'name', ExpectedException = typeof(ArgumentNullException), ExpectedMessage = 'Username', MatchType=MessageMatch.Contains)]
+			[TestCase( """", ExpectedException = typeof(ArgumentNullException), ExpectedMessage = ""Username"", MatchType=MessageMatch.Contains)]
+			[TestCase( ""name"", ExpectedException = typeof(ArgumentNullException), ExpectedMessage = ""Username"", MatchType=MessageMatch.Contains)]
 			public void TestWithException(string name) {
 			}
 

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/ExpectedException/ExpectedExceptionAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/ExpectedException/ExpectedExceptionAnalyzerTests.cs
@@ -161,7 +161,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ExpectedException {
 			return new DiagnosticResult {
 				Id = ExpectedExceptionAnalyzer.DiagnosticId,
 				Message = ExpectedExceptionAnalyzer.MessageFormat,
-				Severity = DiagnosticSeverity.Warning,
+				Severity = DiagnosticSeverity.Error,
 				Locations = new[] {
 					new DiagnosticResultLocation( "Test0.cs", line, column )
 				}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
@@ -125,7 +125,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 			return new DiagnosticResult {
 				Id = IgnoreAttributeAnalyzer.DiagnosticId,
 				Message = IgnoreAttributeAnalyzer.MessageFormat,
-				Severity = DiagnosticSeverity.Warning,
+				Severity = DiagnosticSeverity.Error,
 				Locations = new[] {
 					new DiagnosticResultLocation( "Test0.cs", line, column )
 				}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
@@ -43,7 +43,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 
 	namespace test {
 		[TestFixture]
-		[Ignore('ignore reason')]
+		[Ignore(""ignore reason"")]
 		class Test {
 
 			[Test]

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/TestCaseSourceAttributeAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/TestCaseSourceAttributeAnalyzerTests.cs
@@ -204,7 +204,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 			return new DiagnosticResult {
 				Id = TestCaseSourceAttributeAnalyzer.DiagnosticId,
 				Message = string.Format( TestCaseSourceAttributeAnalyzer.MessageFormat, message ),
-				Severity = DiagnosticSeverity.Warning,
+				Severity = DiagnosticSeverity.Error,
 				Locations = new[] {
 					new DiagnosticResultLocation( "Test0.cs", line, column )
 				}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/TestCaseSourceAttributeAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/TestCaseSourceAttributeAnalyzerTests.cs
@@ -49,7 +49,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 				new object[] { 12, 4, 3 }
 			};
 
-			[TestCaseSource( 'DivideCases' )]
+			[TestCaseSource( ""DivideCases"" )]
 			public void DivideTest( int n, int d, int q ) {
 			}
 
@@ -72,7 +72,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 				new object[] { 12, 4, 3 }
 			};
 			
-			[Test, TestCaseSource( 'DivideCases' )]
+			[Test, TestCaseSource( ""DivideCases"" )]
 			public void DivideTest( int n, int d, int q ) {
 			}
 		}
@@ -95,7 +95,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 				}
 			}
 
-			[TestCaseSource( 'ValidCases' )]
+			[TestCaseSource( ""ValidCases"" )]
 			public void DivideTest( int n, int d, int q ) {
 			}
 		}
@@ -131,7 +131,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 		class Test {
 			static IEnumerable TestCases{}
 
-			[Test, TestCaseSource( typeof( MyFactoryClass ), 'TestCases' )]
+			[Test, TestCaseSource( typeof( MyFactoryClass ), ""TestCases"" )]
 			public void DivideTest( int n, int d, int q ) {
 			}
 		}
@@ -145,8 +145,8 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 					yield return new TestCaseData( 12, 4 ).Returns( 3 );
 					yield return new TestCaseData( 0, 0 )
 					  .Throws( typeof( DivideByZeroException ) )
-					  .SetName( 'DivideByZero' )
-					  .SetDescription( 'An exception is expected' );
+					  .SetName( ""DivideByZero"" )
+					  .SetDescription( ""An exception is expected"" );
 				}
 			}
 		}
@@ -168,7 +168,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 				new object[] { 12, 4, 3 }
 			};
 
-			[Test, TestCaseSource( 'DivideCases' )]
+			[Test, TestCaseSource( ""DivideCases"" )]
 			public void DivideTest( int n, int d, int q ) {
 			}
 
@@ -180,7 +180,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 				}
 			}
 
-			[TestCaseSource( 'ValidCases' )]
+			[TestCaseSource( ""ValidCases"" )]
 			public void DivideTest( int n, int d, int q ) {
 			}
 		}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/ValueSourceAttributeAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/ValueSourceAttributeAnalyzerTests.cs
@@ -80,10 +80,10 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 	namespace test {
 		class Test {
 			private String ValidCases {
-				return new String('test');
+				return new String(""test"");
 			}
 
-			public void test1( [ValueSource( 'ValidCases' )] String s ) {
+			public void test1( [ValueSource( ""ValidCases"" )] String s ) {
 
 			}
 		}
@@ -103,7 +103,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 			}
 
 			[Test]
-			public void test4( [ValueSource( 'GetContractVersions' )] JsonContractVersion contractVersion ) {
+			public void test4( [ValueSource( ""GetContractVersions"" )] JsonContractVersion contractVersion ) {
 
 			}
 		}
@@ -123,7 +123,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 			}
 
 			[Test]
-			public void test4( [ValueSource( typeof(Foo), 'GetContractVersions' )] JsonContractVersion contractVersion ) {
+			public void test4( [ValueSource( typeof(Foo), ""GetContractVersions"" )] JsonContractVersion contractVersion ) {
 
 			}
 		}
@@ -158,7 +158,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 			}
 
 			[Test]
-			public void test4( [ValueSource( 'GetContractVersions' )] JsonContractVersion contractVersion, [ValueSource( 'GetHealthStatusCodes' )] HealthStatusCode healthStatusCode ) {
+			public void test4( [ValueSource( ""GetContractVersions"" )] JsonContractVersion contractVersion, [ValueSource( ""GetHealthStatusCodes"" )] HealthStatusCode healthStatusCode ) {
 
 			}
 		}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/ValueSourceAttributeAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/ValueSourceAttributeAnalyzerTests.cs
@@ -182,7 +182,7 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 			return new DiagnosticResult {
 				Id = ValueSourceAttributeAnalyzer.DiagnosticId,
 				Message = string.Format( ValueSourceAttributeAnalyzer.MessageFormat, message ),
-				Severity = DiagnosticSeverity.Warning,
+				Severity = DiagnosticSeverity.Error,
 				Locations = new[] {
 					new DiagnosticResultLocation( "Test0.cs", line, column )
 				}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/TestCase/TestCaseAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/TestCase/TestCaseAnalyzerTests.cs
@@ -96,7 +96,7 @@ namespace D2L.CodeStyle.TestAnalyzers.TestCase {
 			return new DiagnosticResult {
 				Id = TestCaseAnalyzer.DiagnosticId,
 				Message = TestCaseAnalyzer.MessageFormat,
-				Severity = DiagnosticSeverity.Warning,
+				Severity = DiagnosticSeverity.Error,
 				Locations = new[] {
 					new DiagnosticResultLocation( "Test0.cs", line, column )
 				}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/TestCaseData/TestCaseDataAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/TestCaseData/TestCaseDataAnalyzerTests.cs
@@ -173,7 +173,7 @@ namespace D2L.CodeStyle.TestAnalyzers.TestCaseData {
 			return new DiagnosticResult {
 				Id = TestCaseDataAnalyzer.DiagnosticId,
 				Message = string.Format( TestCaseDataAnalyzer.MessageFormat, message ),
-				Severity = DiagnosticSeverity.Warning,
+				Severity = DiagnosticSeverity.Error,
 				Locations = new[] {
 					new DiagnosticResultLocation( "Test0.cs", line, column )
 				}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/TestContext/TestContextAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/TestContext/TestContextAnalyzerTests.cs
@@ -94,7 +94,7 @@ namespace D2L.CodeStyle.TestAnalyzers.TestContext {
 			return new DiagnosticResult {
 				Id = TestContextAnalyzer.DiagnosticId,
 				Message = TestContextAnalyzer.MessageFormat,
-				Severity = DiagnosticSeverity.Warning,
+				Severity = DiagnosticSeverity.Error,
 				Locations = new[] {
 					new DiagnosticResultLocation( "Test0.cs", line, column )
 				}


### PR DESCRIPTION
make all test analyers' `DiagnosticSeverity` as `Error` instead of `Warning`