### PR TITLE
Add count4net counters to known immutable type list

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -22,6 +22,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		private static readonly ImmutableHashSet<string> KnownImmutableTypes = new HashSet<string> {
 			"count4net.IRateCounter",
 			"count4net.IStatCounter",
+			"count4net.IValueCounter",
+			"count4net.Writers.DurationCounter",
 			"log4net.ILog",
 			"Newtonsoft.Json.JsonSerializer",
 			"System.ComponentModel.TypeConverter",


### PR DESCRIPTION
`IValueCounter`, `Writers.DurationCounter` in count4net should be considered immutable.
Note `AverageTimer` and instance of `IDurationCounter` is not immutable, which is why I did not include it