### PR TITLE
Public DependencyRegistry, DependencyRegistrationExpression, DependencyRegistration 

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/ConfigureInstancePluginsExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/ConfigureInstancePluginsExpression.cs
@@ -11,7 +11,7 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	//			ObjectScope scope
 	//		) where TExtensionPoint : ExtensionPointDescriptor, new();
 	internal sealed class ConfigureInstancePluginsExpression : DependencyRegistrationExpression {
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return
 				( method.Name == "ConfigureInstancePlugins"
 				&& method.IsExtensionMethod
@@ -24,7 +24,7 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 				&& method.Parameters.Length == 1 );
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 1 ) {
 				return null;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/ConfigurePluginsExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/ConfigurePluginsExpression.cs
@@ -7,7 +7,7 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	// void ConfigureOrderedPlugins<TPlugin, TComparer>( this IDependencyRegistry registry, ObjectScope scope ) 
 	//		where TComparer : IComparer<TPlugin>, new()
 	internal sealed class ConfigurePluginsExpression : DependencyRegistrationExpression {
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return
 				( method.Name == "ConfigurePlugins"
 				&& method.IsExtensionMethod
@@ -20,7 +20,7 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 				&& method.Parameters.Length == 1 );
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 1 ) {
 				return null;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/DependencyRegistration.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/DependencyRegistration.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
-	internal sealed class DependencyRegistration {
+	public sealed class DependencyRegistration {
 
 		public ObjectScope ObjectScope { get; }
 
@@ -27,14 +27,14 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 			DynamicObjectFactoryType = dynamicObjectType;
 		}
 
-		internal static DependencyRegistration NonFactory( ObjectScope scope, ITypeSymbol dependencyType, ITypeSymbol concreteType )
+		public static DependencyRegistration NonFactory( ObjectScope scope, ITypeSymbol dependencyType, ITypeSymbol concreteType )
 			=> new DependencyRegistration(
 				scope,
 				dependencyType: dependencyType,
 				concreteType: concreteType
 			);
 
-		internal static DependencyRegistration Factory( ObjectScope scope, ITypeSymbol dependencyType, ITypeSymbol factoryType, ITypeSymbol concreteType )
+		public static DependencyRegistration Factory( ObjectScope scope, ITypeSymbol dependencyType, ITypeSymbol factoryType, ITypeSymbol concreteType )
 			=> new DependencyRegistration(
 				scope,
 				dependencyType: dependencyType,
@@ -42,7 +42,7 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 				concreteType: concreteType
 			);
 
-		internal static DependencyRegistration DynamicObjectFactory( ObjectScope scope, ITypeSymbol dependencyType, ITypeSymbol dynamicObjectType )
+		public static DependencyRegistration DynamicObjectFactory( ObjectScope scope, ITypeSymbol dependencyType, ITypeSymbol dynamicObjectType )
 			=> new DependencyRegistration(
 				scope,
 				dependencyType: dependencyType,
@@ -54,7 +54,7 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	/// This is copied from lp/framework/core/D2L.LP.Foundation/LP/Extensibility/Activation/Domain/ObjectScope.cs
 	/// so that the values match.
 	/// </summary>
-	internal enum ObjectScope {
+	public enum ObjectScope {
 		AlwaysCreateNewInstance = 0,
 		Singleton = 1,
 		Thread = 2,

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/DependencyRegistrationExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/DependencyRegistrationExpression.cs
@@ -4,15 +4,15 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
-	internal abstract class DependencyRegistrationExpression {
+	public abstract class DependencyRegistrationExpression {
 
 		protected const string IFactoryTypeMetadataName = "D2L.LP.Extensibility.Activation.Domain.IFactory`1";
 
-		internal abstract bool CanHandleMethod(
+		public abstract bool CanHandleMethod(
 			IMethodSymbol method
 		);
 
-		internal abstract DependencyRegistration GetRegistration(
+		public abstract DependencyRegistration GetRegistration(
 			IMethodSymbol method, 
 			SeparatedSyntaxList<ArgumentSyntax> arguments, 
 			SemanticModel semanticModel

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/DependencyRegistry.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/DependencyRegistry.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
-	internal sealed class DependencyRegistry {
+	public sealed class DependencyRegistry {
 
 		private static readonly ImmutableArray<DependencyRegistrationExpression> s_registrationExpressions = ImmutableArray.Create<DependencyRegistrationExpression>(
 			new RegisterParentAwareFactoryExpression(),

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/FullyGenericRegisterExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/FullyGenericRegisterExpression.cs
@@ -19,14 +19,14 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 			"RegisterPluginFactory"
 		);
 
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return s_validNames.Contains( method.Name )
 				&& method.IsGenericMethod 
 				&& method.TypeArguments.Length == 2 
 				&& method.Parameters.Length == 1;
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 1 ) {
 				return null;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/NonGenericRegisterExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/NonGenericRegisterExpression.cs
@@ -4,13 +4,13 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	// void Register( Type dependencyType, Type concreteType, ObjectScope scope );
 	internal sealed class NonGenericRegisterExpression : DependencyRegistrationExpression {
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return method.Name == "Register"
 				&& !method.IsGenericMethod
 				&& method.Parameters.Length == 3;
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 3 ) {
 				return null;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterDynamicObjectFactoryExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterDynamicObjectFactoryExpression.cs
@@ -12,14 +12,14 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	// ) where TConcrete : class, TOutput
 	internal sealed class RegisterDynamicObjectFactoryExpression : DependencyRegistrationExpression {
 
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return method.Name == "RegisterDynamicObjectFactory"
 				&& method.IsExtensionMethod
 				&& ( method.TypeArguments.Length == 3 || method.TypeArguments.Length == 4 )
 				&& method.Parameters.Length == 1;
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 1 ) {
 				return null;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterExtensionPointExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterExtensionPointExpression.cs
@@ -7,14 +7,14 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	//			ObjectScope scope
 	//		) where TExtensionPoint : IExtensionPoint<T>;
 	internal sealed class RegisterExtensionPointExpression : DependencyRegistrationExpression {
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return method.Name == "RegisterPluginExtensionPoint"
 				&& method.IsExtensionMethod
 				&& method.Parameters.Length == 1
 				&& method.TypeArguments.Length == 2;
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 1 ) {
 				return null;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterInstantiatedObjectExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterInstantiatedObjectExpression.cs
@@ -5,14 +5,14 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	// void Register<TDependencyType>( TDependencyType instance );
 	// void RegisterPlugin<TDependencyType>( TDependencyType instance );
 	internal sealed class RegisterInstantiatedObjectExpression : DependencyRegistrationExpression {
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return ( method.Name == "Register" || method.Name == "RegisterPlugin" )
 				&& method.IsGenericMethod 
 				&& method.TypeParameters.Length == 1 
 				&& method.Parameters.Length == 1;
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 1 ) {
 				return null;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterParentAwareFactoryExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterParentAwareFactoryExpression.cs
@@ -5,13 +5,13 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	// void RegisterParentAwareFactory<TDependencyType, TFactoryType>();
 	internal sealed class RegisterParentAwareFactoryExpression : DependencyRegistrationExpression {
 
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return method.Name == "RegisterParentAwareFactory"
 				&& method.TypeArguments.Length == 2
 				&& method.Parameters.Length == 0;
 		}
 
-		internal override DependencyRegistration GetRegistration(
+		public override DependencyRegistration GetRegistration(
 			IMethodSymbol method,
 			SeparatedSyntaxList<ArgumentSyntax> arguments,
 			SemanticModel semanticModel

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterPluginForExtensionPointExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterPluginForExtensionPointExpression.cs
@@ -16,14 +16,14 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	//		where TFactoryType : IFactory<TDependencyType>
 	//		where TExtensionPoint : IExtensionPoint<TDependencyType>;
 	internal sealed class RegisterPluginForExtensionPointExpression : DependencyRegistrationExpression {
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return ( method.Name == "RegisterPlugin" || method.Name == "RegisterPluginFactory" )
 				&& method.IsExtensionMethod
 				&& method.Parameters.Length == 1
 				&& method.TypeArguments.Length == 3;
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 1 ) {
 				return null;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterSubInterfaceExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/DependencyInjection/RegisterSubInterfaceExpression.cs
@@ -7,14 +7,14 @@ namespace D2L.CodeStyle.Analyzers.Common.DependencyInjection {
 	//		ObjectScope scope
 	// ) where TInjectableSuperInterfaceType : TSubInterfaceType
 	internal sealed class RegisterSubInterfaceExpression : DependencyRegistrationExpression {
-		internal override bool CanHandleMethod( IMethodSymbol method ) {
+		public override bool CanHandleMethod( IMethodSymbol method ) {
 			return method.Name == "RegisterSubInterface"
 				&& method.IsExtensionMethod
 				&& method.TypeArguments.Length == 2
 				&& method.Parameters.Length == 1;
 		}
 
-		internal override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
+		public override DependencyRegistration GetRegistration( IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel ) {
 			if( arguments.Count != 1 ) {
 				return null;
 			}


### PR DESCRIPTION
Marking as public because in an external project I would like to:
1. Create a `DependencyRegistry`
2. Check if a method `IsRegistationMethod` then try to get a `DependencyRegistrationExpression`
3. Retrieve the `DependencyRegistration` information from the `DependencyRegistrationExpression`