### PR TITLE
Add GenericTypeParameterGoal/GenericTypeParameterRule

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/Mutability/Goals/GenericTypeParameterGoal.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/Mutability/Goals/GenericTypeParameterGoal.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace D2L.CodeStyle.Analyzers.Common.Mutability.Goals {
+	internal struct GenericTypeParameterGoal : Goal {
+		public GenericTypeParameterGoal(
+			ITypeParameterSymbol type
+		) {
+			Type = type;
+		}
+
+		public ITypeParameterSymbol Type { get; }
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Common/Mutability/Rules/GenericTypeParameterRule.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/Mutability/Rules/GenericTypeParameterRule.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using D2L.CodeStyle.Analyzers.Common.Mutability.Goals;
+
+namespace D2L.CodeStyle.Analyzers.Common.Mutability.Rules {
+	internal static class GenericTypeParameterRule {
+		public static IEnumerable<Goal> Apply(
+			ISemanticModel model,
+			GenericTypeParameterGoal goal
+		) {
+			// TODO: being constrained by a type that is [Immutable] should
+			// make a type parameter safe.
+			yield return goal;
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -57,6 +57,8 @@
     <Compile Include="Common\MutabilityInspector.cs" />
     <Compile Include="Common\Mutability\Goals\EventGoal.cs" />
     <Compile Include="Common\Mutability\ISemanticModel.cs" />
+    <Compile Include="Common\Mutability\Goals\GenericTypeParameterGoal.cs" />
+    <Compile Include="Common\Mutability\Rules\GenericTypeParameterRule.cs" />
     <Compile Include="Common\Mutability\WrappedSemanticModel.cs" />
     <Compile Include="Common\TypeSymbolExtensions.cs" />
     <Compile Include="Contract\NotNullAnalyzer.cs" />


### PR DESCRIPTION
This is a stub for now. We implement this in the current mutability inspector but no code is actually using it. It's still a nice thing to have but for now I'm not going to ignore it.