### PR TITLE
Minor cleanup of InspectProperty and InspectField.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResult.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspectionResult.cs
@@ -114,6 +114,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		}
 
 		public MutabilityInspectionResult WithPrefixedMember( string parentMember ) {
+
 			var newMember = string.IsNullOrWhiteSpace( this.MemberPath )
 				? parentMember
 				: $"{parentMember}.{this.MemberPath}";


### PR DESCRIPTION
GetDeclarationSyntax will also be used for fields once we start looking
at initializers. It's pretty picky that there is exactly one
declaration. Previously, properties were a bit more flexible about that
and would continue to analyze the type of the property even if it wasn't
an auto-property. I don't think that's correct even if it were possible
that there were 0 or more than 1 decl for the property (I don't think it is.)

For reference: https://github.com/Brightspace/D2L.CodeStyle/blob/master/src/D2L.CodeStyle.Analyzers/Common/Mutability/Rules/PropertyRule.cs

