### PR TITLE
Disallow `System.Action` and `System.Func`.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResult.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResult.cs
@@ -6,6 +6,7 @@
 	}
 
 	public enum MutabilityCause {
+		IsNotAllowed,
 		IsNotReadonly,
 		IsNotSealed,
 		IsAnInterface,

--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResultFormatter.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResultFormatter.cs
@@ -39,6 +39,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 					return "not read-only";
 				case MutabilityCause.IsPotentiallyMutable:
 					return "not deterministically immutable";
+				case MutabilityCause.IsNotAllowed:
+					return "not allowed";
 				default:
 					throw new NotImplementedException( $"unknown cause '{result.Cause}'" );
 			}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
@@ -254,6 +254,21 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		}
 
 		[Test]
+		public void InspectType_TypeWithFuncProperty_ReturnsMutable() {
+			var type = Property( "public Func<string> StringGetter { get; }" ).ContainingType;
+			var expected = MutabilityInspectionResult.Mutable(
+				"StringGetter",
+				"System.Func",
+				MutabilityTarget.Type,
+				MutabilityCause.IsNotAllowed
+			);
+
+			var actual = m_inspector.InspectType( type );
+
+			AssertResultsAreEqual( expected, actual );
+		}
+
+		[Test]
 		public void IsTypeMarkedImmutable_No_ReturnsFalse() {
 			var type = Type( "class Foo {}" );
 


### PR DESCRIPTION
Because they hold on to state that we cannot analyze.