### PR TITLE
Aggregate Immutable exceptions into SeenUnauditedReasons

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -122,8 +122,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			// If we're verifying immutability, then carry on; otherwise, bailout
 			if( !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && type.IsTypeMarkedImmutable() ) {
-				// TODO: Get immutable exceptions and add them to the result's SeenUnauditedReasons
-				return MutabilityInspectionResult.NotMutable();
+				ImmutableHashSet<string> actualImmutableExceptions = type.GetActualImmutableExceptions();
+				return MutabilityInspectionResult.NotMutable( actualImmutableExceptions );
 			}
 
 			// System.Object is safe if we can allow unsealed types (i.e., the type is the concrete type). 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Common/MutabilityInspectorTests.cs
@@ -323,7 +323,8 @@ namespace D2L.CodeStyle.Annotations {
 		ItsStickyDataOhNooo,
 		WeNeedToMakeTheAnalyzerConsiderThisSafe,
 		ItsUgly,
-		ItsOnDeathRow
+		ItsOnDeathRow,
+		SomeNewReason
 	}
 
 	public enum UndiffBucket {
@@ -341,21 +342,28 @@ namespace D2L.CodeStyle.Annotations {
 
 	public static class Objects {
 		public sealed class Immutable : Attribute {
+			public Except Except { get; }
+		}
+
+		[Flags]
+		public enum Except {
+			None = 0,
+			ItHasntBeenLookedAt = 1,
+			ItsSketchy = 2,
+			ItsStickyDataOhNooo = 4,
+			WeNeedToMakeTheAnalyzerConsiderThisSafe = 8,
+			ItsUgly = 16,
+			ItsOnDeathRow = 32
 		}
 	}
 }
 ";
 
 		[Test]
-		public void InspectType_TypeHasNoUnauditedMembers_NoUnauditedReasons() {
+		public void InspectType_TypeHasNoMembers_NoUnauditedReasons() {
 
 			const string source = AnnotationsPreamble + @"
-sealed class Foo {
-	public int Bar { get; }
-}
-
-[Immutable]
-sealed class Bar { }
+sealed class Foo {}
 ";
 
 			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
@@ -364,7 +372,41 @@ sealed class Bar { }
 		}
 
 		[Test]
-		public void InspectType_TypeHasOneUnauditedMember_ReturnsUnauditedReason() {
+		public void InspectType_TypeHasDefaultImmutableMember_ReturnsDefaultImmutabilityExceptionsAsSeenUnauditedReasons() {
+
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+	public Bar Bar { get; }
+}
+
+[Immutable]
+sealed class Bar { }
+";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			AssertUnauditedReasonsResult( ty, ImmutableHelpers.DefaultImmutabilityExceptions.ToArray() );
+		}
+
+		[Test]
+		public void InspectType_TypeHasImmutableMemberWithSpecifiedExceptions_ReturnsThoseExceptionsAsSeenUnauditedReasons() {
+
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+	public Bar Bar { get; }
+}
+
+[Immutable( Except = Except.ItsUgly | Except.ItsSketchy )]
+sealed class Bar { }
+";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			AssertUnauditedReasonsResult( ty, "ItsUgly", "ItsSketchy" );
+		}
+
+		[Test]
+		public void InspectType_TypeHasOneUnauditedMember_ReturnsUnauditedReasonAsSeenUnauditedReasons() {
 
 			const string source = AnnotationsPreamble + @"
 sealed class Foo {
@@ -379,7 +421,7 @@ sealed class Foo {
 		}
 
 		[Test]
-		public void InspectType_TypeHasMultipleDifferentUnauditedMembers_ReturnsAllUnauditedReasons() {
+		public void InspectType_TypeHasMultipleDifferentUnauditedMembers_ReturnsAllUnauditedReasonsAsSeenUnauditedReasons() {
 
 			const string source = AnnotationsPreamble + @"
 sealed class Foo {
@@ -396,7 +438,7 @@ sealed class Foo {
 		}
 
 		[Test]
-		public void InspectType_TypeHasMultipleIdenticalUnauditedMembers_ReturnsAllUnauditedReasons() {
+		public void InspectType_TypeHasMultipleIdenticalUnauditedMembers_ReturnsAllUnauditedReasonsAsSeenUnauditedReasons() {
 
 			const string source = AnnotationsPreamble + @"
 sealed class Foo {
@@ -410,6 +452,90 @@ sealed class Foo {
 			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
 
 			AssertUnauditedReasonsResult( ty, "ItsSketchy" );
+		}
+
+		[Test]
+		public void InspectType_TypeHasUnauditedMembersAndDefaultImmutableMember_ReturnsDefaultImmutabilityExceptionsAsSeenUnauditedReasons() {
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+	[Mutability.Unaudited( Because.ItsSketchy )]
+	public Func<string> Bar { get; }
+	[Mutability.Unaudited( Because.ItsUgly )]
+	public Func<string> Baz { get; }
+
+	public Bar XYZ { get; }
+}
+
+[Immutable]
+sealed class Bar { }
+";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			AssertUnauditedReasonsResult( ty, ImmutableHelpers.DefaultImmutabilityExceptions.ToArray() );
+		}
+
+		[Test]
+		public void InspectType_TypeHasUnauditedMembersAndImmutableMemberWithSharedExceptions_ReturnsUnionOfExceptionsAndReasonsAsSeenUnauditedReasons() {
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+	[Mutability.Unaudited( Because.ItsSketchy )]
+	public Func<string> Bar { get; }
+	[Mutability.Unaudited( Because.ItsUgly )]
+	public Func<string> Baz { get; }
+
+	public Bar XYZ { get; }
+}
+
+[Immutable( Except = Except.ItHasntBeenLookedAt )]
+sealed class Bar { }
+";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			AssertUnauditedReasonsResult( ty, "ItsSketchy", "ItsUgly", "ItHasntBeenLookedAt" );
+		}
+
+		[Test]
+		public void InspectType_TypeHasUnauditedMembersAndImmutableMemberWithNoExceptions_ReturnsUnauditedReasonsAsSeenUnauditedReasons() {
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+	[Mutability.Unaudited( Because.ItsSketchy )]
+	public Func<string> Bar { get; }
+	[Mutability.Unaudited( Because.ItsUgly )]
+	public Func<string> Baz { get; }
+
+	public Bar XYZ { get; }
+}
+
+[Immutable( Except = Except.None )]
+sealed class Bar { }
+";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			AssertUnauditedReasonsResult( ty, "ItsSketchy", "ItsUgly" );
+		}
+
+		[Test]
+		public void InspectType_TypeHasNonDefaultUnauditedMembersAndDefaultImmutableMember_ReturnsUnionOfDefaultExceptionsAndNonDefaultReasonAsSeenUnauditedReasons() {
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+	[Mutability.Unaudited( Because.ItsSketchy )]
+	public Func<string> Bar { get; }
+	[Mutability.Unaudited( Because.SomeNewReason )]
+	public Func<string> Baz { get; }
+
+	public Bar XYZ { get; }
+}
+
+[Immutable]
+sealed class Bar { }
+";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			AssertUnauditedReasonsResult( ty, ImmutableHelpers.DefaultImmutabilityExceptions.Add( "SomeNewReason" ).ToArray() );
 		}
 
 		private TestSymbol<ITypeSymbol> CompileAndGetFooType( string source ) {
@@ -434,7 +560,7 @@ sealed class Foo {
 				ImmutableHashSet.Create( expectedUnauditedReasons )
 			);
 
-			var actual = inspector.InspectType( ty.Symbol );
+			var actual = inspector.InspectType( ty.Symbol, MutabilityInspectionFlags.IgnoreImmutabilityAttribute );
 
 			AssertResultsAreEqual( expected, actual );
 		}


### PR DESCRIPTION
This PR adds support for pulling the Immutable exceptions during the mutability inspection process, joining them with the actual Unaudited reasons to build the complete set.

Next PR will hook this into the analyzer to report a diagnostic if the type being analyzed's exceptions are not a superset of the SeenUnauditedReasons set.

@j3parker 