### PR TITLE
Commute immutable containers check

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -115,6 +115,10 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				return MutabilityInspectionResult.NotMutable();
 			}
 
+			if( IsAnImmutableContainerType( type ) ) {
+				return InspectImmutableContainerType( type, typeStack );
+			}
+
 			switch( type.TypeKind ) {
 				case TypeKind.Array:
 					// Arrays are always mutable because you can rebind the
@@ -217,10 +221,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			typeStack.Add( type );
 			try {
-				if( IsAnImmutableContainerType( type ) ) {
-					return InspectImmutableContainerType( type, typeStack );
-				}
-
 				if( type.TypeKind == TypeKind.Interface ) {
 					return MutabilityInspectionResult.MutableType( type, MutabilityCause.IsAnInterface );
 				}


### PR DESCRIPTION
This is safe because the only check we're commuting around is the typeStack
check. It's impossible to get an infinite recursion loop via type
parameters so that check isn't necessary. As a "side benefit" those
types won't ever appear in the typeStack so there is some trivial
savings there.