### PR TITLE
Fix base type analysis

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -257,7 +257,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				return MutabilityInspectionResult.NotMutable();
 			}
 
-			return InspectClassStructOrInterfaceOrTypeParameter( type.BaseType, rootAssembly, MutabilityInspectionFlags.AllowUnsealed, typeStack );
+			return InspectTypeRecursive( type.BaseType, rootAssembly, MutabilityInspectionFlags.AllowUnsealed, typeStack );
 		}
 
 		private MutabilityInspectionResult InspectClassStructOrInterfaceOrTypeParameter(


### PR DESCRIPTION
We were skipping the full analysis stack which meant we didn't include the
known immutable types in the analysis for base classes.