### PR TITLE
Add helper for parsing Immutable exceptions from attribute

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/ImmutableHelpers.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/ImmutableHelpers.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace D2L.CodeStyle.Analyzers.Common {
+	internal static class ImmutableHelpers {
+
+		/// <summary>
+		/// These values are used as the exceptions when a type is marked [Immutable] with no defined exceptions.
+		/// </summary>
+		public static readonly ImmutableHashSet<string> DefaultImmutabilityExceptions = ImmutableHashSet.Create(
+			"ItHasntBeenLookedAt",
+			"ItsSketchy",
+			"ItsStickyDataOhNooo",
+			"WeNeedToMakeTheAnalyzerConsiderThisSafe",
+			"ItsUgly",
+			"ItsOnDeathRow"
+		);
+
+		/// <summary>
+		/// Parses the Except values from a type's [Immutable] attribute.
+		/// </summary>
+		public static ImmutableHashSet<string> GetActualImmutableExceptions( this ITypeSymbol ty ) {
+
+			AttributeData attrData = Attributes.Objects.Immutable.GetAll( ty ).FirstOrDefault();
+			if( attrData == null ) {
+				throw new Exception( $"Unable to get Immutable attribute from type '{ty.GetFullTypeName()}'" );
+			}
+
+			SyntaxNode syntaxNode = attrData
+				.ApplicationSyntaxReference?
+				.GetSyntax();
+
+			AttributeSyntax attrSyntax = syntaxNode as AttributeSyntax;
+
+			if( attrSyntax == null ) {
+				throw new Exception( $"Unable to get AttributeSyntax for Immutable attribute on '{ty.GetFullTypeName()}'" );
+			}
+
+			AttributeArgumentSyntax foundArg = attrSyntax
+				.ArgumentList?
+				.Arguments
+				.FirstOrDefault(
+					// Get the first argument that is defined by the "Except = ..." syntax
+					arg => arg.NameEquals?.Name?.Identifier.ValueText == "Except"
+				);
+
+			if( foundArg == null ) {
+				// We have the Immutable attribute but no Except value, so we just return the defaults
+				return DefaultImmutabilityExceptions;
+			}
+
+			ImmutableHashSet<string> exceptions = ExceptFlagValuesToSet( foundArg.Expression );
+			return exceptions;
+		}
+
+		private static ImmutableHashSet<string> ExceptFlagValuesToSet( ExpressionSyntax expr ) {
+
+			ImmutableHashSet<string>.Builder builder = ImmutableHashSet.CreateBuilder<string>();
+
+			ExceptFlagValuesToSetRecursive( expr, builder );
+
+			return builder.ToImmutable();
+		}
+
+		private static void ExceptFlagValuesToSetRecursive( ExpressionSyntax expr, ImmutableHashSet<string>.Builder builder ) {
+
+			if( expr is MemberAccessExpressionSyntax ) {
+				MemberAccessExpressionSyntax memEx = (MemberAccessExpressionSyntax)expr;
+				string value = memEx.Name.Identifier.ValueText;
+				// "None" values are skipped over. If there was only the one None value, the empty set will be returned as
+				// expected. If there were other values, None is irrelevant since we only support OR operations.
+				if( value != "None" ) {
+					builder.Add( value );
+				}
+				return;
+			}
+
+			if( expr is BinaryExpressionSyntax ) {
+				BinaryExpressionSyntax binEx = (BinaryExpressionSyntax)expr;
+
+				if( binEx.Kind() != SyntaxKind.BitwiseOrExpression ) {
+					throw new Exception( $"Flags are being created with unsupported operator: '{binEx}" );
+				}
+
+				ExceptFlagValuesToSetRecursive( binEx.Right, builder );
+				ExceptFlagValuesToSetRecursive( binEx.Left, builder );
+				return;
+			}
+
+			throw new Exception( $"Unknown expression syntax type '{expr.GetType()}' when parsing flags: '{expr}'" );
+		}
+
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Common\DependencyInjection\RegisterPluginForExtensionPointExpression.cs" />
     <Compile Include="Common\DependencyInjection\RegisterSubInterfaceExpression.cs" />
     <Compile Include="Common\Diagnostics.cs" />
+    <Compile Include="Common\ImmutableHelpers.cs" />
     <Compile Include="Common\KnownImmutableTypes.cs" />
     <Compile Include="Common\MutabilityInspectionResult.cs" />
     <Compile Include="Common\MutabilityInspectionResultFormatter.cs" />

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/ImmutableHelpersTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/ImmutableHelpersTests.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+using static D2L.CodeStyle.Analyzers.Common.RoslynSymbolFactory;
+
+namespace D2L.CodeStyle.Analyzers.Common {
+	[TestFixture]
+	internal sealed class ImmutableHelpersTests {
+
+		private const string AnnotationsPreamble = @"
+using System;
+using static D2L.CodeStyle.Annotations.Objects;
+ 
+namespace D2L.CodeStyle.Annotations {
+	public static class Objects {
+		public sealed class Immutable : Attribute {
+ 
+			public Except Except { get; set; }
+ 
+		}
+ 
+		[Flags]
+		public enum Except {
+ 
+			None = 0,
+			ItHasntBeenLookedAt = 1,
+			ItsSketchy = 2,
+			ItsStickyDataOhNooo = 4,
+			WeNeedToMakeTheAnalyzerConsiderThisSafe = 8,
+			ItsUgly = 16,
+			ItsOnDeathRow = 32
+ 
+		}
+	}
+}
+";
+
+		[Test]
+		public void GetActualImmutableExceptions_WhenTypeDoesNotHaveImmutableAttribute_ThrowsException() {
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( @"public class Foo { }" );
+
+			Assert.That( () => ty.Symbol.GetActualImmutableExceptions(), Throws.Exception );
+		}
+
+		[Test]
+		public void GetActualImmutableExceptions_WhenNoSpecifiedExceptions_ReturnsDefaultReasons() {
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( @"
+[Immutable]
+public class Foo { }
+" );
+
+			IImmutableSet<string> immutabilityExceptions = ty.Symbol.GetActualImmutableExceptions();
+
+			Assert.That( immutabilityExceptions, Is.EquivalentTo( ImmutableHelpers.DefaultImmutabilityExceptions ) );
+		}
+
+		[Test]
+		public void GetActualImmutableExceptions_WhenSpecifiedExceptions_ReturnsSpecifiedExceptions() {
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( @"
+[Immutable( Except = Except.ItsUgly | Except.WeNeedToMakeTheAnalyzerConsiderThisSafe | Except.ItsSketchy )]
+public class Foo { }
+" );
+
+			IImmutableSet<string> immutabilityExceptions = ty.Symbol.GetActualImmutableExceptions();
+
+			Assert.That( immutabilityExceptions, Is.EquivalentTo( new[] {
+				"WeNeedToMakeTheAnalyzerConsiderThisSafe",
+				"ItsUgly",
+				"ItsSketchy"
+			} ) );
+		}
+
+		[Test]
+		public void GetActualImmutableExceptions_WhenSpecifiedNoneReasons_ReturnsEmptySet() {
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( @"
+[Immutable( Except = Except.None )]
+public class Foo { }
+" );
+
+			IImmutableSet<string> immutabilityExceptions = ty.Symbol.GetActualImmutableExceptions();
+
+			Assert.That( immutabilityExceptions, Is.Empty );
+		}
+
+		private static TestSymbol<ITypeSymbol> CompileAndGetFooType( string source ) {
+			source = $"namespace D2L {{ {source} }}";
+			source = AnnotationsPreamble + source;
+
+			var compilation = Compile( source );
+			var symbol = compilation.GetSymbolsWithName(
+				predicate: n => n == "Foo",
+				filter: SymbolFilter.Type
+			).OfType<ITypeSymbol>().FirstOrDefault();
+
+			Assert.IsNotNull( symbol );
+			Assert.AreNotEqual( TypeKind.Error, symbol.TypeKind );
+
+			return new TestSymbol<ITypeSymbol>( symbol, compilation );
+		}
+
+	}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common\BecauseHelpersTests.cs" />
+    <Compile Include="Common\ImmutableHelpersTests.cs" />
     <Compile Include="Common\KnownImmutableTypesTests.cs" />
     <Compile Include="Common\MutabilityInspectionResultFormatterTests.cs" />
     <Compile Include="Common\MutabilityInspectorTests.cs" />


### PR DESCRIPTION
This PR adds a helper method to parse the Immutable attribute Except flag into a set of the variant names.

It only supports OR operations for creating the flags. Anything else will throw an exception. :/ Alternatives are:
* Add support for all bitwise operations (extra work)
* Treat all bitwise operations as ORs (surprising behaviour, but safe as OR is always going to produce a superset)

r? @j3parker 