### PR TITLE
Move IsTypeMarkedImmutable and IsTypeMarkedSingleton to extension methods

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Contract\NotNullAnalyzer.cs" />
     <Compile Include="DangerousMethodUsages\DangerousMethodUsagesAnalyzer.cs" />
     <Compile Include="DependencyRegistrations\DependencyRegistrationsAnalyzer.cs" />
+    <Compile Include="Extensions\Microsoft.CodeAnalysis.cs" />
     <Compile Include="Extensions\Microsoft.CodeAnalysis.CSharp.cs" />
     <Compile Include="Immutability\ImmutabilityAnalyzer.cs" />
     <Compile Include="Common\Mutability\Goals\ClassGoal.cs" />

--- a/src/D2L.CodeStyle.Analyzers/DependencyRegistrations/DependencyRegistrationsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/DependencyRegistrations/DependencyRegistrationsAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Common;
 using D2L.CodeStyle.Analyzers.Common.DependencyInjection;
+using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -127,7 +128,7 @@ namespace D2L.CodeStyle.Analyzers.DependencyRegistrations {
 			}
 
 			foreach( var typeToInspect in typesToInspect ) {
-				var isMarkedSingleton = inspector.IsTypeMarkedSingleton( typeToInspect );
+				var isMarkedSingleton = typeToInspect.IsTypeMarkedSingleton();
 				if( !isMarkedSingleton ) {
 					var diagnostic = Diagnostic.Create(
 						Diagnostics.UnsafeSingletonRegistration,

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using D2L.CodeStyle.Analyzers.Common;
+using Microsoft.CodeAnalysis;
+
+namespace D2L.CodeStyle.Analyzers.Extensions {
+	internal static partial class Extensions {
+		/// <summary>
+		/// A list of marked immutable types owned externally.
+		/// </summary>
+		private static readonly ImmutableHashSet<string> MarkedImmutableTypes = ImmutableHashSet.Create(
+			"System.StringComparer",
+			"System.Text.ASCIIEncoding",
+			"System.Text.Encoding",
+			"System.Text.UTF8Encoding"
+		);
+		
+		public static bool IsTypeMarkedImmutable( this ITypeSymbol symbol ) {
+			if( MarkedImmutableTypes.Contains( symbol.GetFullTypeName() ) ) {
+				return true;
+			}
+			if( Attributes.Objects.Immutable.IsDefined( symbol ) ) {
+				return true;
+			}
+			if( symbol.Interfaces.Any( IsTypeMarkedImmutable ) ) {
+				return true;
+			}
+			if( symbol.BaseType != null && IsTypeMarkedImmutable( symbol.BaseType ) ) {
+				return true;
+			}
+			return false;
+		}
+
+		public static bool IsTypeMarkedSingleton( this ITypeSymbol symbol ) {
+			if( Attributes.Singleton.IsDefined( symbol ) ) {
+				return true;
+			}
+			if( symbol.Interfaces.Any( IsTypeMarkedSingleton ) ) {
+				return true;
+			}
+			if( symbol.BaseType != null && IsTypeMarkedSingleton( symbol.BaseType ) ) {
+				return true;
+			}
+			return false;
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using D2L.CodeStyle.Analyzers.Common;
+using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -47,7 +48,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				.GetDeclaredSymbol( root );
 
 			// skip classes not marked immutable
-			if( !inspector.IsTypeMarkedImmutable( symbol ) ) {
+			if( !symbol.IsTypeMarkedImmutable() ) {
 				return;
 			}
 

--- a/src/D2L.CodeStyle.Analyzers/UnsafeSingletons/UnsafeSingletonsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeSingletons/UnsafeSingletonsAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using D2L.CodeStyle.Analyzers.Common;
+using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -44,11 +45,11 @@ namespace D2L.CodeStyle.Analyzers.UnsafeSingletons {
 			}
 
 			// skip classes not marked singleton
-			if( !inspector.IsTypeMarkedSingleton( symbol ) ) {
+			if( !symbol.IsTypeMarkedSingleton() ) {
 				return;
 			}
 
-			var isMarkedImmutable = inspector.IsTypeMarkedImmutable( symbol );
+			var isMarkedImmutable = symbol.IsTypeMarkedImmutable();
 			if( !isMarkedImmutable ) {
 				var location = GetLocationOfClassIdentifierAndGenericParameters( root );
 				context.ReportDiagnostic( Diagnostic.Create(

--- a/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/UnsafeStatics/UnsafeStaticsAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Common;
+using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -297,7 +298,7 @@ namespace D2L.CodeStyle.Analyzers.UnsafeStatics {
 				yield break;
 			}
 
-			if( inspector.IsTypeMarkedImmutable( fieldOrPropertyType ) ) {
+			if( fieldOrPropertyType.IsTypeMarkedImmutable() ) {
 				// if the type is marked immutable, skip checking it, to avoid reporting
 				// a diagnostic for each usage of types that are marked
 				// immutable (other analyzers catch those already.)

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspector_IsTypeMarkedImmutableTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspector_IsTypeMarkedImmutableTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using NUnit.Framework;
 using static D2L.CodeStyle.Analyzers.Common.RoslynSymbolFactory;
@@ -40,7 +41,7 @@ namespace D2L.CodeStyle.Annotations {
 				KnownImmutableTypes.Default
 			);
 
-			Assert.IsFalse( inspector.IsTypeMarkedImmutable( type.Symbol ) );
+			Assert.IsFalse( type.Symbol.IsTypeMarkedImmutable() );
 		}
 
 		[Test]
@@ -54,7 +55,7 @@ namespace D2L.CodeStyle.Annotations {
 				KnownImmutableTypes.Default
 			);
 
-			Assert.IsTrue( inspector.IsTypeMarkedImmutable( type.Symbol ) );
+			Assert.IsTrue( type.Symbol.IsTypeMarkedImmutable() );
 		}
 
 		[Test]
@@ -71,7 +72,7 @@ namespace D2L.CodeStyle.Annotations {
 
 			// we have multiple types defined, so ensure that we're asserting on the correct one first.
 			Assert.AreEqual( "Foo", type.Symbol.MetadataName );
-			Assert.IsTrue( inspector.IsTypeMarkedImmutable( type.Symbol ) );
+			Assert.IsTrue( type.Symbol.IsTypeMarkedImmutable() );
 		}
 
 		[Test]
@@ -89,7 +90,7 @@ namespace D2L.CodeStyle.Annotations {
 
 			// we have multiple types defined, so ensure that we're asserting on the correct one first.
 			Assert.AreEqual( "Foo", type.Symbol.MetadataName );
-			Assert.IsTrue( inspector.IsTypeMarkedImmutable( type.Symbol ) );
+			Assert.IsTrue( type.Symbol.IsTypeMarkedImmutable() );
 		}
 
 		[Test]
@@ -107,7 +108,7 @@ namespace D2L.CodeStyle.Annotations {
 
 			// we have multiple types defined, so ensure that we're asserting on the correct one first.
 			Assert.AreEqual( "Foo", type.Symbol.MetadataName );
-			Assert.IsTrue( inspector.IsTypeMarkedImmutable( type.Symbol ) );
+			Assert.IsTrue( type.Symbol.IsTypeMarkedImmutable() );
 		}
 
 
@@ -125,7 +126,7 @@ namespace D2L.CodeStyle.Annotations {
 
 			// we have multiple types defined, so ensure that we're asserting on the correct one first.
 			Assert.AreEqual( "Foo", type.Symbol.MetadataName );
-			Assert.IsTrue( inspector.IsTypeMarkedImmutable( type.Symbol ) );
+			Assert.IsTrue( type.Symbol.IsTypeMarkedImmutable() );
 		}
 
 		[Test]
@@ -143,7 +144,7 @@ namespace D2L.CodeStyle.Annotations {
 
 			// we have multiple types defined, so ensure that we're asserting on the correct one first.
 			Assert.AreEqual( "Foo", type.Symbol.MetadataName );
-			Assert.IsTrue( inspector.IsTypeMarkedImmutable( type.Symbol ) );
+			Assert.IsTrue( type.Symbol.IsTypeMarkedImmutable() );
 		}
 	}
 }


### PR DESCRIPTION
Folks are creating MutabilityInspectors to get access to these methods
unnecessarily.