### PR TITLE
Remove helpers that checked for readonly but flipped the logic

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -202,7 +202,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 						return MutabilityInspectionResult.NotMutable();
 					}
 
-					if( IsPropertyMutable( prop ) ) {
+					if( !prop.IsReadOnly ) {
 						return MutabilityInspectionResult.Mutable( prop.Name, prop.Type.GetFullTypeName(), MutabilityTarget.Member, MutabilityCause.IsNotReadonly );
 					}
 
@@ -217,7 +217,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 					var field = (IFieldSymbol)symbol;
 
-					if( IsFieldMutable( field ) ) {
+					if( !field.IsReadOnly ) {
 						return MutabilityInspectionResult.Mutable( field.Name, field.Type.GetFullTypeName(), MutabilityTarget.Member, MutabilityCause.IsNotReadonly );
 					}
 
@@ -266,32 +266,5 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			}
 			return false;
 		}
-
-		/// <summary>
-		/// Determine if a property is mutable.
-		/// This does not check if the type of the property is also mutable; use <see cref="InspectType"/> for that.
-		/// </summary>
-		/// <param name="prop">The property to check for mutability.</param>
-		/// <returns>Determines whether the property is mutable.</returns>
-		public bool IsPropertyMutable( IPropertySymbol prop ) {
-			if( prop.IsReadOnly ) {
-				return false;
-			}
-			return true;
-		}
-
-		/// <summary>
-		/// Determine if a field is mutable.
-		/// This does not check if the type of the field is also mutable; use <see cref="InspectType"/> for that.
-		/// </summary>
-		/// <param name="field">The field to check for mutability.</param>
-		/// <returns>Determines whether the property is mutable.</returns>
-		public bool IsFieldMutable( IFieldSymbol field ) {
-			if( field.IsReadOnly ) {
-				return false;
-			}
-			return true;
-		}
-
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
@@ -62,7 +62,7 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 					return;
 				}
 
-				if( m_immutabilityInspector.IsFieldMutable( symbol ) ) {
+				if( !symbol.IsReadOnly ) {
 					var diagnostic = CreateDiagnostic(
 						variable.GetLocation(),
 						symbol.Name,
@@ -121,7 +121,7 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 				return;
 			}
 
-			if( m_immutabilityInspector.IsPropertyMutable( prop ) ) {
+			if( !prop.IsReadOnly ) {
 				var diagnostic = CreateDiagnostic(
 					root.GetLocation(),
 					prop.Name,

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
@@ -11,62 +11,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		private readonly MutabilityInspector m_inspector = new MutabilityInspector();
 
 		[Test]
-		public void IsFieldMutable_Private_True() {
-			var field = Field( "private int[] random" );
-
-			Assert.IsTrue( m_inspector.IsFieldMutable( field ) );
-		}
-
-		[Test]
-		public void IsFieldMutable_Readonly_False() {
-			var field = Field( "readonly int[] random" );
-
-			Assert.IsFalse( m_inspector.IsFieldMutable( field ) );
-		}
-
-		[Test]
-		public void IsFieldMutable_PublicReadonly_False() {
-			var field = Field( "public readonly int[] random" );
-
-			Assert.IsFalse( m_inspector.IsFieldMutable( field ) );
-		}
-
-		[Test]
-		public void IsFieldMutable_Public_True() {
-			var field = Field( "public int[] random" );
-
-			Assert.IsTrue( m_inspector.IsFieldMutable( field ) );
-		}
-
-		[Test]
-		public void IsPropertyMutable_Private_True() {
-			var prop = Property( "private int random { get; set; }" );
-
-			Assert.IsTrue( m_inspector.IsPropertyMutable( prop ) );
-		}
-
-		[Test]
-		public void IsPropertyMutable_Readonly_False() {
-			var prop = Property( "int random { get; }" );
-
-			Assert.IsFalse( m_inspector.IsPropertyMutable( prop ) );
-		}
-
-		[Test]
-		public void IsPropertyMutable_PrivateSetter_True() {
-			var prop = Property( "int random { get; private set; }" );
-
-			Assert.IsTrue( m_inspector.IsPropertyMutable( prop ) );
-		}
-
-		[Test]
-		public void IsPropertyMutable_PublicWithSetter_True() {
-			var prop = Property( "public int random { get; set; }" );
-
-			Assert.IsTrue( m_inspector.IsPropertyMutable( prop ) );
-		}
-
-		[Test]
 		public void InspectType_PrimitiveType_NotMutable() {
 			var type = Field( "uint foo" ).Type;
 			var expected = MutabilityInspectionResult.NotMutable();
@@ -172,7 +116,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		[Test]
 		public void InspectType_LooksAtMembersInDeclaredType() {
 			var field = Field( "public string random" );
-			Assert.IsTrue( m_inspector.IsFieldMutable( field ) );
+
 			var expected = MutabilityInspectionResult.Mutable(
 				"random",
 				"System.String",
@@ -188,7 +132,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		[Test]
 		public void InspectType_LooksAtMembersInExternalType() {
 			var field = Field( "public readonly System.Text.StringBuilder random" );
-			Assert.IsFalse( m_inspector.IsFieldMutable( field ) );
+
 			var expected = MutabilityInspectionResult.Mutable(
 				"Capacity",
 				"System.Int32",
@@ -204,7 +148,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		[Test]
 		public void InspectType_LooksFieldsInType() {
 			var field = Field( "public readonly System.Text.StringBuilder random" );
-			Assert.IsFalse( m_inspector.IsFieldMutable( field ) );
+
 			var expected = MutabilityInspectionResult.Mutable(
 				"random.Capacity",
 				"System.Int32",
@@ -220,7 +164,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		[Test]
 		public void InspectType_LooksAtPropertiesInType() {
 			var prop = Property( "public string random { get; set; }" );
-			Assert.IsTrue( m_inspector.IsPropertyMutable( prop ) );
+
 			var expected = MutabilityInspectionResult.Mutable(
 				$"random",
 				"System.String",


### PR DESCRIPTION
I think it reads simpler this way - although there are `!`s, it maps directly to C# language constructs; the previous helper names didn't so it wasn't clear what was going on without going to their implementation.