### PR TITLE
Emit diagnostics for unnecessary and conflicting static annotations

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/Diagnostics.cs
@@ -55,7 +55,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		public static readonly DiagnosticDescriptor UnnecessaryStaticAnnotation = new DiagnosticDescriptor(
 			id: "D2L0007",
 			title: "Unnecessary static annotations should be removed to keep the code base clean",
-			messageFormat: "The '{0}' annotation is not necessary because the member '{1}' is immutable. Please remove this attribute to keep our code base clean.",
+			messageFormat: "The {0} annotation is not necessary because {1} is immutable. Please remove this attribute to keep our code base clean.",
 			category: "Cleanliness",
 			defaultSeverity: DiagnosticSeverity.Error, // this may seem extreme but we want to keep the amount of annotated stuff minimal
 			isEnabledByDefault:true,

--- a/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
@@ -159,18 +159,25 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 			// - if we did .ToArray() early then we would avoid multiple
 			//   enumeration but would compute diagnostics even when we
 			//   ultimately ignore them due to annotations
-			using( var enumerator = diagnostics.GetEnumerator() ) {
-				ProcessDiagnostics( context, enumerator, location, attributes );
+			using( var diagnosticsEnumerator = diagnostics.GetEnumerator() ) {
+				ProcessDiagnostics(
+					context,
+					diagnosticsEnumerator,
+					location,
+					attributes,
+					fieldOrPropertyName
+				);
 			}
 		}
 		
 		private void ProcessDiagnostics(
 			SyntaxNodeAnalysisContext context,
-			IEnumerator<Diagnostic> enumerator,
+			IEnumerator<Diagnostic> diagnostics,
 			Location location,
-			ImmutableArray<AttributeSyntax> attributes
+			ImmutableArray<AttributeSyntax> attributes,
+			string fieldOrPropertyName
 		) {
-			var hasDiagnostics = enumerator.MoveNext();
+			var hasDiagnostics = diagnostics.MoveNext();
 
 			// TODO: This EndsWith stuff is lame. We should do the same thing
 			// that the RpcAnalyzer does with looking up and caching the types.
@@ -201,7 +208,10 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 				context.ReportDiagnostic(
 					Diagnostic.Create(
 						Diagnostics.UnnecessaryStaticAnnotation,
-						location
+						location,
+						ImmutableDictionary<string, string>.Empty,
+						hasAuditedAnnotation ? "Statics.Audited" : "Statics.Unaudited",
+						fieldOrPropertyName
 					)
 				);
 
@@ -215,8 +225,8 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 			}
 
 			while ( hasDiagnostics ) {
-				context.ReportDiagnostic( enumerator.Current );
-				hasDiagnostics = enumerator.MoveNext();
+				context.ReportDiagnostic( diagnostics.Current );
+				hasDiagnostics = diagnostics.MoveNext();
 			}
 		}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/UnsafeStatics/UnsafeStaticsAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/UnsafeStatics/UnsafeStaticsAnalyzerTests.cs
@@ -842,6 +842,70 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 			VerifyCSharpDiagnostic( file );
 		}
 
+		[Test]
+		public void DocumentWithAuditedSafeThing_Diag() {
+			const string test = @"
+namespace test {
+	class tests {
+		[Statics.Audited("""", """", """")]
+		private readonly static string x = ""hey""
+	}
+}";
+			var expected = new DiagnosticResult {
+				Id = Diagnostics.UnnecessaryStaticAnnotation.Id,
+				Message = string.Format( Diagnostics.UnnecessaryStaticAnnotation.MessageFormat.ToString(), "Statics.Audited", "x" ),
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] {
+					new DiagnosticResultLocation( "Test0.cs", 5, 34),
+				}
+			};
+
+			VerifyCSharpDiagnostic( test, expected );
+		}
+
+		[Test]
+		public void DocumentWithUnauditedSafeThing_Diag() {
+			const string test = @"
+namespace test {
+	class tests {
+		[Statics.Unaudited( Because.ItsSketchy )]
+		private readonly static string x = ""hey""
+	}
+}";
+			var expected = new DiagnosticResult {
+				Id = Diagnostics.UnnecessaryStaticAnnotation.Id,
+				Message = string.Format( Diagnostics.UnnecessaryStaticAnnotation.MessageFormat.ToString(), "Statics.Unaudited", "x" ),
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] {
+					new DiagnosticResultLocation( "Test0.cs", 5, 34),
+				}
+			};
+
+			VerifyCSharpDiagnostic( test, expected );
+		}
+
+		[Test]
+		public void DocumentWithConflictingAnnotations_Diag() {
+			const string test = @"
+namespace test {
+	class tests {
+		[Statcs.Unaudited( Because.ItsSketchy )]
+		[Statics.Audited("""", """", """")]
+		private static string x = ""hey""
+	}
+}";
+			var expected = new DiagnosticResult {
+				Id = Diagnostics.ConflictingStaticAnnotation.Id,
+				Message = Diagnostics.ConflictingStaticAnnotation.MessageFormat.ToString(),
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] {
+					new DiagnosticResultLocation( "Test0.cs", 6, 25),
+				}
+			};
+
+			VerifyCSharpDiagnostic( test, expected );
+		}
+
         private void AssertSingleDiagnostic( string file, int line, int column, string fieldOrProp, MutabilityInspectionResult inspectionResult ) {
 
             DiagnosticResult result = CreateDiagnosticResult( line, column, fieldOrProp, inspectionResult );


### PR DESCRIPTION
This required refactoring InspectType (renamed to InspectFieldOrProperty
because that is more accurate) and the AnalyzeField/Property methods.

In the new design most branches out of analysis are via yield breaks in
GenerateDiagnostics. This allows InspectFieldOrProperty to implement the
"if there are no diagnostics but there is an annotation, emit a
diagnostic" logic. Bailing out earlier (e.g. in AnalyzeField) would
break this. I've added some more comments, particularly around any
bailing-out and some overall design notes for future readers.

In the near future I plan to fix the way attributes are compared to use
types from semantic analysis similar to the RpcAnalyzer.