### PR TITLE
Enable AppVeyor account feed.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ pull_requests:
 skip_tags: true
 clone_depth: 5
 nuget:
+  account_feed: true
   project_feed: true
 before_build:
   - nuget restore


### PR DESCRIPTION
So that we don't need to use nuget.org anymore
when bumping things on Github private.