### PR TITLE
Add missed unaudited reason aggregations

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -287,6 +287,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		) {
 			var namedType = type as INamedTypeSymbol;
 
+			ImmutableHashSet<string>.Builder unauditedReasonsBuilder = ImmutableHashSet.CreateBuilder<string>();
+
 			for( int i = 0; i < namedType.TypeArguments.Length; i++ ) {
 				var arg = namedType.TypeArguments[ i ];
 
@@ -310,9 +312,11 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					}
 					return result;
 				}
+
+				unauditedReasonsBuilder.UnionWith( result.SeenUnauditedReasons );
 			}
 
-			return MutabilityInspectionResult.NotMutable();
+			return MutabilityInspectionResult.NotMutable( unauditedReasonsBuilder.ToImmutable() );
 		}
 
 		private MutabilityInspectionResult InspectTypeParameter(
@@ -333,7 +337,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					);
 
 					if( !result.IsMutable ) {
-						return MutabilityInspectionResult.NotMutable();
+						return result;
 					}
 				}
 			}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
@@ -312,6 +312,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 		private const string AnnotationsPreamble = @"
 using System;
+using System.Collections.Generic;
 using D2L.CodeStyle.Annotations;
 using static D2L.CodeStyle.Annotations.Objects;
  
@@ -558,6 +559,25 @@ sealed class Bar { }
 			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
 
 			AssertUnauditedReasonsResult( ty, ImmutableHelpers.DefaultImmutabilityExceptions.Add( "SomeNewReason" ).ToArray() );
+		}
+
+		[Test]
+		public void InspectType_TypeHasImmutableCollectionMember_ReturnsUnionOfExceptionsInCollectionTypes() {
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+	public IReadOnlyDictionary<Bar, Baz> XYZ { get; }
+}
+
+[Immutable( Except = Except.ItsUgly )]
+sealed class Bar { }
+
+[Immutable( Except = Except.ItHasntBeenLookedAt )]
+sealed class Baz { }
+";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			AssertUnauditedReasonsResult( ty, "ItsUgly", "ItHasntBeenLookedAt" );
 		}
 
 		private TestSymbol<ITypeSymbol> CompileAndGetFooType( string source ) {


### PR DESCRIPTION
Missed these two type param cases when aggregating unaudited reasons from members.

r? @j3parker 