### PR TITLE
Remove annoying Obsolete attributes from our attributes

### DIFF
--- a/src/D2L.CodeStyle.Annotations/Mutability/UnauditedAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/Mutability/UnauditedAttribute.cs
@@ -3,7 +3,6 @@
 // ReSharper disable once CheckNamespace
 namespace D2L.CodeStyle.Annotations {
 	public static partial class Mutability {
-		[Obsolete( "State marked as unaudited requires auditing. Only use this attribute as a temporary measure in assemblies." )]
 		[AttributeUsage( validOn: AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Event )]
 		public sealed class UnauditedAttribute : Attribute {
 			public readonly Because m_cuz;

--- a/src/D2L.CodeStyle.Annotations/Statics/Unaudited.cs
+++ b/src/D2L.CodeStyle.Annotations/Statics/Unaudited.cs
@@ -3,7 +3,6 @@
 // ReSharper disable once CheckNamespace
 namespace D2L.CodeStyle.Annotations {
 	public static partial class Statics {
-		[Obsolete( "Static variables marked as unaudited require auditing. Only use this attribute as a temporary measure in assemblies." )]
 		[AttributeUsage( validOn: AttributeTargets.Field | AttributeTargets.Property )]
 		public sealed class Unaudited : Attribute {
 			public readonly Because m_cuz;


### PR DESCRIPTION
Why I think we should do this:

- We've added this all over the place and its disruptive to folks in VS because some slns treat this warning as an error (but our "real" builds don't because we explicitly ignore this warning in them)
- This is unlikely to help someone
- We have a large team dedicated to cleaning these up and lots of tracking/charts/etc.

CC @chris-redekop @JeffAshton 