### PR TITLE
Adding attributes for dangerous methods

### DIFF
--- a/src/D2L.CodeStyle.Annotations/D2L.CodeStyle.Annotations.csproj
+++ b/src/D2L.CodeStyle.Annotations/D2L.CodeStyle.Annotations.csproj
@@ -32,6 +32,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Contract\NotNullAttribute.cs" />
+    <Compile Include="DangerousMethodUsage\UnauditedAttribute.cs" />
+    <Compile Include="DangerousMethodUsage\AuditedAttribute.cs" />
     <Compile Include="Mutability\UnauditedAttribute.cs" />
     <Compile Include="Objects\Immutable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/D2L.CodeStyle.Annotations/DangerousMethodUsage/AuditedAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/DangerousMethodUsage/AuditedAttribute.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace D2L.CodeStyle.Annotations {
+
+	public static partial class DangerousMethodUsage {
+
+		/// <summary>
+		/// Indicates usages of a dangerous method have been declared as safe
+		/// </summary>
+		[AttributeUsage( validOn: AttributeTargets.Method, AllowMultiple = true, Inherited = false )]
+		public sealed class AuditedAttribute : Attribute {
+
+			/// <summary>
+			/// Indicates usages of a dangerous method have been declared as safe
+			/// </summary>
+			/// <param name="declaringType">The type that declares the dangerous method.</param>
+			/// <param name="methodName">The name of the dangerous method.</param>
+			/// <param name="owner">The user who last reviewed this method usage.</param>
+			/// <param name="auditedDate">The last time this method usage was reviewed.</param>
+			/// <param name="rationale">A brief explaination of why this method usage is safe.</param>
+			public AuditedAttribute(
+					Type declaringType,
+					string methodName,
+					string owner,
+					string auditedDate,
+					string rationale
+				) {
+
+				DeclaringType = declaringType;
+				MethodName = methodName;
+				Owner = owner;
+				AuditedDate = auditedDate;
+				Rationale = rationale;
+			}
+
+			public Type DeclaringType { get; }
+			public string MethodName { get; }
+			public string Owner { get; }
+			public string AuditedDate { get; }
+			public string Rationale { get; }
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Annotations/DangerousMethodUsage/UnauditedAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/DangerousMethodUsage/UnauditedAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace D2L.CodeStyle.Annotations {
+
+	public static partial class DangerousMethodUsage {
+
+		/// <summary>
+		/// Indicates usages of a dangerous method are still unaudited
+		/// </summary>
+		[AttributeUsage( validOn: AttributeTargets.Method, AllowMultiple = true, Inherited = false )]
+		public sealed class UnauditedAttribute : Attribute {
+
+			/// <summary>
+			/// Indicates usages of a dangerous method are still unaudited
+			/// </summary>
+			/// <param name="declaringType">The type that declares the dangerous method.</param>
+			/// <param name="methodName">The name of the dangerous method.</param>
+			public UnauditedAttribute(
+					Type declaringType,
+					string methodName
+				) {
+
+				DeclaringType = declaringType;
+				MethodName = methodName;
+			}
+
+			public Type DeclaringType { get; }
+			public string MethodName { get; }
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Annotations/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid( "35fe7851-3f76-4057-9754-e883231619d0" )]
 
-[assembly: AssemblyVersion( "0.12.0.0" )]
-[assembly: AssemblyFileVersion( "0.12.0.0" )]
+[assembly: AssemblyVersion( "0.13.0.0" )]
+[assembly: AssemblyFileVersion( "0.13.0.0" )]


### PR DESCRIPTION
```csharp
	internal sealed class Example {

		[DangerousMethodUsage.Audited(
			declaringType: typeof( PropertyInfo ),
			methodName: nameof( PropertyInfo.SetValue ),
			owner: "Jeff Ashton",
			auditedDate: "2017-11-16",
			rationale: "DJ was crazy, there is no rationale"
		)]
		public void Test1() {

			PropertyInfo p = this.GetType().GetProperty( "Unsafe" );
			p.SetValue( this, "Fucked", null );
		}

		[DangerousMethodUsage.Unaudited(
			declaringType: typeof( PropertyInfo ),
			methodName: nameof( PropertyInfo.SetValue )
		)]
		public void Test2() {

			PropertyInfo p = this.GetType().GetProperty( "Unsafe" );
			p.SetValue( this, "Fucked", null );
		}
	}
```