### PR TITLE
Support for non-Inherited Immutable attribute.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Attributes.ImmutableAttribute.cs
+++ b/src/D2L.CodeStyle.Analyzers/Attributes.ImmutableAttribute.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace D2L.CodeStyle.Analyzers {
+	internal static partial class Attributes {
+		internal sealed class ImmutableAttribute : RoslynAttribute {
+			private const string InheritedPropertyName = "Inherited";
+			private const bool DefaultInheritedValue = true;
+
+			public ImmutableAttribute()
+				: base( "D2L.CodeStyle.Annotations.Objects.Immutable" ) { }
+
+			public bool GetValueForInherited( ISymbol s ) {
+				if( !IsDefined( s ) ) {
+					throw new InvalidOperationException(
+						"cannot call GetValueForInherited on a symbol on which the attribute is not defined"
+					);
+				}
+
+				var definition = GetAll( s ).First();
+				foreach( var arg in definition.NamedArguments ) {
+					if( arg.Key != InheritedPropertyName ) {
+						continue;
+					}
+
+					var value = arg.Value.Value;
+					if( value is bool ) {
+						// the value may not be a bool, as in the middle of typing
+						return (bool)value;
+					}
+				}
+				return DefaultInheritedValue;
+			}
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Attributes.cs
+++ b/src/D2L.CodeStyle.Analyzers/Attributes.cs
@@ -3,7 +3,7 @@ using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers {
-	internal static class Attributes {
+	internal static partial class Attributes {
 		internal static class Types {
 			internal static readonly RoslynAttribute Audited = new RoslynAttribute( "D2L.CodeStyle.Annotations.Types.Audited" );
 		}
@@ -15,7 +15,7 @@ namespace D2L.CodeStyle.Analyzers {
 			internal static readonly RoslynAttribute Unaudited = new RoslynAttribute( "D2L.CodeStyle.Annotations.Statics.Unaudited" );
 		}
 		internal static class Objects {
-			internal static readonly RoslynAttribute Immutable = new RoslynAttribute( "D2L.CodeStyle.Annotations.Objects.Immutable" );
+			internal static readonly ImmutableAttribute Immutable = new ImmutableAttribute();
 		}
 		internal static class Mutability {
 			internal static readonly RoslynAttribute Audited = new RoslynAttribute( "D2L.CodeStyle.Annotations.Mutability.AuditedAttribute" );
@@ -25,7 +25,7 @@ namespace D2L.CodeStyle.Analyzers {
 		internal static readonly RoslynAttribute DIFramework = new RoslynAttribute( "D2L.LP.Extensibility.Activation.Domain.DIFrameworkAttribute" );
 		internal static readonly RoslynAttribute Dependency = new RoslynAttribute( "D2L.LP.Extensibility.Activation.Domain.DependencyAttribute" );
 
-		internal sealed class RoslynAttribute {
+		internal class RoslynAttribute {
 
 			private readonly string m_fullTypeName;
 

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Attributes.cs" />
+    <Compile Include="Attributes.ImmutableAttribute.cs" />
     <Compile Include="Extensions\Microsoft.CodeAnalysis.CSharp.Syntax.cs" />
     <Compile Include="Language\ClassShouldBeSealedAnalyzer.cs" />
     <Compile Include="Immutability\BecauseHelpers.cs" />

--- a/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
@@ -5,10 +5,13 @@ namespace D2L.CodeStyle.Annotations {
 	public static class Objects {
 		/// <summary>
 		/// If a class, struct or interface is marked with this annotation it
-		/// means that it's type is immutable. This includes all subtypes of
-		/// that type (which is trivial for structs and sealed classes.) It is
-		/// always safe to add this annotation because an analyzer will check
-		/// that it is valid.
+		/// means that its type is immutable. If the type is an interface or 
+		/// if Inherited is true, then this includes all subtypes of that type
+		/// (which is trivial for structs and sealed classes.). By default 
+		/// Inherited is true. 
+		/// 
+		/// It is always safe to add this annotation because an analyzer will
+		/// check that it is valid.
 		/// </summary>
 		[AttributeUsage(
 			validOn: AttributeTargets.Class
@@ -18,6 +21,8 @@ namespace D2L.CodeStyle.Annotations {
 		public sealed class Immutable : Attribute {
 
 			public Except Except { get; set; }
+
+			public bool Inherited { get; set; } = true;
 
 		}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -10,7 +10,9 @@ namespace D2L.LP.Extensibility.Activation.Domain {
 
 namespace D2L.CodeStyle.Annotations {
 	public static class Objects {
-		public sealed class Immutable : Attribute { }
+		public sealed class Immutable : Attribute {
+			public bool Inherited { get; set; }
+		}
 	}
 	public static class Mutability {
 		public sealed class AuditedAttribute : Attribute { }
@@ -44,6 +46,29 @@ namespace SpecTests {
 			[Mutability.Unaudited( Because.ItsSketchy )]
 			private int m_auditedBad;
 		}
+	}
+
+	class InheritedTests {
+
+		[Objects.Immutable( Inherited = true )]
+		class AlwaysImmutableExplicitly { }
+
+		[Objects.Immutable]
+		class AlwaysImmutableByDefault { }
+
+		[Objects.Immutable( Inherited = false )]
+		class ConcretelyImmutable { }
+
+		class /* ImmutableClassIsnt('m_bad' is not read-only) */ ShouldBeRequiredImmutable1 /**/ : AlwaysImmutableByDefault {
+			private int m_bad;
+		}
+		class /* ImmutableClassIsnt('m_bad' is not read-only) */ ShouldBeRequiredImmutable2 /**/ : AlwaysImmutableExplicitly {
+			private int m_bad;
+		}
+		class ShouldNotBeRequiredImmutable2 : ConcretelyImmutable {
+			private int m_bad;
+		}
+
 	}
 
 	class GenericsTests {


### PR DESCRIPTION
The spec is as such:

```csharp
class InheritedTests {

	[Objects.Immutable( Inherited = true )]
	class AlwaysImmutableExplicitly { }

	[Objects.Immutable]
	class AlwaysImmutableByDefault { }

	[Objects.Immutable( Inherited = false )]
	class ConcretelyImmutable { }

	class /* ImmutableClassIsnt('m_bad' is not read-only) */ ShouldBeRequiredImmutable1 /**/ : AlwaysImmutableByDefault {
		private int m_bad;
	}
	class /* ImmutableClassIsnt('m_bad' is not read-only) */ ShouldBeRequiredImmutable2 /**/ : AlwaysImmutableExplicitly {
		private int m_bad;
	}
	class ShouldNotBeRequiredImmutable2 : ConcretelyImmutable {
		private int m_bad;
	}

}
```