### PR TITLE
Fix issue where base type of base type is marked immutable

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableHelpers.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableHelpers.cs
@@ -119,13 +119,15 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			var builder = ImmutableDictionary.CreateBuilder<ISymbol, ImmutableHashSet<string>>();
 
-			if( type.BaseType != null ) {
-				// Interfaces of the base type are covered in AllInterfaces below, so we only need to get direct exceptions
+			ITypeSymbol baseType = type.BaseType;
+			while( baseType != null ) {
+				// Interfaces of the base types are covered in AllInterfaces below, so we only need to get direct exceptions
 				// if they exist.
 				ImmutableHashSet<string> baseTypeExceptions;
-				if( type.BaseType.TryGetDirectImmutableExceptions( out baseTypeExceptions ) ) {
-					builder.Add( type.BaseType, baseTypeExceptions );
+				if( baseType.TryGetDirectImmutableExceptions( out baseTypeExceptions ) ) {
+					builder.Add( baseType, baseTypeExceptions );
 				}
+				baseType = baseType.BaseType;
 			}
 
 			foreach( INamedTypeSymbol iface in type.AllInterfaces ) {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/ImmutableHelpersTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/ImmutableHelpersTests.cs
@@ -173,6 +173,27 @@ public sealed class Foo : FooBase { }
 		}
 
 		[Test]
+		public void GetInheritedImmutableExceptions_WhenBaseTypeIndirectlyImmutableThroughBaseType_ReturnsInheritedTypesExceptions() {
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( @"
+[Immutable( Except = Except.ItHasntBeenLookedAt )]
+public class FooBase { }
+public class FooBase2 : FooBase { }
+
+public sealed class Foo : FooBase2 { }
+" );
+
+			ImmutableDictionary<ISymbol, ImmutableHashSet<string>> inheritedExceptions = ty.Symbol.GetInheritedImmutableExceptions();
+
+			Assert.That( inheritedExceptions, Has.Count.EqualTo( 1 ) );
+
+			ISymbol fooBaseSymbol = inheritedExceptions.Keys.FirstOrDefault( s => s.Name == "FooBase" );
+			Assert.That( fooBaseSymbol, Is.Not.Null );
+
+			Assert.That( inheritedExceptions[fooBaseSymbol], Is.EquivalentTo( new[] { "ItHasntBeenLookedAt" } ) );
+		}
+
+		[Test]
 		public void GetInheritedImmutableExceptions_WhenInterfaceIndirectlyImmutable_ReturnsInheritedTypesExceptions() {
 
 			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( @"


### PR DESCRIPTION
Argh, this inheritance stuff is tricky. Didn't let the rebuild run long enough to see the one instance of this we have in our codebase. Oops. Ran it in full this time, build succeeds. 🤦‍♂️