### PR TITLE
Mark MutabilityInspector and KnownImmutableTypes As Public

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/KnownImmutableTypes.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/KnownImmutableTypes.cs
@@ -5,9 +5,9 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers.Common {
-	internal sealed class KnownImmutableTypes {
+	public sealed class KnownImmutableTypes {
 
-		internal static readonly KnownImmutableTypes Default = new KnownImmutableTypes( ImmutableHashSet<string>.Empty );
+		public static readonly KnownImmutableTypes Default = new KnownImmutableTypes( ImmutableHashSet<string>.Empty );
 
 		/// <summary>
 		/// A list of known immutable types.
@@ -79,14 +79,14 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		/// </summary>
 		private readonly ImmutableHashSet<string> DeclaredKnownImmutableTypes;
 
-		internal KnownImmutableTypes( ImmutableHashSet<string> declaredKnownImmutableTypes ) {
+		public KnownImmutableTypes( ImmutableHashSet<string> declaredKnownImmutableTypes ) {
 			DeclaredKnownImmutableTypes = declaredKnownImmutableTypes;
 		}
 
-		internal KnownImmutableTypes( IAssemblySymbol a )
+		public KnownImmutableTypes( IAssemblySymbol a )
 			: this( LoadFromAssembly( a ).ToImmutableHashSet() ) { }
 
-		internal bool IsTypeKnownImmutable( ITypeSymbol type ) {
+		public bool IsTypeKnownImmutable( ITypeSymbol type ) {
 			if( ImmutableSpecialTypes.Contains( type.SpecialType ) ) {
 				return true;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -17,7 +17,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		IgnoreImmutabilityAttribute = 2,
 	}
 
-	internal sealed class MutabilityInspector {
+	public sealed class MutabilityInspector {
 		/// <summary>
 		/// A list of immutable container types (i.e., types that hold other types)
 		/// </summary>
@@ -46,7 +46,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 		private readonly ConcurrentDictionary<Tuple<ITypeSymbol, MutabilityInspectionFlags>, MutabilityInspectionResult> m_cache
 			= new ConcurrentDictionary<Tuple<ITypeSymbol, MutabilityInspectionFlags>, MutabilityInspectionResult>();
 
-		internal MutabilityInspector(
+		public MutabilityInspector(
 			Compilation compilation,
 			KnownImmutableTypes knownImmutableTypes
 		) {


### PR DESCRIPTION
Marking as public because in an external project I would like to:
1. Create a `MutabilityInspector `
2. `InspectType` to determine if a type is mutable
