### PR TITLE
Pass Compilation rather than SemanticModel in MutabilityInspector

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -46,7 +46,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				| MutabilityInspectionFlags.AllowUnsealed // `symbol` is the concrete type
 				| MutabilityInspectionFlags.IgnoreImmutabilityAttribute; // we're _validating_ the attribute
 
-			var mutabilityResult = inspector.InspectType( symbol, context.SemanticModel, flags );
+			var mutabilityResult = inspector.InspectType( symbol, context.Compilation, flags );
 
 			if( mutabilityResult.IsMutable ) {
 				var reason = m_resultFormatter.Format( mutabilityResult );

--- a/src/D2L.CodeStyle.Analyzers/UnsafeSingletons/UnsafeSingletonsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeSingletons/UnsafeSingletonsAnalyzer.cs
@@ -62,7 +62,7 @@ namespace D2L.CodeStyle.Analyzers.UnsafeSingletons {
 				| MutabilityInspectionFlags.AllowUnsealed // `symbol` is the concrete type
 				| MutabilityInspectionFlags.IgnoreImmutabilityAttribute; // we're _validating_ the attribute
 
-			var mutabilityResult = inspector.InspectType( symbol, context.SemanticModel, flags );
+			var mutabilityResult = inspector.InspectType( symbol, context.Compilation, flags );
 
 			if( hasAuditedAttribute || hasUnauditedAttribute ) {
 				if( !mutabilityResult.IsMutable ) {

--- a/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
@@ -319,7 +319,7 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 				flags |= MutabilityInspectionFlags.AllowUnsealed;
 			}
 
-			var result = inspector.InspectType( fieldOrPropertyType, model, flags );
+			var result = inspector.InspectType( fieldOrPropertyType, model.Compilation, flags );
 			if ( result.IsMutable ) {
 				result = result.WithPrefixedMember( fieldOrPropertyName );
 				yield return CreateDiagnostic( 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
@@ -16,7 +16,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			var field = Field( "uint foo" );
 			var expected = MutabilityInspectionResult.NotMutable();
 
-			var actual = m_inspector.InspectType( field.Symbol.Type, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.Type, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -26,7 +26,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			var field = Field( "uint? foo" );
 			var expected = MutabilityInspectionResult.NotMutable();
 
-			var actual = m_inspector.InspectType( field.Symbol.Type, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.Type, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -44,7 +44,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			var realType = ( field as IFieldSymbol ).Type;
 			var expected = MutabilityInspectionResult.NotMutable();
 
-			var actual = m_inspector.InspectType( realType, type.SemanticModel );
+			var actual = m_inspector.InspectType( realType, type.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -59,7 +59,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				MutabilityCause.IsAnArray
 			);
 
-			var actual = m_inspector.InspectType( field.Symbol.Type, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.Type, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -69,7 +69,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			var field = Field( "string random" );
 			var expected = MutabilityInspectionResult.NotMutable();
 
-			var actual = m_inspector.InspectType( field.Symbol.Type, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.Type, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -84,7 +84,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				MutabilityCause.IsAnInterface
 			);
 
-			var actual = m_inspector.InspectType( type.Symbol, type.SemanticModel );
+			var actual = m_inspector.InspectType( type.Symbol, type.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -94,7 +94,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			var type = Type( "enum blah {}" );
 			var expected = MutabilityInspectionResult.NotMutable();
 
-			var actual = m_inspector.InspectType( type.Symbol, type.SemanticModel );
+			var actual = m_inspector.InspectType( type.Symbol, type.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -109,7 +109,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				MutabilityCause.IsNotSealed
 			);
 
-			var actual = m_inspector.InspectType( type.Symbol, type.SemanticModel );
+			var actual = m_inspector.InspectType( type.Symbol, type.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -119,7 +119,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			var type = Type( "sealed class foo {}" );
 			var expected = MutabilityInspectionResult.NotMutable();
 
-			var actual = m_inspector.InspectType( type.Symbol, type.SemanticModel );
+			var actual = m_inspector.InspectType( type.Symbol, type.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -135,7 +135,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				MutabilityCause.IsNotReadonly
 			);
 
-			var actual = m_inspector.InspectType( field.Symbol.ContainingType, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.ContainingType, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -151,7 +151,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				MutabilityCause.IsAnExternalUnmarkedType
 			);
 
-			var actual = m_inspector.InspectType( field.Symbol.Type, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.Type, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -167,7 +167,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				MutabilityCause.IsNotReadonly
 			);
 
-			var actual = m_inspector.InspectType( field.Symbol.ContainingType, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.ContainingType, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -183,7 +183,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				MutabilityCause.IsNotReadonly
 			);
 
-			var actual = m_inspector.InspectType( prop.Symbol.ContainingType, prop.SemanticModel );
+			var actual = m_inspector.InspectType( prop.Symbol.ContainingType, prop.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -193,7 +193,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			var field = Field( "private readonly System.Collections.Immutable.ImmutableArray<int> random" );
 			var expected = MutabilityInspectionResult.NotMutable();
 
-			var actual = m_inspector.InspectType( field.Symbol.Type, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.Type, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -203,7 +203,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			var field = Field( "private readonly System.Collections.Generic.IEnumerable<int> random" );
 			var expected = MutabilityInspectionResult.NotMutable();
 
-			var actual = m_inspector.InspectType( field.Symbol.Type, field.SemanticModel );
+			var actual = m_inspector.InspectType( field.Symbol.Type, field.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -218,7 +218,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				MutabilityCause.IsADelegate
 			);
 
-			var actual = m_inspector.InspectType( prop.Symbol.ContainingType, prop.SemanticModel );
+			var actual = m_inspector.InspectType( prop.Symbol.ContainingType, prop.Compilation );
 
 			AssertResultsAreEqual( expected, actual );
 		}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/TestBase.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/TestBase.cs
@@ -9,10 +9,10 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 	internal sealed class TestSymbol<T> where T : ISymbol {
 		internal readonly T Symbol;
-		internal readonly SemanticModel SemanticModel;
-		public TestSymbol( T symbol, SemanticModel semanticModel ) {
+		internal readonly Compilation Compilation;
+		public TestSymbol( T symbol, Compilation compilation ) {
 			Symbol = symbol;
-			SemanticModel = semanticModel;
+			Compilation = compilation;
 		}
 	}
 
@@ -46,7 +46,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			Assert.IsNotNull( toReturn );
 			Assert.AreNotEqual( TypeKind.Error, toReturn.TypeKind );
 
-			return new TestSymbol<ITypeSymbol>( toReturn, compilation.GetSemanticModel( toReturn.DeclaringSyntaxReferences.First().SyntaxTree ) );
+			return new TestSymbol<ITypeSymbol>( toReturn, compilation );
 		}
 
 		internal static TestSymbol<IFieldSymbol> Field( string text ) {
@@ -56,7 +56,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			Assert.IsNotNull( toReturn );
 			Assert.AreNotEqual( TypeKind.Error, toReturn.Type.TypeKind );
 
-			return new TestSymbol<IFieldSymbol>( toReturn, type.SemanticModel );
+			return new TestSymbol<IFieldSymbol>( toReturn, type.Compilation );
 		}
 
 		internal static TestSymbol<IPropertySymbol> Property( string text ) {
@@ -66,7 +66,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			Assert.IsNotNull( toReturn );
 			Assert.AreNotEqual( TypeKind.Error, toReturn.Type.TypeKind );
 
-			return new TestSymbol<IPropertySymbol>( toReturn, type.SemanticModel );
+			return new TestSymbol<IPropertySymbol>( toReturn, type.Compilation );
 		}
 	}
 


### PR DESCRIPTION
We'll need to hit up comp.GetSemanticModel( ... ) multiple times while
recursively analyzing. Because of the very limited use of the semantic
model in the analyzer (GetTypeInfo for InitializerExpression) we
shouldn't hit the perf issues that come from not caching the SMs.