### PR TITLE
Don't throw for types that resolve as IErrorTypeSymbol

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -90,7 +90,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		) {
 			if( type is IErrorTypeSymbol ) {
 				// This only happens for code that otherwise won't compile. Our
-				// analyzer doesn't need to validate these types.
+				// analyzer doesn't need to validate these types. It only needs
+				// to be strict for valid code.
 				return MutabilityInspectionResult.NotMutable();
 			}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/UnsafeStaticsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/UnsafeStaticsAnalyzer.cs
@@ -63,6 +63,15 @@ namespace SpecTests {
 		public static int x;
 		[Statics.Unaudited( Because.ItsStickyDataOhNooo )]
 		public static readonly INotNecessarilyImmutableInterface x;
+
+		internal sealed class ClassWithMemberOfUnknownType {
+			private readonly INotSureWhatThisIs m_foo = null;
+		}
+
+		// This shouldn't emit a diagnostic and shouldn't throw an exception
+		// even though we can't complete the analysis. That's okay because
+		// our analyzer only needs to be strict for builds that pass.
+		public static readonly ClassWithMemberOfUnknownType m_classWithMemberOfUnknownType;
 		
 	}
 }


### PR DESCRIPTION
This only happens when there are other build errors. Our analyzer is
safe to ignore these types - it only needs to be strict for builds that
pass.