### PR TITLE
Kill the unneeded NUnit 2 reference.

### DIFF
--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/packages.config
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/packages.config
@@ -8,6 +8,5 @@
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net461" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="NUnit" version="3.4.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This used to be needed for the nunit analyzers that used to exist, but wasn't removed when those were cleaned up.