### PR TITLE
InitializerGoal needs to track the type.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/Mutability/Goals/InitializerGoal.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/Mutability/Goals/InitializerGoal.cs
@@ -1,11 +1,17 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.Common.Mutability.Goals {
 	internal struct InitializerGoal : Goal {
-		public InitializerGoal( ExpressionSyntax expr ) {
+		public InitializerGoal(
+			ITypeSymbol type,
+			ExpressionSyntax expr
+		) {
+			Type = type;
 			Expr = expr;
 		}
 
+		public ITypeSymbol Type { get; }
 		public ExpressionSyntax Expr { get; }
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Common/Mutability/Rules/FieldRule.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/Mutability/Rules/FieldRule.cs
@@ -32,7 +32,10 @@ namespace D2L.CodeStyle.Analyzers.Common.Mutability.Rules {
 			// expression's type is often narrower than the declared type of
 			// the variable. 
 			if ( decl.Initializer != null ) {
-				yield return new InitializerGoal( decl.Initializer.Value );
+				yield return new InitializerGoal(
+					goal.Field.Type,
+					decl.Initializer.Value
+				);
 			} else {
 				yield return new TypeGoal( goal.Field.Type );
 			}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/Mutability/Rules/FieldRuleTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/Mutability/Rules/FieldRuleTests.cs
@@ -49,7 +49,7 @@ namespace D2L.CodeStyle.Analyzers.Common.Mutability.Rules {
 				subgoals,
 				new Goal[] {
 					new ReadOnlyGoal( field ),
-					new InitializerGoal( expr ),
+					new InitializerGoal( type, expr ),
 				}
 			);
 		}


### PR DESCRIPTION
The initializer will be coerced to the type of the thing being
initialized. Later we will want to handle the bug around casts to unsafe
types inside the rule for this goal.