### PR TITLE
Adding RegSpec to the ServiceLocator whitelist

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ServiceLocator/OldAndBrokenServiceLocatorAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ServiceLocator/OldAndBrokenServiceLocatorAnalyzer.cs
@@ -82,6 +82,7 @@ namespace D2L.CodeStyle.Analyzers.ServiceLocator {
 		private static readonly ImmutableHashSet<string> WhitelistedAssemblies = new HashSet<string> {
 			"D2L",
 			"D2L.AP.S3.SISImporter",
+			"D2L.Automation.RegSpecFramework",
 			"D2L.Awards",
 			"D2L.Core.JobManagement",
 			"D2L.Core.Metadata",


### PR DESCRIPTION
RegSpec is a framework for running specification tests.  It only needs the service locator because the code that gets tested depends on it.