### PR TITLE
Revert "Aggregate Immutable exceptions into SeenUnauditedReasons"

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Common/MutabilityInspector.cs
@@ -122,8 +122,8 @@ namespace D2L.CodeStyle.Analyzers.Common {
 
 			// If we're verifying immutability, then carry on; otherwise, bailout
 			if( !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && type.IsTypeMarkedImmutable() ) {
-				ImmutableHashSet<string> actualImmutableExceptions = type.GetActualImmutableExceptions();
-				return MutabilityInspectionResult.NotMutable( actualImmutableExceptions );
+				// TODO: Get immutable exceptions and add them to the result's SeenUnauditedReasons
+				return MutabilityInspectionResult.NotMutable();
 			}
 
 			// System.Object is safe if we can allow unsealed types (i.e., the type is the concrete type). 


### PR DESCRIPTION
Reverts Brightspace/D2L.CodeStyle#280

Breaks if the type isn't directly marked Immutable. Reverting until I can fix it properly.