### PR TITLE
Commute interface check

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -157,10 +157,12 @@ namespace D2L.CodeStyle.Analyzers.Common {
 						typeStack
 					);
 
-				case TypeKind.Class:
 				case TypeKind.Interface:
+					return MutabilityInspectionResult.MutableType( type, MutabilityCause.IsAnInterface );
+
+				case TypeKind.Class:
 				case TypeKind.Struct: // equivalent to TypeKind.Structure
-					return InspectClassStructOrInterface(
+					return InspectClassOrStruct(
 						type,
 						flags,
 						typeStack
@@ -206,7 +208,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			);
 		}
 
-		private MutabilityInspectionResult InspectClassStructOrInterface(
+		private MutabilityInspectionResult InspectClassOrStruct(
 			ITypeSymbol type,
 			MutabilityInspectionFlags flags,
 			HashSet<ITypeSymbol> typeStack
@@ -221,10 +223,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			typeStack.Add( type );
 			try {
-				if( type.TypeKind == TypeKind.Interface ) {
-					return MutabilityInspectionResult.MutableType( type, MutabilityCause.IsAnInterface );
-				}
-
 				if( !flags.HasFlag( MutabilityInspectionFlags.AllowUnsealed )
 						&& type.TypeKind == TypeKind.Class
 						&& !type.IsSealed


### PR DESCRIPTION
This change should be a no-op: interfaces don't recurse so the typestack
check was unnecessary. As a small side benefit these types never appear
in type stack now.

The InspectClassStructOrInterface method was weird. When I refactored
that stuff iirc I meant for it to be InspectClassOrStruct but fucked up.

There is only one more commutation I'm going to do; I did this in a
bunch of "easy" pieces to avoid one hard-to-think-about move.