### PR TITLE
US88817 - removing 'CannedMetronIdsFeature'.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/LaunchDarkly/LegacyFeatureTypes.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/LaunchDarkly/LegacyFeatureTypes.cs
@@ -47,7 +47,6 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.LaunchDarkly {
 			"D2L.LP.Auth.Webpages.Login.LoginFailedOpenRedirectFeature",
 			"D2L.LP.Communication.ExternalEmail.EmailVerification.AllUsersEmailVerificationFeature",
 			"D2L.LP.Communication.ExternalEmail.EmailVerification.EmailVerificationFeature",
-			"D2L.LP.Distributed.Events.ExternalPublish.Aggregation.Default.CannedMetronIdsFeature",
 			"D2L.LP.Distributed.Queues.Domain.DateQueuedFlag",
 			"D2L.LP.Distributed.Queues.Service.Verification.Tasks.UndiffVerificationMessageEnqueuingFeature",
 			"D2L.LP.Enrollments.FeatureToggles.GroupTypeSelfEnrollmentQuicklinkFeature",


### PR DESCRIPTION
To be merged after [PR for US88817 - removing canned-metron-ids toggle](https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/8188/overview).