### PR TITLE
Add logic for initializers to MutabilityInspector

### DIFF
--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/UnsafeStaticsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/UnsafeStaticsAnalyzer.cs
@@ -1,7 +1,7 @@
 ﻿// analyzer: D2L.CodeStyle.Analyzers.UnsafeStatics.UnsafeStaticsAnalyzer
 
 using System;
-
+using D2L.CodeStyle.Analyzers.UnsafeStatics;
 using D2L.CodeStyle.Annotations;
 namespace D2L.CodeStyle.Annotations {
 	public class Statics {
@@ -102,6 +102,16 @@ namespace SpecTests {
 		public sealed class OkClassWithBase : OkBaseClass { }
 
 		private static readonly OkClassWithBase m_okWithBase = new OkClassWithBase();
+
+		private class ConcretelySafeIfYouLookAtInitializers {
+			private static OkClassWithBase Foo() { return null; }
+			private readonly OkBaseClass m_ok1 = new OkBaseClass();
+			private readonly OkBaseClass m_ok2 = Foo();
+			private readonly OkBaseClass m_ok3 = null;
+		}
+
+		private static readonly ConcretelySafeIfYouLookAtInitializers m_concretelySafeIfYouLookAtInitializers
+			= new ConcretelySafeIfYouLookAtInitializers();
 	}
 
 	public class MutableBaseClass {
@@ -114,6 +124,12 @@ namespace SpecTests {
 		private static int /* UnsafeStatic(m_mutableInt,'m_mutableInt' is not read-only) */ m_mutableInt /**/;
 
 		private static readonly ClassWithMutableBaseClass /* UnsafeStatic(m_foo,'m_foo.m_mutableInt' is not read-only) */ m_foo /**/ ;
+
+		private class UnsafeThingWithInitializer {
+			private readonly MutableBaseClass m_eh = new MutableBaseClass();
+		}
+
+		private static readonly UnsafeThingWithInitializer /* UnsafeStatic(m_unsafeWithInit,'m_unsafeWithInit.m_eh.m_mutableInt' is not read-only) */ m_unsafeWithInit = new UnsafeThingWithInitializer() /**/;
 	}
 
 	public sealed class ValueTypeCases {

--- a/tests/D2L.CodeStyle.Analyzers.Test/UnsafeStatics/UnsafeStaticsAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/UnsafeStatics/UnsafeStaticsAnalyzerTests.cs
@@ -745,10 +745,10 @@ namespace D2L.CodeStyle.Annotations {
 	namespace test {
 		class Tests {
 
-            private readonly static Foo foo = new Foo();
+			private readonly static Foo foo = new Foo();
 
 			internal sealed class Foo {
-				public readonly Bar Bar = null; // Bar is not sealed, so this is not immutable
+				public readonly Bar Bar = null; // this makes Foo analyze as safe because null is harmless
 			}
 
 			internal class Bar {
@@ -757,12 +757,7 @@ namespace D2L.CodeStyle.Annotations {
 		}
 	}";
 
-            AssertSingleDiagnostic( s_preamble + test, 18, 41, "foo", MutabilityInspectionResult.Mutable(
-                mutableMemberPath: "foo.Bar",
-                membersTypeName: "test.Tests.Bar",
-                kind: MutabilityTarget.Type,
-                cause: MutabilityCause.IsNotSealed
-            ) );
+			AssertNoDiagnostic( s_preamble + test );
 		}
 
 		[Test]


### PR DESCRIPTION
In this PR the MutabilityInspector learns special cases for
initializers. In future PRs the MutabilityInspector will be reworked to
allow the UnsafeStatics analyzer to use MutabilityInspector directly and
ultimately remove it's duplication of all this logic.

Will retarget master after #201 