### PR TITLE
Fix: don't map methods not on or extending `IDependencyRegistry`.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/DependencyRegistry.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/DependencyRegistry.cs
@@ -60,6 +60,10 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 		}
 
 		public bool IsRegistationMethod( IMethodSymbol method ) {
+			if( method.ContainingType != m_dependencyRegistryType && method.ReceiverType != m_dependencyRegistryType ) {
+				return false;
+			}
+
 			// if we have a handler for it, then yes
 			var mappedHandler = s_registrationExpressions.FirstOrDefault(
 				handler => handler.CanHandleMethod( method )

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/UnsafeSingletonsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/UnsafeSingletonsAnalyzer.cs
@@ -122,6 +122,15 @@ namespace SpecTests {
 				reg.Register<TDependencyType, TConcreteType>();
 			}
 		}
+
+		public static class OnlyRegistrationMethodsOnIDependencyRegistryMatter {
+			public static void DoesntMatter( IDependencyRegistry reg ) {
+				Register<UnsafeSingleton>( null );
+			}
+			public static void Register<TDependencyType>(
+				TDependencyType instance
+			);
+		}
 	}
 
 	[Objects.Immutable]


### PR DESCRIPTION
I could have gone two ways with this: pass the registry symbol everywhere, or bail early in the registry. I chose the bail-early to keep the static handlers list and bail-early semantics.