### PR TITLE
Add initial phase of attribute-banning

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousAttributeUsages/DangerousAttributeUsages.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousAttributeUsages/DangerousAttributeUsages.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousAttributeUsages {
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	internal sealed class DangerousAttributeUsages : DiagnosticAnalyzer {
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+			Diagnostics.DangerousAttributesShouldBeAvoided
+		);
+
+		public override void Initialize( AnalysisContext context ) {
+
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction( RegisterAnalysis );
+		}
+
+		private void RegisterAnalysis( CompilationStartAnalysisContext context ) {
+
+			context.RegisterSyntaxNodeAction(
+				ctx => AnalyzeAttribute( ctx ),
+				SyntaxKind.Attribute
+			);
+		}
+
+		private void AnalyzeAttribute( SyntaxNodeAnalysisContext context ) {
+
+			AttributeSyntax attribute = context.Node as AttributeSyntax;
+			if( attribute == null ) {
+				return;
+			}
+
+			if( !DangerousAttributes.Definitions.Contains( attribute.Name.ToString() ) ) {
+				return;
+			}
+
+			Location location = attribute.GetLocation();
+			string attributeName = attribute.Name.ToString();
+			var diagnostic = Diagnostic.Create(
+				Diagnostics.DangerousAttributesShouldBeAvoided,
+				location,
+				attributeName
+			);
+
+			context.ReportDiagnostic( diagnostic );
+		}
+
+	}
+
+}

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousAttributeUsages/DangerousAttributes.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousAttributeUsages/DangerousAttributes.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousAttributeUsages {
+
+	internal static class DangerousAttributes {
+
+		internal static readonly IReadOnlyList<string> Definitions =
+			ImmutableList.Create<string>().Add( "JsonParamBinder" );
+
+	}
+
+}

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -31,6 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ApiUsage\DangerousAttributeUsages\DangerousAttributes.cs" />
+    <Compile Include="ApiUsage\DangerousAttributeUsages\DangerousAttributeUsages.cs" />
     <Compile Include="Attributes.cs" />
     <Compile Include="Extensions\Microsoft.CodeAnalysis.CSharp.Syntax.cs" />
     <Compile Include="Language\ClassShouldBeSealedAnalyzer.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -192,5 +192,15 @@ namespace D2L.CodeStyle.Analyzers {
 			description: "Switch your feature definition to inherit D2L.LP.LaunchDarkly.FeatureDefinition, configure your feature for DI, and use one of the new IInstanceFlag/IOrgFlag/ICurrentOrgFlag interfaces instead"
 		);
 
+		public static readonly DiagnosticDescriptor DangerousAttributesShouldBeAvoided = new DiagnosticDescriptor(
+			id: "D2L0023",
+			title: "Avoid using dangerous attributes",
+			messageFormat: "Should not use {0} because it's considered dangerous",
+			category: "Safety",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: false,
+			description: "Avoid using dangerous attributes"
+		);
+
 	}
 }

--- a/src/D2L.CodeStyle.Annotations/D2L.CodeStyle.Annotations.csproj
+++ b/src/D2L.CodeStyle.Annotations/D2L.CodeStyle.Annotations.csproj
@@ -52,6 +52,9 @@
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="DangerousAttributeUsage\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Just looking for feedback at this point, not expecting to merge this yet or anything, hence it being disabled :)

This currently would cause errors on any usage of `JsonParamBinder` (the attribute that caused this discussion). Not sure what's next here - adding the audited/unaudited attributes and applying them everywhere in the codebase? Or is there some way to make _new_ usages barred, and then slowly audit the existing ones (presumably with the audited/unaudited attributes as an interim step)?