### PR TITLE
US87654: Handle parameterless object initializer syntax

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Contract/NotNullAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Contract/NotNullAnalyzer.cs
@@ -49,7 +49,7 @@ namespace D2L.CodeStyle.Analyzers.Contract {
 		) {
 			AnalyzeInvocationLikeThing(
 				context,
-				invocation.ArgumentList.Arguments
+				invocation.ArgumentList
 			);
 		}
 
@@ -59,7 +59,7 @@ namespace D2L.CodeStyle.Analyzers.Contract {
 		) {
 			AnalyzeInvocationLikeThing(
 				context,
-				construction.ArgumentList.Arguments
+				construction.ArgumentList
 			);
 		}
 
@@ -69,13 +69,21 @@ namespace D2L.CodeStyle.Analyzers.Contract {
 		/// </summary>
 		private static void AnalyzeInvocationLikeThing(
 			SyntaxNodeAnalysisContext context,
-			SeparatedSyntaxList<ArgumentSyntax> arguments
+			ArgumentListSyntax argumentList
 		) {
+			// If a constructor takes no arguments, and is populated using
+			// object initializer syntax, then the argument list will be null.
+			// There's nothing for us to analyze.
+			if( argumentList == null ) {
+				return;
+			}
+
 			// Validate that all arguments that are provided are either not
 			// null or associated with a parameter that does not have [NotNull]
 			// attribute. This would miss a null being passed to a params 
 			// parameter which may be reasonable to always complain about
 			// because it's a weird and ugly edge-case.
+			SeparatedSyntaxList<ArgumentSyntax> arguments = argumentList.Arguments;
 			foreach( var argument in arguments ) {
 				// If the argument expression looks safe we don't need to
 				// inspect the parameter.

--- a/tests/D2L.CodeStyle.Analyzers.Test/Contracts/NotNullAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Contracts/NotNullAnalyzerTests.cs
@@ -372,6 +372,37 @@ namespace Test {
 				);
 		}
 
+		[Test]
+		public void NotNullParam_ConstructorCalledThenObjectInitializerSyntax_ReportsProblem() {
+			const string test = NotNullParamMethod + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			var foo = new Foo( null, null ) {
+				Id = 42,
+				Count = 3.14159
+			};
+		}
+	}
+
+	internal class Foo {
+		public Foo(
+			string name,
+			[NotNull] string other
+		) {}
+
+		public int Id {get; set;}
+		public double Count {get; set;}
+	}
+}";
+			AssertProducesError(
+					test,
+					4 + NotNullParamMethodLines,
+					29,
+					"other"
+				);
+		}
+
 		#endregion
 
 		#region Should not produce errors
@@ -497,6 +528,27 @@ namespace Test {
 		private void DoSomeStuff(
 			[NotNull] string value = ""a value""
 		) {}
+	}
+}";
+			AssertDoesNotProduceError( test );
+		}
+
+		[Test]
+		public void NotNullParam_EmptyConstructorUsingObjectInitializerSyntax_DoesNotReportProblem() {
+			const string test = NotNullParamMethod + @"
+namespace Test {
+	class TestCaller {
+		public void TestMethod() {
+			var obj = new MyObject {
+				Id = 5,
+				Name = ""My Name""
+			};
+		}
+	}
+
+	class MyObject {
+		public int Id {get; set;}
+		public string Name {get; set;}
 	}
 }";
 			AssertDoesNotProduceError( test );


### PR DESCRIPTION
This was causing issues during the build of the main LMS.