### PR TITLE
Specify values for Because enum variants

### DIFF
--- a/src/D2L.CodeStyle.Annotations/Because.cs
+++ b/src/D2L.CodeStyle.Annotations/Because.cs
@@ -4,7 +4,7 @@ namespace D2L.CodeStyle.Annotations {
 		/// <summary>
 		/// DEPRECATED: Things marked with this attribute should be recategorized.
 		/// </summary>
-		ItHasntBeenLookedAt,
+		ItHasntBeenLookedAt = 1,
 
 		/// <summary>
 		/// DEPRECATED: Things marked with this attribute should be recategorized.
@@ -12,26 +12,26 @@ namespace D2L.CodeStyle.Annotations {
 		/// be an undiff problem. We need to better categorize these so that we can
 		/// prioritize work that gets us closer to undiff.
 		/// </summary>
-		ItsSketchy,
+		ItsSketchy = 2,
 
 		/// <summary>
 		/// These are blockers for undiff.
 		/// </summary>
-		ItsStickyDataOhNooo,
+		ItsStickyDataOhNooo = 3,
 
 		/// <summary>
 		/// These are things which could be analyzed as safe but require improvements
 		/// to the analyzer. An alternative is [Audited(...)] when we don't
 		/// expect an improvements to the analyzer to pass this variable.
 		/// </summary>
-		WeNeedToMakeTheAnalyzerConsiderThisSafe,
+		WeNeedToMakeTheAnalyzerConsiderThisSafe = 4,
 
 		/// <summary>
 		/// This code is ugly and we don't feel comfortable making it
 		/// [Audited(...)] (which is a long-term acceptable bucket) we
 		/// are not prioritizing this work for undiff.
 		/// </summary>
-		ItsUgly,
+		ItsUgly = 5,
 
 		/// <summary>
 		/// This code won't ship or be enabled for undiff clients. It
@@ -39,6 +39,6 @@ namespace D2L.CodeStyle.Annotations {
 		/// because there is a newer parallel implementation or it is not
 		/// compatible with next-gen hosting.
 		/// </summary>
-		ItsOnDeathRow
+		ItsOnDeathRow = 6
 	}
 }


### PR DESCRIPTION
To safely parse these in the analyzer, it's best for these to be specified. Otherwise they may change as variants are added/removed.