### PR TITLE
Littlefoot/statics/fix test analyzers

### DIFF
--- a/src/D2L.CodeStyle.TestAnalyzers/ExpectedException/ExpectedExceptionAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/ExpectedException/ExpectedExceptionAnalyzer.cs
@@ -51,6 +51,9 @@ namespace D2L.CodeStyle.TestAnalyzers.ExpectedException {
 					isExpectedException = true;
 					break;
 				} else if( attribute.Name.ToString().Equals( "TestCase" ) ) {
+					if( attribute.ArgumentList == null ) {
+						continue;
+					}
 					foreach( var argument in attribute.ArgumentList.Arguments ) {
 						if( argument.NameEquals != null && argument.NameEquals.Name.ToString().Equals( "ExpectedException" ) ) {
 							location = argument.GetLocation();

--- a/src/D2L.CodeStyle.TestAnalyzers/IgnoreAttribute/IgnoreAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/IgnoreAttribute/IgnoreAttributeAnalyzer.cs
@@ -39,7 +39,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 			if( root == null ) {
 				return;
 			}
-			
+
 			foreach( var attribute in root.Attributes ) {
 				if( attribute.Name.ToString().Equals( "Ignore" ) ) {
 					var parentClassDeclaration = root.AncestorsAndSelf().OfType<ClassDeclarationSyntax>().ToImmutableArray().Single();
@@ -50,7 +50,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 							}
 						}
 					}
-					
+
 					if( attribute.ArgumentList == null ) {
 						var diagnostic = Diagnostic.Create( Rule, attribute.GetLocation() );
 						context.ReportDiagnostic( diagnostic );

--- a/src/D2L.CodeStyle.TestAnalyzers/IgnoreAttribute/IgnoreAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/IgnoreAttribute/IgnoreAttributeAnalyzer.cs
@@ -42,16 +42,12 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 
 			foreach( var attribute in root.Attributes ) {
 				if( attribute.Name.ToString().Equals( "Ignore" ) ) {
-					var parentClassDeclaration = root.AncestorsAndSelf().OfType<ClassDeclarationSyntax>().ToImmutableArray().Single();
-					foreach( var parentAttributeList in parentClassDeclaration.AttributeLists ) {
-						foreach( var parentAttribute in parentAttributeList.Attributes ) {
-							if( parentAttribute.Name.ToString().Equals( "ReflectionSerializer" ) ) {
-								return;
-							}
-						}
+					var memberGroups = context.SemanticModel.GetMemberGroup( attribute );
+					if( memberGroups.Length == 0 ) {
+						return;
 					}
 
-					if( attribute.ArgumentList == null ) {
+					if( memberGroups.First().ContainingType.ToString().Equals( "NUnit.Framework.IgnoreAttribute" ) && attribute.ArgumentList == null ) {
 						var diagnostic = Diagnostic.Create( Rule, attribute.GetLocation() );
 						context.ReportDiagnostic( diagnostic );
 					}

--- a/src/D2L.CodeStyle.TestAnalyzers/IgnoreAttribute/IgnoreAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/IgnoreAttribute/IgnoreAttributeAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -38,9 +39,18 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 			if( root == null ) {
 				return;
 			}
-
+			
 			foreach( var attribute in root.Attributes ) {
 				if( attribute.Name.ToString().Equals( "Ignore" ) ) {
+					var parentClassDeclaration = root.AncestorsAndSelf().OfType<ClassDeclarationSyntax>().ToImmutableArray().Single();
+					foreach( var parentAttributeList in parentClassDeclaration.AttributeLists ) {
+						foreach( var parentAttribute in parentAttributeList.Attributes ) {
+							if( parentAttribute.Name.ToString().Equals( "ReflectionSerializer" ) ) {
+								return;
+							}
+						}
+					}
+					
 					if( attribute.ArgumentList == null ) {
 						var diagnostic = Diagnostic.Create( Rule, attribute.GetLocation() );
 						context.ReportDiagnostic( diagnostic );

--- a/src/D2L.CodeStyle.TestAnalyzers/ParallelizableTests/ParallelizableTestsAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/ParallelizableTests/ParallelizableTestsAnalyzer.cs
@@ -22,7 +22,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ParallelizableTests {
             Title, 
             MessageFormat, 
             Category,
-            DiagnosticSeverity.Error,
+            DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: Description
         );

--- a/src/D2L.CodeStyle.TestAnalyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.8.6.0" )]
-[assembly: AssemblyFileVersion( "0.8.6.0" )]
+[assembly: AssemblyVersion( "0.8.7.0" )]
+[assembly: AssemblyFileVersion( "0.8.7.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.TestAnalyzers.Tests" )]

--- a/src/D2L.CodeStyle.TestAnalyzers/SourceAttribute/TestCaseSourceAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/SourceAttribute/TestCaseSourceAttributeAnalyzer.cs
@@ -60,14 +60,14 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 						ITypeSymbol typeContainingMember = null;
 
 						if( attributeArguments.Length == 2 ) {
-							var typeExpression = attributeArguments[0].Expression as TypeOfExpressionSyntax;
+							var typeExpression = attributeArguments[ 0 ].Expression as TypeOfExpressionSyntax;
 							memberType = typeExpression.Type.ToString();
-							nameExpression = attributeArguments[1].Expression;
+							nameExpression = attributeArguments[ 1 ].Expression;
 							typeContainingMember = context.SemanticModel.GetTypeInfo( typeExpression.Type ).Type;
 						} else {
 							var methodSymbol = context.SemanticModel.GetDeclaredSymbol( method );
 							memberType = methodSymbol.ContainingType.MetadataName;
-							nameExpression = attributeArguments[0].Expression;
+							nameExpression = attributeArguments[ 0 ].Expression;
 							typeContainingMember = methodSymbol.ContainingType;
 						}
 
@@ -77,7 +77,11 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 							InvocationExpressionSyntax invocationExpression = nameExpression as InvocationExpressionSyntax;
 							memberName = invocationExpression.ArgumentList.Arguments.First().Expression.ToString();
 						}
-						
+
+						while( typeContainingMember.GetMembers( memberName ).Length == 0 ) {
+							typeContainingMember = typeContainingMember.BaseType;
+						}
+
 						var source = typeContainingMember.GetMembers( memberName ).First();
 						if( !source.IsStatic ) {
 							var diagnostic = Diagnostic.Create( Rule, attribute.GetLocation(), memberName );

--- a/src/D2L.CodeStyle.TestAnalyzers/TestCase/TestCaseAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/TestCase/TestCaseAnalyzer.cs
@@ -38,9 +38,13 @@ namespace D2L.CodeStyle.TestAnalyzers.TestCase {
 			if( root == null ) {
 				return;
 			}
-			
+
 			foreach( var attribute in root.Attributes ) {
 				if( attribute.Name.ToString().Equals( "TestCase" ) ) {
+					if( attribute.ArgumentList == null ) {
+						continue;
+					}
+
 					var attributeArguments = attribute.ArgumentList.Arguments.ToImmutableArray();
 					foreach( var attributeArgument in attributeArguments ) {
 						if( attributeArgument.NameEquals != null && attributeArgument.NameEquals.Name.ToString().Equals( "Result" ) ) {

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
@@ -37,6 +37,24 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 		}
 
 		[Test]
+		public void DocumentWithoutTestIgnore_NoDiag() {
+			const string test = @"
+	using System;
+
+	namespace test {
+		[ReflectionSerializer]
+		class Test {
+
+			[Ignore]
+			public void TestWithoutIgnore() {
+			}
+
+		}
+	}";
+			AssertNoDiagnostic( test );
+		}
+
+		[Test]
 		public void DocumentWithIgnore_WithReason_NoDiag() {
 			const string test = @"
 	using System;

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.IO;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using D2L.CodeStyle.TestAnalyzers.Test.Verifiers;
 using Microsoft.CodeAnalysis;
@@ -23,6 +24,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 		public void DocumentWithoutIgnore_NoDiag() {
 			const string test = @"
 	using System;
+	using NUnit.Framework;
 
 	namespace test {
 		class Test {
@@ -58,6 +60,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 		public void DocumentWithIgnore_WithReason_NoDiag() {
 			const string test = @"
 	using System;
+	using NUnit.Framework;
 
 	namespace test {
 		[TestFixture]
@@ -76,6 +79,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 		public void DocumentWithIgnore_WithoutReason_Case1_Diag() {
 			const string test = @"
 	using System;
+	using NUnit.Framework;
 
 	namespace test {
 		[TestFixture]
@@ -87,13 +91,14 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 			}
 		}
 	}";
-			AssertSingleDiagnostic( test, 6, 4 );
+			AssertSingleDiagnostic( test, 7, 4 );
 		}
 
 		[Test]
 		public void DocumentWithIgnore_WithoutReason_Case2_Diag() {
 			const string test = @"
 	using System;
+	using NUnit.Framework;
 
 	namespace test {
 		[TestFixture]
@@ -105,13 +110,14 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 			}
 		}
 	}";
-			AssertSingleDiagnostic( test, 9, 5 );
+			AssertSingleDiagnostic( test, 10, 5 );
 		}
 
 		[Test]
 		public void DocumentWithIgnore_WithoutReason_Case3_Diag() {
 			const string test = @"
 	using System;
+	using NUnit.Framework;
 
 	namespace test {
 		[TestFixture]
@@ -124,8 +130,8 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 			}
 		}
 	}";
-			var diag1 = CreateDiagnosticResult( 6, 4 );
-			var diag2 = CreateDiagnosticResult( 10, 5 );
+			var diag1 = CreateDiagnosticResult( 7, 4 );
+			var diag2 = CreateDiagnosticResult( 11, 5 );
 			VerifyCSharpDiagnostic( test, diag1, diag2 );
 		}
 
@@ -149,5 +155,12 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 				}
 			};
 		}
+
+		protected override MetadataReference[] GetAdditionalReferences() {
+			return new MetadataReference[] { MetadataReference.CreateFromFile( Path.Combine(
+				Path.GetDirectoryName( this.GetType().Assembly.Location ), @"..\..\..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll"
+			) ) };
+		}
+
 	}
 }

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/IgnoreAttribute/IgnoreAnalyzerTests.cs
@@ -44,7 +44,7 @@ namespace D2L.CodeStyle.TestAnalyzers.IgnoreAttribute {
 	using System;
 
 	namespace test {
-		[ReflectionSerializer]
+		public class IgnoreAttribute : Attribute { }
 		class Test {
 
 			[Ignore]

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/ParallelizableTests/ParallelizableTestsAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/ParallelizableTests/ParallelizableTestsAnalyzerTests.cs
@@ -42,7 +42,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ParallelizableTests {
             var expected = new DiagnosticResult {
                 Id = ParallelizableTestsAnalyzer.DiagnosticId,
                 Message = string.Format( ParallelizableTestsAnalyzer.MessageFormat, "System.DateTime", "System.DateTime" ),
-                Severity = DiagnosticSeverity.Error,
+                Severity = DiagnosticSeverity.Warning,
                 Locations =
                     new[] {
                             new DiagnosticResultLocation("Test0.cs", 8, 28)
@@ -69,7 +69,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ParallelizableTests {
             var expected = new DiagnosticResult {
                 Id = ParallelizableTestsAnalyzer.DiagnosticId,
                 Message = string.Format( ParallelizableTestsAnalyzer.MessageFormat, "System.DateTime", "System.DateTime" ),
-                Severity = DiagnosticSeverity.Error,
+                Severity = DiagnosticSeverity.Warning,
                 Locations =
                     new[] {
                             new DiagnosticResultLocation("Test0.cs", 8, 28)
@@ -96,7 +96,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ParallelizableTests {
             var expected = new DiagnosticResult {
                 Id = ParallelizableTestsAnalyzer.DiagnosticId,
                 Message = string.Format( ParallelizableTestsAnalyzer.MessageFormat, "System.DateTime", "System.DateTime" ),
-                Severity = DiagnosticSeverity.Error,
+                Severity = DiagnosticSeverity.Warning,
                 Locations =
                     new[] {
                             new DiagnosticResultLocation("Test0.cs", 8, 28)

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/TestCaseSourceAttributeAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/SourceAttribute/TestCaseSourceAttributeAnalyzerTests.cs
@@ -190,6 +190,36 @@ namespace D2L.CodeStyle.TestAnalyzers.SourceAttribute {
 			VerifyCSharpDiagnostic( test, diag1, diag2 );
 		}
 
+		[Test]
+		public void DocumentWithTestCaseSource_WithoutStatic_Case6_Diag() {
+			const string test = @"
+	using System;
+
+	namespace test {
+		class Test : BaseTest{
+
+			[TestCaseSource( ""ValidCases"" )]
+			public void DivideTest( int n, int d, int q ) {
+			}
+		}
+
+		class BaseTest : BaseBaseTest{
+			
+		}
+
+		class BaseBaseTest{
+			private IEnumerable<TestCaseData> ValidCases {
+				get
+				{
+					yield return new TestCaseData( 12, 3, 4 );
+					yield return new TestCaseData( 12, 2, 6 );
+				}
+			}
+		}
+	}";
+			AssertSingleDiagnostic( test, 7, 5, "ValidCases" );
+		}
+
 		private void AssertNoDiagnostic( string file ) {
 			VerifyCSharpDiagnostic( file );
 		}


### PR DESCRIPTION
- temporarily set ParallelizableTestsAnalyer as Warning instead of Error
- fix a few test analyzers bugs
    -- fix bug of null object reference in ExpectedExceptionAnalyzer and TestCaseAnalyer
 -- fix  IgnoreAttributeAnalyzer: check if the Ignore is under [ReflectionSerializer]
 -- fix TestCaseSourceAttributeAnalyer: consider the case that the source is the base class in another doc 