### PR TITLE
Don't assume that the symbol lookup for an attribute succeeded

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/RpcDependencies/RpcDependencyAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/RpcDependencies/RpcDependencyAnalyzer.cs
@@ -169,7 +169,7 @@ namespace D2L.CodeStyle.Analyzers.RpcDependencies {
 
 			// Note: symbol corresponds to the constructor for the attribute,
 			// so we need to look at symbol.ContainingType
-			return expectedType.Equals( attributeConstructorType.ContainingType );
+			return expectedType.Equals( attributeConstructorType?.ContainingType );
 		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/RpcDependencies/RpcDependencyAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/RpcDependencies/RpcDependencyAnalyzerTests.cs
@@ -34,6 +34,18 @@ namespace Test {
 		}
 
 		[Test]
+		public void NormalMethodWithUnknownAttribute_NoDiag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	class Test {
+		[SomethingWeird]
+		public void Test( int x ) {}
+	}
+}";
+			AssertNoDiagnostic( test );
+		}
+
+		[Test]
 		public void MethodWithUnrelatedButAnnoyinglyNamedRpcAttribute_NoDiag() {
 			const string test = PREAMBLE + @"
 namespace Test {
@@ -141,6 +153,20 @@ namespace Test {
 	class Test {
 		[Rpc]
 		public void Test( IRpcContext x, int x, int y ) {}
+	}
+}";
+			AssertNoDiagnostic( test );
+		}
+
+		[Test]
+		public void RpcWithParameterThatHasBadAttributeType_NoDiag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	using D2L.Web;
+	using D2L.LP.Extensibility.Activation.Domain;
+	class Test {
+		[Rpc]
+		public void Test( IRpcContext x, [SomethingWeird] int x, int y ) {}
 	}
 }";
 			AssertNoDiagnostic( test );


### PR DESCRIPTION
Both of these now result in no diagnostic. This is good because in both
cases it's unclear how our diagnostics could help the user.