### PR TITLE
D2L.CodeStyle.Annotations to target .NET 2.0

### DIFF
--- a/src/D2L.CodeStyle.Annotations/D2L.CodeStyle.Annotations.csproj
+++ b/src/D2L.CodeStyle.Annotations/D2L.CodeStyle.Annotations.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>D2L.CodeStyle.Annotations</RootNamespace>
     <AssemblyName>D2L.CodeStyle.Annotations</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
@@ -1,15 +1,15 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("D2L.CodeStyle.Annotations")]
-[assembly: AssemblyDescription("Annotations")]
-[assembly: AssemblyCompany("D2L")]
-[assembly: AssemblyProduct("D2L.CodeStyle.Annotations")]
-[assembly: AssemblyCopyright("Copyright © D2L 2016")]
+[assembly: AssemblyTitle( "D2L.CodeStyle.Annotations" )]
+[assembly: AssemblyDescription( "Annotations" )]
+[assembly: AssemblyCompany( "D2L" )]
+[assembly: AssemblyProduct( "D2L.CodeStyle.Annotations" )]
+[assembly: AssemblyCopyright( "Copyright © D2L 2016" )]
 
-[assembly: ComVisible(false)]
+[assembly: ComVisible( false )]
 
-[assembly: Guid("35fe7851-3f76-4057-9754-e883231619d0")]
+[assembly: Guid( "35fe7851-3f76-4057-9754-e883231619d0" )]
 
-[assembly: AssemblyVersion("0.10.0.0")]
-[assembly: AssemblyFileVersion("0.10.0.0")]
+[assembly: AssemblyVersion( "0.11.0.0" )]
+[assembly: AssemblyFileVersion( "0.11.0.0" )]


### PR DESCRIPTION
Switching D2L.CodeStyle.Annotations to target .NET 2.0 so that it doesn't force other projects to upgrade in order to consume