### PR TITLE
Make TemporarilyAllowedImmutableTypes behave similar to [Objects.Immutable]

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -281,7 +281,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			typeStack.Add( type );
 			try {
-
 				if( ImmutableContainerTypes.ContainsKey( type.GetFullTypeName() ) ) {
 					var namedType = type as INamedTypeSymbol;
 					for( int i = 0; i < namedType.TypeArguments.Length; i++ ) {
@@ -337,6 +336,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 						// this if-block is temporary!
 						return MutabilityInspectionResult.MutableType( type, MutabilityCause.IsAnExternalUnmarkedType );
 					}
+
+					return MutabilityInspectionResult.NotMutable();
 				}
 
 				foreach( ISymbol member in type.GetExplicitNonStaticMembers() ) {


### PR DESCRIPTION

This changes makes us bail out once we've determined something is in
another assembly but in the TemporarilyAllowedImmutableTypes list

Checking its members theoretically buys us something (a little bit of
analysis is better than none) but it makes it impossible to bless some
.NET types which use lazy initialization but expose an immutable
interface. We haven't been "blessing" our own types like this (and we
haven't been able to) going forward I don't expect us to bless types
across an assembly boundary unless they also pass the analyzer - i.e. I
expect us to fix our code and use [Objects.Immutable].