### PR TITLE
 Add caching to MutabilityInspector

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -93,10 +93,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			return m_cache.GetOrAdd(
 				cacheKey,
-				query => {
-					var typesInCurrentCycle = new HashSet<ITypeSymbol>();
-					return InspectTypeImpl( query.Item1, query.Item2, typesInCurrentCycle );
-				} );
+				query => InspectTypeImpl( query.Item1, query.Item2, typeStack )
+			);
 		}
 
 		private MutabilityInspectionResult InspectTypeImpl(

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -94,5 +94,38 @@ namespace SpecTests {
 			int x;
 		}
 		#endregion
+
+		#region No exponential worst case (thanks cache)
+
+		[Objects.Immutable] // there are 3^25 = 847,288,609,443 paths to check here :)
+		sealed class A { readonly B b1, b2, b3; }
+
+		sealed class B { readonly C c1, c2, c3; }
+		sealed class C { readonly D d1, d2, d3; }
+		sealed class D { readonly E e1, e2, e3; }
+		sealed class E { readonly F f1, f2, f3; }
+		sealed class F { readonly G g1, g2, g3; }
+		sealed class G { readonly H h1, h2, h3; }
+		sealed class H { readonly I i1, i2, i3; }
+		sealed class I { readonly J j1, j2, j3; }
+		sealed class J { readonly K k1, k2, k3; }
+		sealed class K { readonly L l1, l2, l3; }
+		sealed class L { readonly M m1, m2, m3; }
+		sealed class M { readonly N n1, n2, n3; }
+		sealed class N { readonly O o1, o2, o3; }
+		sealed class O { readonly P p1, p2, p3; }
+		sealed class P { readonly Q q1, q2, q3; }
+		sealed class Q { readonly R r1, r2, r3; }
+		sealed class R { readonly S s1, s2, s3; }
+		sealed class S { readonly T t1, t2, t3; }
+		sealed class T { readonly U u1, u2, u3; }
+		sealed class U { readonly V v1, v2, v3; }
+		sealed class V { readonly W w1, w2, w3; }
+		sealed class W { readonly X x1, x2, x3; }
+		sealed class X { readonly Y y1, y2, y3; }
+		sealed class Y { readonly Z z1, z2, z3; }
+		sealed class Z {}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
This fixes the worst perf problems of the analyzer that have recently
plagued the build (e.g. the worst case perf is no longer exponential.)

There is still some work to do: the analyzers should share a cache and
if we've validated a type is immutable then the concrete type (i.e.
analyzing with AllowUnsealed) should be a cache hit. This gets the build
back to normal ASAP.