### PR TITLE
Remove the legacy Unaudited constructor.

### DIFF
--- a/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("35fe7851-3f76-4057-9754-e883231619d0")]
 
-[assembly: AssemblyVersion("0.4.5.0")]
-[assembly: AssemblyFileVersion("0.4.5.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]

--- a/src/D2L.CodeStyle.Annotations/Statics/Unaudited.cs
+++ b/src/D2L.CodeStyle.Annotations/Statics/Unaudited.cs
@@ -15,11 +15,6 @@ namespace D2L.CodeStyle.Annotations {
 		public sealed class Unaudited : Attribute {
 			public readonly Because m_cuz;
 
-			// extra-legacy parameterless constructor
-			public Unaudited() {
-				m_cuz = Because.ItHasntBeenLookedAt; 
-			}
-
 			public Unaudited( Because why ) {
 				m_cuz = why;
 			}


### PR DESCRIPTION
We are killing the legacy constructor that does not provide a reason, and will require everyone to specific a reason.

This should not have any impact on the analyzers, but I'll of course test this before I merge.