### PR TITLE
Add test for Tuple<...>

### DIFF
--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/UnsafeStaticsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/UnsafeStaticsAnalyzer.cs
@@ -120,6 +120,9 @@ namespace SpecTests {
 		[Statics.Unaudited( Because.ItsStickyDataOhNooo )]
 		private static readonly ClassWithTypelessInitializerExpression m_unsafeClassWithTypelessInitializerExpression
 			= new ClassWithTypelessInitializerExpression();
+
+		// Tuple's are a blessed "container" type
+		private static readonly Tuple<int, string> m_aTuple;
 	}
 
 	public class MutableBaseClass {


### PR DESCRIPTION
Tuple is a "blessed container type". This test makes sure it looks
immutable even without an initializer. This ensures that special case is
checked prior to checking if a class is sealed (and erroring when it
isn't.)