### PR TITLE
Don't bail out of for suspected test assemblies

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -33,11 +33,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		private readonly MutabilityInspector m_immutabilityInspector = new MutabilityInspector();
 
 		public override void Initialize( AnalysisContext context ) {
-			context.RegisterCompilationStartAction( ctx =>
-				ctx.RegisterSyntaxNodeAction(
-					AnalyzeClass,
-					SyntaxKind.ClassDeclaration
-				)
+			context.RegisterSyntaxNodeAction(
+				AnalyzeClass,
+				SyntaxKind.ClassDeclaration
 			);
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
@@ -39,16 +39,14 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 		private readonly MutabilityInspectionResultFormatter m_resultFormatter = new MutabilityInspectionResultFormatter();
 
 		public override void Initialize( AnalysisContext context ) {
-			context.RegisterCompilationStartAction( ctx => {
-				ctx.RegisterSyntaxNodeAction(
-					AnalyzeField,
-					SyntaxKind.FieldDeclaration
-				);
-				ctx.RegisterSyntaxNodeAction(
-					AnalyzeProperty,
-					SyntaxKind.PropertyDeclaration
-				);
-			} );
+			context.RegisterSyntaxNodeAction(
+				AnalyzeField,
+				SyntaxKind.FieldDeclaration
+			);
+			context.RegisterSyntaxNodeAction(
+				AnalyzeProperty,
+				SyntaxKind.PropertyDeclaration
+			);
 		}
 
 		private void AnalyzeField( SyntaxNodeAnalysisContext context ) {


### PR DESCRIPTION
We used to detect assemblies that might be tests based on their assembly
name containing "Test" or having a reference to something related to NUnit.

Since we have a smarter way of validating that non-test assemblies in
the LMS include our analyzer this check isn't helpful and actually has
allowed some assemblies to sneak through (things with invalid references
to NUnit, etc.)