### PR TITLE
UnsafeStaticsAnalyzer now exposes better messages for why something is mutable.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResult.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResult.cs
@@ -1,0 +1,78 @@
+﻿namespace D2L.CodeStyle.Analyzers.Common {
+	public enum MutabilityTarget {
+		Member,
+		Type,
+		TypeArgument
+	}
+
+	public enum MutabilityCause {
+		IsNotReadonly,
+		IsNotSealed,
+		IsAnInterface,
+		IsAnArray,
+		IsPotentiallyMutable
+	}
+
+	public sealed class MutabilityInspectionResult {
+
+		private readonly static MutabilityInspectionResult s_notMutableResult = new MutabilityInspectionResult( false, null, null, null, null );
+
+		public bool IsMutable { get; }
+
+		public string MemberPath { get; }
+
+		public string TypeName { get; }
+
+		public MutabilityCause? Cause { get; }
+
+		public MutabilityTarget? Target { get; }
+
+		private MutabilityInspectionResult(
+			bool isMutable,
+			string memberPath,
+			string typeName,
+			MutabilityTarget? target,
+			MutabilityCause? cause
+		) {
+			IsMutable = isMutable;
+			MemberPath = memberPath;
+			TypeName = typeName;
+			Target = target;
+			Cause = cause;
+		}
+
+		public static MutabilityInspectionResult NotMutable() {
+			return s_notMutableResult;
+		}
+
+		public static MutabilityInspectionResult Mutable(
+			string mutableMemberPath,
+			string membersTypeName,
+			MutabilityTarget kind,
+			MutabilityCause cause
+		) {
+			return new MutabilityInspectionResult(
+				true,
+				mutableMemberPath,
+				membersTypeName,
+				kind,
+				cause
+			);
+		}
+
+		public MutabilityInspectionResult WithPrefixedMember( string parentMember ) {
+			var newMember = string.IsNullOrWhiteSpace( this.MemberPath )
+				? parentMember
+				: $"{parentMember}.{this.MemberPath}";
+
+			return new MutabilityInspectionResult(
+				this.IsMutable,
+				newMember,
+				this.TypeName,
+				this.Target,
+				this.Cause
+			);
+		}
+
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResultFormatter.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResultFormatter.cs
@@ -32,7 +32,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				case MutabilityCause.IsAnArray:
 					return "an array";
 				case MutabilityCause.IsAnInterface:
-					return "an interface";
+					return "an interface that is not marked with `[Objects.Immutable]`";
 				case MutabilityCause.IsNotSealed:
 					return "not sealed";
 				case MutabilityCause.IsNotReadonly:

--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResultFormatter.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResultFormatter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace D2L.CodeStyle.Analyzers.Common {
+	public sealed class MutabilityInspectionResultFormatter {
+		public string Format( MutabilityInspectionResult result ) {
+			if( !result.IsMutable ) {
+				return string.Empty;
+			}
+
+			var targetString = FormatTarget( result );
+			var causeString = FormatCause( result );
+
+			var formattedResult = $"{targetString} is {causeString}";
+			return formattedResult;
+		}
+
+		private string FormatTarget( MutabilityInspectionResult result ) {
+			switch( result.Target ) {
+				case MutabilityTarget.Member:
+					return $"'{result.MemberPath}'";
+				case MutabilityTarget.Type:
+					return $"'{result.MemberPath}''s type ('{result.TypeName}')";
+				case MutabilityTarget.TypeArgument:
+					return $"'{result.MemberPath}''s type argument ('{result.TypeName}')";
+				default:
+					throw new NotImplementedException( $"unknown target '{result.Target}'" );
+			}
+		}
+
+		private string FormatCause( MutabilityInspectionResult result ) {
+			switch( result.Cause ) {
+				case MutabilityCause.IsAnArray:
+					return "an array";
+				case MutabilityCause.IsAnInterface:
+					return "an interface";
+				case MutabilityCause.IsNotSealed:
+					return "not sealed";
+				case MutabilityCause.IsNotReadonly:
+					return "not read-only";
+				case MutabilityCause.IsPotentiallyMutable:
+					return "not deterministically immutable";
+				default:
+					throw new NotImplementedException( $"unknown cause '{result.Cause}'" );
+			}
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Common/TypeSymbolExtensions.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/TypeSymbolExtensions.cs
@@ -8,7 +8,7 @@ using System.Collections.Immutable;
 namespace D2L.CodeStyle.Analyzers.Common {
 
 	public static class SyntaxNodeExtension {
-		public static bool IsPropertyGetterImplemented(this PropertyDeclarationSyntax syntax) {
+		public static bool IsPropertyGetterImplemented( this PropertyDeclarationSyntax syntax ) {
 			var getter = syntax.AccessorList?.Accessors.FirstOrDefault( a => a.IsKind( SyntaxKind.GetAccessorDeclaration ) );
 			return getter?.Body != null;
 		}
@@ -41,9 +41,9 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			miscellaneousOptions: SymbolDisplayMiscellaneousOptions.ExpandNullable
 		);
 
-		private static readonly SymbolDisplayFormat FullTypeWithGenericsDisplayFormat = new SymbolDisplayFormat( 
-			typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces, 
-			genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters ,
+		private static readonly SymbolDisplayFormat FullTypeWithGenericsDisplayFormat = new SymbolDisplayFormat(
+			typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+			genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
 			miscellaneousOptions: SymbolDisplayMiscellaneousOptions.ExpandNullable
 		);
 
@@ -58,10 +58,10 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			return fullyQualifiedName;
 		}
 
-		public static IEnumerable<ISymbol> GetNonStaticMembers( this INamespaceOrTypeSymbol type ) {
+		public static IEnumerable<ISymbol> GetExplicitNonStaticMembers( this INamespaceOrTypeSymbol type ) {
 
 			return type.GetMembers()
-				.Where( t => !t.IsStatic );
+				.Where( t => !t.IsStatic && !t.IsImplicitlyDeclared );
 		}
 
 		public static bool IsPrimitive( this ITypeSymbol symbol ) {

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -30,6 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Common\MutabilityInspectionResult.cs" />
+    <Compile Include="Common\MutabilityInspectionResultFormatter.cs" />
     <Compile Include="Common\MutabilityInspector.cs" />
     <Compile Include="Common\TypeSymbolExtensions.cs" />
     <Compile Include="Common\Utils.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -67,7 +67,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				| MutabilityInspectionFlags.AllowUnsealed // `symbol` is the concrete type
 				| MutabilityInspectionFlags.IgnoreImmutabilityAttribute; // we're _validating_ the attribute
 
-			if( m_immutabilityInspector.IsTypeMutable( symbol, flags ) ) {
+			if( m_immutabilityInspector.InspectType( symbol, flags ).IsMutable ) {
 				var diagnostic = Diagnostic.Create( Rule, root.GetLocation() );
 				context.ReportDiagnostic( diagnostic );
 			}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectionResultFormatterTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectionResultFormatterTests.cs
@@ -29,7 +29,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			new TestCaseData(
 				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsAnInterface),
-				"'foo''s type ('bar') is an interface"
+				"'foo''s type ('bar') is an interface that is not marked with `[Objects.Immutable]`"
 			).SetName("type is an interface"),
 
 			new TestCaseData(
@@ -51,7 +51,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			new TestCaseData(
 				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnInterface),
-				"'foo''s type argument ('bar') is an interface"
+				"'foo''s type argument ('bar') is an interface that is not marked with `[Objects.Immutable]`"
 			).SetName("type argument is an interface"),
 
 			new TestCaseData(

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectionResultFormatterTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectionResultFormatterTests.cs
@@ -1,0 +1,79 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace D2L.CodeStyle.Analyzers.Common {
+	[TestFixture]
+	class MutabilityInspectionResultFormatterTests {
+
+		private readonly MutabilityInspectionResultFormatter m_formatter = new MutabilityInspectionResultFormatter();
+
+		private static readonly IEnumerable<TestCaseData> m_testCases = new[] {
+			new TestCaseData(
+				MutabilityInspectionResult.NotMutable(),
+				string.Empty
+			).SetName("not mutable"),
+
+            // field cases
+
+            new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Member, MutabilityCause.IsNotReadonly),
+				"'foo' is not read-only"
+			).SetName("field is not read-only"),
+
+            // type cases
+
+            new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsAnArray),
+				"'foo''s type ('bar') is an array"
+			).SetName("type is an array"),
+
+			new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsAnInterface),
+				"'foo''s type ('bar') is an interface"
+			).SetName("type is an interface"),
+
+			new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsNotSealed),
+				"'foo''s type ('bar') is not sealed"
+			).SetName("type is not sealed"),
+
+			new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsPotentiallyMutable),
+				"'foo''s type ('bar') is not deterministically immutable"
+			).SetName("type is not not deterministically immutable"),
+
+            // type argument cases
+
+            new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnArray),
+				"'foo''s type argument ('bar') is an array"
+			).SetName("type argument is an array"),
+
+			new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnInterface),
+				"'foo''s type argument ('bar') is an interface"
+			).SetName("type argument is an interface"),
+
+			new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsNotSealed),
+				"'foo''s type argument ('bar') is not sealed"
+			).SetName("type argument is not sealed"),
+
+			new TestCaseData(
+				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsPotentiallyMutable),
+				"'foo''s type argument ('bar') is not deterministically immutable"
+			).SetName("type argument is not not deterministically immutable"),
+
+		};
+
+		[Test, TestCaseSource( nameof( m_testCases ) )]
+		public void Format_NotMutable_FormatsCorrectly(
+			MutabilityInspectionResult result,
+			string expected
+		) {
+			var formatted = m_formatter.Format( result );
+
+			Assert.AreEqual( expected, formatted );
+		}
+	}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/TestBase.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/TestBase.cs
@@ -10,6 +10,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 	public static class RoslynSymbolFactory {
 
 		internal static string TestAssemblyName = DiagnosticVerifier.TestProjectName;
+		internal static string RootNamespace = "D2L";
+		internal static string RootClass = "Fake";
 
 		public static CSharpCompilation Compile( string source ) {
 			var tree = CSharpSyntaxTree.ParseText( source );
@@ -25,7 +27,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		}
 
 		public static ITypeSymbol Type( string text ) {
-			var source = $"using System; namespace D2L {{ {text} }}";
+			var source = $"using System; namespace {RootNamespace} {{ {text} }}";
 			var compilation = Compile( source );
 
 			var toReturn = compilation.GetSymbolsWithName(
@@ -38,7 +40,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		}
 
 		public static IFieldSymbol Field( string text ) {
-			var type = Type( "sealed class Fake { " + text + "; }" );
+			var type = Type( "sealed class " + RootClass + " { " + text + "; }" );
 
 			var toReturn = type.GetMembers().OfType<IFieldSymbol>().FirstOrDefault();
 			Assert.IsNotNull( toReturn );
@@ -47,7 +49,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		}
 
 		public static IPropertySymbol Property( string text ) {
-			var type = Type( "sealed class Fake { " + text + "; }" );
+			var type = Type( "sealed class " + RootClass + " { " + text + "; }" );
 
 			var toReturn = type.GetMembers().OfType<IPropertySymbol>().FirstOrDefault();
 			Assert.IsNotNull( toReturn );

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -36,6 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Common\MutabilityInspectionResultFormatterTests.cs" />
     <Compile Include="Common\MutabilityInspectorTests.cs" />
     <Compile Include="Common\SyntaxNodeExtensionTests.cs" />
     <Compile Include="Common\TestBase.cs" />


### PR DESCRIPTION
Examples of messages include:

```
The static field or property 'foo' is unsafe because 'foo.Bar''s type ('test.Tests.Bar') is not sealed.
The static field or property 'foo' is unsafe because 'foo.Bar''s type argument ('System.Object') is not sealed.
The static field or property 'foo' is unsafe because 'foo.Bar.Baz' is not readonly.
```

Sorry for the large PR, I could have broken this up into steps, but they wouldn't have made sense that way.