### PR TITLE
Use AllInterfaces for inherited exceptions

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableHelpers.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableHelpers.cs
@@ -119,11 +119,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			var builder = ImmutableDictionary.CreateBuilder<ISymbol, ImmutableHashSet<string>>();
 
-			if( type.BaseType != null && type.BaseType.IsTypeMarkedImmutable() ) {
-				builder.Add( type.BaseType, type.BaseType.GetAllImmutableExceptions() );
+			if( type.BaseType != null ) {
+				// Interfaces of the base type are covered in AllInterfaces below, so we only need to get direct exceptions
+				// if they exist.
+				ImmutableHashSet<string> baseTypeExceptions;
+				if( type.BaseType.TryGetDirectImmutableExceptions( out baseTypeExceptions ) ) {
+					builder.Add( type.BaseType, baseTypeExceptions );
+				}
 			}
 
-			foreach( INamedTypeSymbol iface in type.Interfaces ) {
+			foreach( INamedTypeSymbol iface in type.AllInterfaces ) {
 				ImmutableHashSet<string> ifaceExceptions;
 				if( iface.TryGetDirectImmutableExceptions( out ifaceExceptions ) ) {
 					builder.Add( iface, ifaceExceptions );

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/ImmutableHelpersTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/ImmutableHelpersTests.cs
@@ -166,10 +166,31 @@ public sealed class Foo : FooBase { }
 
 			Assert.That( inheritedExceptions, Has.Count.EqualTo( 1 ) );
 
-			ISymbol fooBaseSymbol = inheritedExceptions.Keys.FirstOrDefault( s => s.Name == "FooBase" );
-			Assert.That( fooBaseSymbol, Is.Not.Null );
+			ISymbol ifooSymbol = inheritedExceptions.Keys.FirstOrDefault( s => s.Name == "IFoo" );
+			Assert.That( ifooSymbol, Is.Not.Null );
 
-			Assert.That( inheritedExceptions[fooBaseSymbol], Is.EquivalentTo( new[] { "ItHasntBeenLookedAt" } ) );
+			Assert.That( inheritedExceptions[ifooSymbol], Is.EquivalentTo( new[] { "ItHasntBeenLookedAt" } ) );
+		}
+
+		[Test]
+		public void GetInheritedImmutableExceptions_WhenInterfaceIndirectlyImmutable_ReturnsInheritedTypesExceptions() {
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( @"
+[Immutable( Except = Except.ItHasntBeenLookedAt )]
+public interface IFoo { }
+public interface IFoo2 : IFoo { }
+
+public sealed class Foo : IFoo2 { }
+" );
+
+			ImmutableDictionary<ISymbol, ImmutableHashSet<string>> inheritedExceptions = ty.Symbol.GetInheritedImmutableExceptions();
+
+			Assert.That( inheritedExceptions, Has.Count.EqualTo( 1 ) );
+
+			ISymbol ifooSymbol = inheritedExceptions.Keys.FirstOrDefault( s => s.Name == "IFoo" );
+			Assert.That( ifooSymbol, Is.Not.Null );
+
+			Assert.That( inheritedExceptions[ifooSymbol], Is.EquivalentTo( new[] { "ItHasntBeenLookedAt" } ) );
 		}
 
 		[Test]


### PR DESCRIPTION
My bad, I missed that `IsTypeMarkedImmutable` does check _**all**_ interfaces by recursively calling `IsTypeMarkedImmutable` on them.

The code in master now successfully compiles the LMS, but was failing when adding the check in the analyzer to verify the returned unaudited reasons.

r? @j3parker 