### PR TITLE
Adding support for assembly-declared known immutables.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/KnownImmutableTypes.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/KnownImmutableTypes.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace D2L.CodeStyle.Analyzers.Common {
+	internal sealed class KnownImmutableTypes {
+
+		internal static readonly KnownImmutableTypes Default = new KnownImmutableTypes( ImmutableHashSet<string>.Empty );
+
+		/// <summary>
+		/// A list of known immutable types.
+		/// </summary>
+		private static readonly ImmutableHashSet<string> DefaultKnownImmutableTypes = new HashSet<string> {
+			"count4net.IRateCounter",
+			"count4net.IStatCounter",
+			"count4net.IValueCounter",
+			"count4net.Writers.DurationCounter",
+			"log4net.ILog",
+			"Newtonsoft.Json.JsonSerializer",
+			"System.ComponentModel.TypeConverter",
+			"System.DateTime",
+			"System.Drawing.Size", // only safe because it's a struct with primitive fields
+			"System.Guid",
+			"System.Reflection.ConstructorInfo",
+			"System.Reflection.FieldInfo",
+			"System.Reflection.MemberInfo",
+			"System.Reflection.MethodInfo",
+			"System.Reflection.PropertyInfo",
+			"System.Text.RegularExpressions.Regex",
+			"System.TimeSpan",
+			"System.Type",
+			"System.Uri",
+			"System.String",
+			"System.Version",
+			"System.Workflow.ComponentModel.DependencyProperty",
+			"System.Xml.Serialization.XmlSerializer"
+		}.ToImmutableHashSet();
+
+		/// <summary>
+		/// A list of known immutable types defined for the assembly.
+		/// </summary>
+		private readonly ImmutableHashSet<string> DeclaredKnownImmutableTypes;
+
+		internal KnownImmutableTypes( ImmutableHashSet<string> declaredKnownImmutableTypes ) {
+			DeclaredKnownImmutableTypes = declaredKnownImmutableTypes;
+		}
+
+		internal KnownImmutableTypes( IAssemblySymbol a )
+			: this( LoadFromAssembly( a ) ) { }
+
+		internal bool IsTypeKnownImmutable( ITypeSymbol type ) {
+			if( type.IsPrimitive() ) {
+				return true;
+			}
+
+			string typeName = type.GetFullTypeName();
+
+			if( DeclaredKnownImmutableTypes.Contains( typeName ) ) {
+				return true;
+			}
+
+			if( DefaultKnownImmutableTypes.Contains( typeName ) ) {
+				return true;
+			}
+
+			return false;
+		}
+
+		private static ImmutableHashSet<string> LoadFromAssembly( IAssemblySymbol a ) {
+			var knownImmutableTypesAttribute = a.GetAttributes()
+				.Where( attr => attr.AttributeClass.Name == "KnownImmutableTypes" )
+				.SingleOrDefault();
+
+			if( knownImmutableTypesAttribute == null ) {
+				return ImmutableHashSet<string>.Empty;
+			}
+
+			var knownImmutableTypes = knownImmutableTypesAttribute
+				.ConstructorArguments
+				.SelectMany( GetTypeConstantValues<string> );
+
+			return knownImmutableTypes
+				.Select( t => t.ToString() )
+				.ToImmutableHashSet();
+		}
+
+		private static ISet<T> GetTypeConstantValues<T>( TypedConstant c ) {
+			var values = new HashSet<T>();
+
+			if( c.Value != null ) {
+				values.Add( (T) c.Value );
+			}
+
+			if( !c.Values.IsDefaultOrEmpty ) {
+				var nestedValues = c.Values.SelectMany( GetTypeConstantValues<T> );
+				foreach( var nestedValue in nestedValues ) {
+					values.Add( nestedValue );
+				}
+			}
+
+			return values;
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -14,36 +14,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		IgnoreImmutabilityAttribute = 2,
 	}
 
-	public sealed class MutabilityInspector {
-
-		/// <summary>
-		/// A list of known immutable types
-		/// </summary>
-		private static readonly ImmutableHashSet<string> KnownImmutableTypes = new HashSet<string> {
-			"count4net.IRateCounter",
-			"count4net.IStatCounter",
-			"count4net.IValueCounter",
-			"count4net.Writers.DurationCounter",
-			"log4net.ILog",
-			"Newtonsoft.Json.JsonSerializer",
-			"System.ComponentModel.TypeConverter",
-			"System.DateTime",
-			"System.Drawing.Size", // only safe because it's a struct with primitive fields
-			"System.Guid",
-			"System.Reflection.ConstructorInfo",
-			"System.Reflection.FieldInfo",
-			"System.Reflection.MemberInfo",
-			"System.Reflection.MethodInfo",
-			"System.Reflection.PropertyInfo",
-			"System.Text.RegularExpressions.Regex",
-			"System.TimeSpan",
-			"System.Type",
-			"System.Uri",
-			"System.String",
-			"System.Version",
-			"System.Workflow.ComponentModel.DependencyProperty",
-			"System.Xml.Serialization.XmlSerializer"
-		}.ToImmutableHashSet();
+	internal sealed class MutabilityInspector {
 
 		/// <summary>
 		/// A list of marked immutable types owned externally.
@@ -74,6 +45,14 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			[ "System.Tuple" ] = new[] { "Item1", "Item2", "Item3", "Item4", "Item5", "Item6" }
 		}.ToImmutableDictionary();
 
+		private readonly KnownImmutableTypes _knownImmutableTypes;
+
+		internal MutabilityInspector(
+			KnownImmutableTypes knownImmutableTypes
+		) {
+			_knownImmutableTypes = knownImmutableTypes;
+		}
+
 		/// <summary>
 		/// Determine if a given type is mutable.
 		/// </summary>
@@ -98,7 +77,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 					+ "are referenced, including transitive dependencies." );
 			}
 
-			if( IsTypeKnownImmutable( type ) ) {
+			if( _knownImmutableTypes.IsTypeKnownImmutable( type ) ) {
 				return MutabilityInspectionResult.NotMutable();
 			}
 
@@ -237,18 +216,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 					// we've got a member (event, etc.) that we can't currently be smart about, so fail
 					return MutabilityInspectionResult.Mutable( symbol.Name, null, MutabilityTarget.Member, MutabilityCause.IsPotentiallyMutable );
 			}
-		}
-
-		private bool IsTypeKnownImmutable( ITypeSymbol type ) {
-			if( type.IsPrimitive() ) {
-				return true;
-			}
-
-			if( KnownImmutableTypes.Contains( type.GetFullTypeName() ) ) {
-				return true;
-			}
-
-			return false;
 		}
 
 		public bool IsTypeMarkedImmutable( ITypeSymbol symbol ) {

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common\Diagnostics.cs" />
+    <Compile Include="Common\KnownImmutableTypes.cs" />
     <Compile Include="Common\MutabilityInspectionResult.cs" />
     <Compile Include="Common\MutabilityInspectionResultFormatter.cs" />
     <Compile Include="Common\MutabilityInspector.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -10,7 +10,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 	public sealed class ImmutabilityAnalyzer : DiagnosticAnalyzer {
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create( Diagnostics.ImmutableClassIsnt );
 
-		private readonly MutabilityInspector m_immutabilityInspector = new MutabilityInspector();
+		private readonly MutabilityInspector m_immutabilityInspector = new MutabilityInspector( KnownImmutableTypes.Default );
 
 		public override void Initialize( AnalysisContext context ) {
 			context.RegisterSyntaxNodeAction(

--- a/src/D2L.CodeStyle.Analyzers/UnsafeSingletons/UnsafeSingletonsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeSingletons/UnsafeSingletonsAnalyzer.cs
@@ -10,7 +10,7 @@ namespace D2L.CodeStyle.Analyzers.UnsafeSingletons {
 	public sealed class UnsafeSingletonsAnalyzer : DiagnosticAnalyzer {
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create( Diagnostics.UnsafeSingletonField );
 
-		private readonly MutabilityInspector m_immutabilityInspector = new MutabilityInspector();
+		private readonly MutabilityInspector m_immutabilityInspector = new MutabilityInspector( KnownImmutableTypes.Default );
 		private readonly Utils m_utils = new Utils();
 		private readonly MutabilityInspectionResultFormatter m_resultFormatter = new MutabilityInspectionResultFormatter();
 

--- a/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
@@ -22,7 +22,7 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 			Diagnostics.UnnecessaryStaticAnnotation
 		);
 
-		private readonly MutabilityInspector m_immutabilityInspector = new MutabilityInspector();
+		private readonly MutabilityInspector m_immutabilityInspector = new MutabilityInspector( KnownImmutableTypes.Default );
 		private readonly Utils m_utils = new Utils();
 		private readonly MutabilityInspectionResultFormatter m_resultFormatter = new MutabilityInspectionResultFormatter();
 

--- a/src/D2L.CodeStyle.Annotations/D2L.CodeStyle.Annotations.csproj
+++ b/src/D2L.CodeStyle.Annotations/D2L.CodeStyle.Annotations.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Compile Include="Objects\Audited.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Statics\KnownImmutableTypes.cs" />
     <Compile Include="Statics\Audited.cs" />
     <Compile Include="Statics\Unaudited.cs" />
   </ItemGroup>

--- a/src/D2L.CodeStyle.Annotations/Statics/KnownImmutableTypes.cs
+++ b/src/D2L.CodeStyle.Annotations/Statics/KnownImmutableTypes.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+// ReSharper disable once CheckNamespace
+namespace D2L.CodeStyle.Annotations {
+    public static partial class Statics {
+		/// <summary>
+		/// Define a list of known immutable types used in the assembly.
+		/// </summary>
+		[AttributeUsage( validOn: AttributeTargets.Assembly, AllowMultiple = false )]
+        public sealed class KnownImmutableTypes : Attribute {
+			/// <summary>
+			/// Define a list of known immutable types used in the assembly.
+			/// </summary>
+			/// <param name="typeNames">Type names, fully qualified, but not assembly qualified.</param>
+			public KnownImmutableTypes( params string[] typeNames ) {
+				TypeNames = typeNames;
+			}
+
+            public string[] TypeNames { get; }
+        }
+	}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/KnownImmutableTypesTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/KnownImmutableTypesTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using NUnit.Framework;
+using static D2L.CodeStyle.Analyzers.Common.RoslynSymbolFactory;
+
+namespace D2L.CodeStyle.Analyzers.Common {
+	[TestFixture]
+	public class KnownImmutableTypesTests {
+
+		[Test]
+		public void IsTypeKnownImmutable_DefaultlyImmutable_True() {
+			var knownTypes = new KnownImmutableTypes( ImmutableHashSet<string>.Empty );
+			var type = Field( "System.Version foo" ).Type;
+
+			var result = knownTypes.IsTypeKnownImmutable( type );
+
+			Assert.True( result );
+		}
+
+		[Test]
+		public void IsTypeKnownImmutable_DefaultlyNotImmutable_False() {
+			var knownTypes = new KnownImmutableTypes( ImmutableHashSet<string>.Empty );
+			var type = Field( "System.IDisposable foo" ).Type;
+
+			var result = knownTypes.IsTypeKnownImmutable( type );
+
+			Assert.False( result );
+		}
+
+		[Test]
+		public void IsTypeKnownImmutable_DeclaredImmutable_True() {
+			var knownTypes = new KnownImmutableTypes( new HashSet<string> {
+				"System.IDisposable"
+			}.ToImmutableHashSet() );
+			var type = Field( "System.IDisposable foo" ).Type;
+
+			var result = knownTypes.IsTypeKnownImmutable( type );
+
+			Assert.True( result );
+		}
+
+		[Test]
+		public void IsTypeKnownImmutable_NotDeclaredImmutableAndNotDefault_False() {
+			var knownTypes = new KnownImmutableTypes( ImmutableHashSet<string>.Empty );
+			var type = Field( "System.IDisposable foo" ).Type;
+
+			var result = knownTypes.IsTypeKnownImmutable( type );
+
+			Assert.False( result );
+		}
+
+	}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
@@ -8,7 +8,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 	[TestFixture]
 	public class MutabilityInspectorTests {
 
-		private readonly MutabilityInspector m_inspector = new MutabilityInspector();
+		private readonly MutabilityInspector m_inspector = new MutabilityInspector( KnownImmutableTypes.Default );
 
 		[Test]
 		public void InspectType_PrimitiveType_NotMutable() {

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -36,6 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Common\KnownImmutableTypesTests.cs" />
     <Compile Include="Common\MutabilityInspectionResultFormatterTests.cs" />
     <Compile Include="Common\MutabilityInspectorTests.cs" />
     <Compile Include="Common\SyntaxNodeExtensionTests.cs" />


### PR DESCRIPTION
The idea behind this is that we can change the list of known immutable types without release a new version of the analyzer. All projects in the LMS will reference a single file in `build` that has them all defined.

I'll be following a similar idea for container types, but that's non-trivial because of the field/props we use for the type arguments of those containers.