### PR TITLE
Temporarily disable the unsafe singletons analyzer.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/UnsafeSingletons/UnsafeSingletonsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeSingletons/UnsafeSingletonsAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace D2L.CodeStyle.Analyzers.UnsafeSingletons {
-	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	// [DiagnosticAnalyzer( LanguageNames.CSharp )]
 	public sealed class UnsafeSingletonsAnalyzer : DiagnosticAnalyzer {
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create( 
 			Diagnostics.UnsafeSingletonField,


### PR DESCRIPTION
Doing this so that we can get the analyzer bumped. It is currently
throwing NREs in non-local builds.

This will likely break report publishing, but should not impact
the build.