### PR TITLE
Add ability to optionally pass allowed unaudited reasons to the Immutable attribute

### DIFF
--- a/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
@@ -15,6 +15,23 @@ namespace D2L.CodeStyle.Annotations {
 			       | AttributeTargets.Interface
 			       | AttributeTargets.Struct
 		)]
-		public sealed class Immutable : Attribute {}
+		public sealed class Immutable : Attribute {
+
+			public Except Except { get; set; }
+
+		}
+
+		[Flags]
+		public enum Except {
+
+			None = 0,
+			ItHasntBeenLookedAt = 1,
+			ItsSketchy = 2,
+			ItsStickyDataOhNooo = 4,
+			WeNeedToMakeTheAnalyzerConsiderThisSafe = 8,
+			ItsUgly = 16,
+			ItsOnDeathRow = 32
+			
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a new constructor to the `Immutable` attribute allowing a user to pass Unaudited reasons to allow when checking immutability. By default, all reasons are allowed.

In practice this looks something like:
<img width="506" alt="screen shot 2018-01-16 at 6 05 28 pm" src="https://user-images.githubusercontent.com/45536/35016719-e2531020-fae7-11e7-9064-38b92f73c055.png">

This will give us the ability to use these values when doing analysis to ensure there are no unsafe unaudited fields/properties in a certain dependency graph.

Note that I added a new enum for handling the flags. This was done for a few reasons:
* Values passed to an attribute must be a constant value – flags are, arrays are not
* `Because` is not currently a flags enum, and is treated as such everywhere it's used. No need to convert it and have to deal with potential silliness.
* This allows us to remove variants from `Because` without needing to update every single place where this constructor is used.

This does have the downside of having to remember to add new unaudited reasons in both places, but they seem stable now so I don't see this being an issue.