### PR TITLE
Remove managerRole from legacy feature white-list

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/LaunchDarkly/LegacyFeatureTypes.cs
+++ b/src/D2L.CodeStyle.Analyzers/LaunchDarkly/LegacyFeatureTypes.cs
@@ -53,7 +53,6 @@ namespace D2L.CodeStyle.Analyzers.LaunchDarkly {
 			"D2L.LE.Locker.Features.DE25830_CheckOwnership",
 			"D2L.LE.Lti.Security.OAuth.CheckTrimmedLtiBodySignature",
 			"D2L.LE.Lti.Security.OAuth.RemoveOAuthBodyTrimFeature",
-			"D2L.LE.ManagerRole.Extensibility.FeatureFlags.ManagerDashboardFeature",
 			"D2L.LE.Quizzes.Activities.Features.QuizzesActivitiesFeature",
 			"D2L.LOR.FeatureToggles.SendAcceptRangesHeaderFeature",
 			"D2L.LP.Attachments.Domain.LinkAttachmentFeature",


### PR DESCRIPTION
This PR removes "ManagerRole" from the LegacyFeatureTypes white-list. This assembly was upgraded in [Bitbucket-105](https://git.dev.d2l/projects/CORE/repos/manager-role/pull-requests/105/overview).

I've tested this in my local build by replacing the DLL in the nuget packages directory: the upgraded assembly compiles without error.

I do not have permission to add code reviewers.