### PR TITLE
Calexander/add di framework attribute

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/Attributes.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/Attributes.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.Common {
 	internal static class Attributes {
@@ -23,6 +24,7 @@ namespace D2L.CodeStyle.Analyzers.Common {
 			internal static readonly RoslynAttribute Unaudited = new RoslynAttribute( "D2L.CodeStyle.Annotations.Mutability.UnauditedAttribute" );
 		}
 		internal static readonly RoslynAttribute Singleton = new RoslynAttribute( "D2L.LP.Extensibility.Activation.Domain.SingletonAttribute" );
+		internal static readonly RoslynAttribute DIFramework = new RoslynAttribute( "D2L.LP.Extensibility.Activation.Domain.DIFrameworkAttribute" );
 		internal static readonly RoslynAttribute Dependency = new RoslynAttribute( "D2L.LP.Extensibility.Activation.Domain.DependencyAttribute" );
 
 		internal sealed class RoslynAttribute {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/OldAndBrokenServiceLocatorAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/OldAndBrokenServiceLocatorAnalyzer.cs
@@ -15,6 +15,8 @@ namespace D2L.LP.Extensibility.Activation.Domain {
 	public class OldAndBrokenServiceLocatorFactory {
 		public IServiceLocator Create() { return null; }
 	}
+
+	public sealed class DIFrameworkAttribute : Attribute { }
 }
 
 namespace D2L.CodeStyle.Analyzers.OldAndBrokenLocator.Examples {
@@ -54,6 +56,16 @@ namespace D2L.CodeStyle.Analyzers.OldAndBrokenLocator.Examples {
 		) {
 			m_foo = injectedFoo;
 			m_bar = injectedBar;
+		}
+	}
+
+	[DIFramework]
+	public sealed class DIFrameworkClass {
+
+		public int InDIFrameworkClass() {
+			IServiceLocator ok = OldAndBrokenServiceLocator.Instance;
+			IServiceLocator alsoOk = OldAndBrokenServiceLocatorFactory.Create();
+			return 0;
 		}
 	}
 }


### PR DESCRIPTION
Adding a new attribute, because we don't need to care about the hundreds of IServiceLocators and IObjectActivators in the core DI classes in LP.  (We don't intend to delete those classes anyways, because they are needed to support the higher level abstractions that we want people to use)