### PR TITLE
Commute sealed check

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -119,6 +119,13 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				return InspectImmutableContainerType( type, typeStack );
 			}
 
+			if( !flags.HasFlag( MutabilityInspectionFlags.AllowUnsealed )
+					&& type.TypeKind == TypeKind.Class
+					&& !type.IsSealed
+				) {
+				return MutabilityInspectionResult.MutableType( type, MutabilityCause.IsNotSealed );
+			}
+
 			switch( type.TypeKind ) {
 				case TypeKind.Array:
 					// Arrays are always mutable because you can rebind the
@@ -164,7 +171,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 				case TypeKind.Struct: // equivalent to TypeKind.Structure
 					return InspectClassOrStruct(
 						type,
-						flags,
 						typeStack
 					);
 
@@ -210,7 +216,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 		private MutabilityInspectionResult InspectClassOrStruct(
 			ITypeSymbol type,
-			MutabilityInspectionFlags flags,
 			HashSet<ITypeSymbol> typeStack
 		) {
 			if( typeStack.Contains( type ) ) {
@@ -223,13 +228,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			typeStack.Add( type );
 			try {
-				if( !flags.HasFlag( MutabilityInspectionFlags.AllowUnsealed )
-						&& type.TypeKind == TypeKind.Class
-						&& !type.IsSealed
-					) {
-					return MutabilityInspectionResult.MutableType( type, MutabilityCause.IsNotSealed );
-				}
-
 				// We have a type that is not marked immutable, is not an interface, is not an immutable container, etc..
 				// If it is defined in a different assembly, we might not have the metadata to correctly analyze it; so we fail.
 				if( type.ContainingAssembly != m_compilation.Assembly ) {


### PR DESCRIPTION
This is safe because its only skipping over the type stack check but
there is no recursion in this check.

Also, remove inspection flags from InspectClassOrStruct.

It might seem a bit weird to have class-specific logic outside of
InspectClassOrStruct. What I'm going for (ultimately, not today) is to
generalize this into a type vs. concrete type subgoal that's independent
of scanning the class decl (members, base etc.) It's a constraint that
applies to more than classes, but different sorts of types satisfy it in
different ways (e.g. interfaces via [Immutable], or in the future
possibly via being internal/private and having only immutable impls.)