### PR TITLE
US87654: Adding a `[NotNullWhenParameter]` attribute

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Contract/NotNullAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Contract/NotNullAnalyzer.cs
@@ -14,6 +14,8 @@ namespace D2L.CodeStyle.Analyzers.Contract {
 
 		private const string Namespace = "D2L.CodeStyle.Annotations.Contract.";
 		private const string NotNullAttribute = Namespace + "NotNullAttribute";
+		private const string NotNullTypeAttribute = Namespace + "NotNullWhenParameterAttribute";
+		private const string AllowNullAttribute = Namespace + "AllowNullAttribute";
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create( Diagnostics.NullPassedToNotNullParameter );
@@ -83,7 +85,7 @@ namespace D2L.CodeStyle.Analyzers.Contract {
 					continue;
 				}
 
-				var parameter = argument.DetermineParameter(
+				IParameterSymbol parameter = argument.DetermineParameter(
 					context.SemanticModel,
 					allowParams: true
 				);
@@ -95,15 +97,14 @@ namespace D2L.CodeStyle.Analyzers.Contract {
 					continue;
 				}
 
-				// If the parameter isn't marked [NotNull] we can skip this
-				// argument. It might be interesting to complain for null
-				// passed to a params argument in the future.
-				if ( !SymbolHasAttribute( parameter, NotNullAttribute ) ) {
+				// If the parameter and its type aren't marked as [NotNull]
+				// we can skip this argument.
+				if( !ParameterMustNotBeNull( parameter ) ) {
 					continue;
 				}
 
 				// We know that the argument looks null enough and the
-				// parameter has the [NotNull] attribute. Emit a diagnostic.
+				// parameter must not be passed null. Emit a diagnostic.
 				context.ReportDiagnostic( Diagnostic.Create(
 					Diagnostics.NullPassedToNotNullParameter,
 					argument.GetLocation(),
@@ -125,6 +126,27 @@ namespace D2L.CodeStyle.Analyzers.Contract {
 			return litExpr.Token.Kind() == SyntaxKind.NullKeyword;
 		}
 
+		private static bool ParameterMustNotBeNull(
+			IParameterSymbol parameter
+		) {
+			// If the parameter is marked [NotNull] we can skip checking for other attributes.
+			if( SymbolHasAttribute( parameter, NotNullAttribute ) ) {
+				return true;
+			}
+
+			// If the parameter's type is marked [NotNullWhenParameter], and
+			// the parameter itself is not marked with [AllowNull], then the
+			// parameter is considered equivalent to having [NotNull] applied.
+			ITypeSymbol paramType = parameter.Type;
+			if( SymbolHasAttribute( paramType, NotNullTypeAttribute )
+				&& !SymbolHasAttribute( parameter, AllowNullAttribute )
+			) {
+				return true;
+			}
+
+			return false;
+		}
+
 		private static bool SymbolHasAttribute(
 			ISymbol symbol,
 			string attributeClassName
@@ -138,3 +160,4 @@ namespace D2L.CodeStyle.Analyzers.Contract {
 		}
 	}
 }
+ 

--- a/src/D2L.CodeStyle.Annotations/Contract/NotNullAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/Contract/NotNullAttribute.cs
@@ -5,7 +5,40 @@ namespace D2L.CodeStyle.Annotations.Contract {
 	/// <summary>
 	/// Indicates that a paramater may not be called with `null`
 	/// </summary>
+	/// <seealso cref="NotNullWhenParameterAttribute"/>
+	/// <seealso cref="AllowNullAttribute"/>
 	[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
 	public sealed class NotNullAttribute : Attribute {
+	}
+
+	/// <summary>
+	/// All paremters of the given type will implicitly have <see cref="NotNullAttribute"/> applied.
+	/// In other words, if a parameter is of a type with this attribute, that parameter cannot be
+	/// passed an explicitly null value.
+	/// </summary>
+	/// <seealso cref="NotNullAttribute"/>
+	/// <seealso cref="AllowNullAttribute"/>
+	[AttributeUsage(
+		AttributeTargets.Class | AttributeTargets.Interface,
+		AllowMultiple = false
+	)]
+	public sealed class NotNullWhenParameterAttribute : Attribute { }
+
+	/// <summary>
+	/// Overrides <see cref="NotNullWhenParameterAttribute"/> for a single parameter, indicating that
+	/// the parameter will be allowed to receive a null value.
+	/// </summary>
+	/// <seealso cref="NotNullAttribute"/>
+	/// <seealso cref="NotNullWhenParameterAttribute"/>
+	[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
+	public sealed class AllowNullAttribute : Attribute {
+
+		public AllowNullAttribute(
+			string rationale
+		) {
+			Rationale = rationale;
+		}
+
+		public string Rationale { get; private set; }
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Contracts/NotNullAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Contracts/NotNullAnalyzerTests.cs
@@ -17,6 +17,8 @@ using D2L.CodeStyle.Annotations.Contract;
 
 namespace D2L.CodeStyle.Annotations.Contract {
 	public class NotNullAttribute : System.Attribute {}
+	public class NotNullWhenParameterAttribute : Attribute {}
+	public class AllowNullAttribute : Attribute {}
 }
 ";
 
@@ -46,7 +48,33 @@ namespace Test {
 }
 ";
 
+		private const string NotNullType = Attributes + @"
+namespace Test {
+	[NotNullWhenParameter]
+	interface IDatabase {}
+	class Database : IDatabase {};
+	class TestProvider {
+		public void TestMethod(
+			IDatabase database
+		) {}
+		public void TestMethod(
+			string allowedToBeNull,
+			IDatabase testDatabase
+		) {}
+		public void MultiNotNull(
+			IDatabase first,
+			IDatabase second
+		) {}
+		public void TestMethodCanTakeNull(
+			[AllowNull] IDatabase database
+		) {}
+		public bool ShouldDoStuff => false;
+	}
+}
+";
+
 		private static readonly int NotNullParamMethodLines = NotNullParamMethod.Count( c => c.Equals( '\n' ) ) + 1;
+		private static readonly int NotNullTypeLines = NotNullType.Count( c => c.Equals( '\n' ) ) + 1;
 
 		#region Parameter has [NotNull] directly
 
@@ -496,6 +524,180 @@ namespace Test {
 
 		private void DoSomeStuff(
 			[NotNull] string value = ""a value""
+		) {}
+	}
+}";
+			AssertDoesNotProduceError( test );
+		}
+
+		#endregion
+
+		#endregion
+
+		#region Parameter's type has [NotNullWhenParameter]
+
+		#region Should produce errors
+
+		[Test]
+		public void NotNullType_NullIsPassed_ReportsProblem() {
+			const string test = NotNullType + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			var provider = new TestProvider();
+			provider.TestMethod( null );
+		}
+	}
+}";
+			AssertProducesError(
+					test,
+					5 + NotNullTypeLines,
+					25,
+					"database"
+				);
+		}
+
+		[Test]
+		public void NotNullType_NullIsPassed_MethodInSameClass_ReportsProblem() {
+			const string test = NotNullType + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			DoStuff( null );
+		}
+		public void DoStuff(
+			IDatabase database
+		) {}
+	}
+}";
+			AssertProducesError(
+					test,
+					4 + NotNullTypeLines,
+					13,
+					"database"
+				);
+		}
+
+		[Test]
+		public void NotNullType_MultipleParamtersWithIssue_ReportsMultipleProblems() {
+			const string test = NotNullType + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			var provider = new TestProvider();
+			provider.TestMethod( new Database() );
+			provider.MultiNotNull(
+					null,
+					null
+				);
+		}
+	}
+}";
+			DiagnosticDescriptor descriptor = Diagnostics.NullPassedToNotNullParameter;
+			DiagnosticResult[] expectedResults = new[] {
+				new DiagnosticResult() {
+					Id = descriptor.Id,
+					Message = string.Format( descriptor.MessageFormat.ToString(), "first" ),
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] {
+						new DiagnosticResultLocation( "Test0.cs", 7 + NotNullTypeLines, 6 )
+					}
+				},
+				new DiagnosticResult() {
+					Id = descriptor.Id,
+					Message = string.Format( descriptor.MessageFormat.ToString(), "second" ),
+					Severity = DiagnosticSeverity.Error,
+					Locations = new[] {
+						new DiagnosticResultLocation( "Test0.cs", 8 + NotNullTypeLines, 6 )
+					}
+				}
+			};
+
+			VerifyCSharpDiagnostic( test, expectedResults );
+		}
+
+		[Test]
+		public void NotNullType_NamedArguments_OneIsNull_ReportsProblem() {
+			const string test = NotNullType + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			var provider = new TestProvider();
+			provider.TestMethod(
+				testDatabase: null,
+				allowedToBeNull: ""This one is actually a string, not a database""
+			);
+		}
+	}
+}";
+			AssertProducesError(
+					test,
+					6 + NotNullTypeLines,
+					5,
+					"testDatabase"
+				);
+		}
+
+		#endregion
+
+		#region  Should not produce errors, due to not passing null
+
+		[Test]
+		public void NotNullType_ValueIsPassed_DoesNotReportProblem() {
+			const string test = NotNullType + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			var provider = new TestProvider();
+			provider.TestMethod( new Database() );
+		}
+	}
+}";
+			AssertDoesNotProduceError( test );
+		}
+
+		[Test]
+		public void NotNullType_OneParamNotNull_NullPassedToNullable_DoesNotReportProblem() {
+			const string test = NotNullType + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			var provider = new TestProvider();
+			provider.TestMethod( null, new Database() );
+		}
+	}
+}";
+			AssertDoesNotProduceError( test );
+		}
+
+		#endregion
+
+		#region Parameter is flagged with [AllowNull]
+
+		[Test]
+		public void NotNullType_AllowNull_NullIsPassed_DoesNotReportProblem() {
+			const string test = NotNullType + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			var provider = new TestProvider();
+			provider.TestMethodCanTakeNull( null );
+		}
+	}
+}";
+			AssertDoesNotProduceError( test );
+		}
+
+		[Test]
+		public void NotNullType_AllowNull_NullIsPassed_MethodInSameClass_DoesNotReportProblem() {
+			const string test = NotNullType + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			DoStuff( null );
+		}
+		public void DoStuff(
+			[AllowNull] IDatabase database
 		) {}
 	}
 }";


### PR DESCRIPTION
This denotes that when this type is used as a parameter, that parameter inherently has the `[NotNull]` attribute applied

Removing the part of the comment about `params` parameters, since this is already covered, and there are unit tests to assert that it works.