### PR TITLE
Bump D2L.CodeStyle.Analyzers from 0.19 to 0.20

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.19.0.0" )]
-[assembly: AssemblyFileVersion( "0.19.0.0" )]
+[assembly: AssemblyVersion( "0.20.0.0" )]
+[assembly: AssemblyFileVersion( "0.20.0.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]


### PR DESCRIPTION
Not backwards compatible, since I moved a bunch of code to a different repo