### PR TITLE
Type parameter initializer bug

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -154,11 +154,6 @@ namespace D2L.CodeStyle.Analyzers.Common {
 					return MutabilityInspectionResult.NotMutable();
 
 				case TypeKind.TypeParameter:
-					if ( flags != MutabilityInspectionFlags.Default ) {
-						// remove this once we no longer take flags
-						throw new InvalidOperationException( "This shouldn't happen" );
-					}
-
 					return InspectTypeParameter(
 						type,
 						typeStack

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -82,7 +82,7 @@ namespace SpecTests {
 
 		#region Type parameter new initializer
 		[Objects.Immutable]
-		public sealed class GenericWithFieldInitializer<T> {
+		public sealed class /* ImmutableClassIsnt('m_t''s type ('T') is a generic type) */ GenericWithFieldInitializer<T> /**/ {
 			private readonly T m_t = new T();
 		}
 		#endregion


### PR DESCRIPTION
Although this looked sane it actually wasn't.

I forgot about the case of `new T()` initializers which tweaks the immutability flags (in the next set of PRs I'm going to replace the flags with overloads.)