### PR TITLE
Report diagnostic for invalid unaudited reasons

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -192,5 +192,15 @@ namespace D2L.CodeStyle.Analyzers {
 			description: "Switch your feature definition to inherit D2L.LP.LaunchDarkly.FeatureDefinition, configure your feature for DI, and use one of the new IInstanceFlag/IOrgFlag/ICurrentOrgFlag interfaces instead"
 		);
 
+		public static readonly DiagnosticDescriptor InvalidUnauditedReasonInImmutable = new DiagnosticDescriptor(
+			id: "D2L0023",
+			title: "Immutability exceptions must be a subset of containing type's",
+			messageFormat: "One or more members on this type have unaudited reasons that are not excepted. Resolve the Unaudited members or relax exceptions on this type to a superset of {{ {0} }}.",
+			category:"Safety",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "Type's members' allowed and used unaudited reasons must be a subset of the type's immutable exceptions."
+		);
+
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/ImmutabilityAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/ImmutabilityAnalyzerTests.cs
@@ -1,4 +1,3 @@
-using D2L.CodeStyle.Analyzers.Immutability;
 using D2L.CodeStyle.Analyzers.Test.Verifiers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -12,10 +11,42 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		}
 
 		private const string s_preamble = @"
+using System;
 using D2L.CodeStyle.Annotations;
+using static D2L.CodeStyle.Annotations.Objects;
+ 
 namespace D2L.CodeStyle.Annotations {
 	public class Objects {
 		public class Immutable : Attribute {}
+		public sealed class Immutable : Attribute {
+			public Except Except { get; set; }
+		}
+ 
+		[Flags]
+		public enum Except {
+			None = 0,
+			ItHasntBeenLookedAt = 1,
+			ItsSketchy = 2,
+			ItsStickyDataOhNooo = 4,
+			WeNeedToMakeTheAnalyzerConsiderThisSafe = 8,
+			ItsUgly = 16,
+			ItsOnDeathRow = 32
+		}
+	}
+ 
+	public class Mutability {
+		public class UnauditedAttribute : Attribute {
+			public UnauditedAttribute( Because cuz ) { }
+		}
+	}
+ 
+	public enum Because {
+		ItHasntBeenLookedAt = 1,
+		ItsSketchy = 2,
+		ItsStickyDataOhNooo = 3,
+		WeNeedToMakeTheAnalyzerConsiderThisSafe = 4,
+		ItsUgly = 5,
+		ItsOnDeathRow = 6
 	}
 }
 ";
@@ -32,10 +63,8 @@ namespace D2L.CodeStyle.Annotations {
 		[Test]
 		public void DocumentWithStatic_ClassIsNotImmutableButIsMarkedImmutable_Diag() {
 			const string test = @"
-	using System;
-
 	namespace test {
-		[Objects.Immutable]
+		[Immutable]
 		class Test {
 
 			public DateTime bad = DateTime.Now;
@@ -43,7 +72,7 @@ namespace D2L.CodeStyle.Annotations {
 
 		}
 	}";
-			AssertSingleDiagnostic( s_preamble + test, 13, 9, MutabilityInspectionResult.Mutable(
+			AssertSingleDiagnostic( s_preamble + test, 43, 9, MutabilityInspectionResult.Mutable(
 				"bad",
 				"System.DateTime",
 				MutabilityTarget.Member,
@@ -55,10 +84,8 @@ namespace D2L.CodeStyle.Annotations {
 		[Test]
 		public void DocumentWithStatic_ClassIsNotImmutableButImplementsImmutableInterface_Diag() {
 			const string test = @"
-	using System;
-
 	namespace test {
-		[Objects.Immutable] interface IFoo {} 
+		[Immutable] interface IFoo {} 
 		class Test : IFoo {
 
 			public DateTime bad = DateTime.Now;
@@ -66,7 +93,7 @@ namespace D2L.CodeStyle.Annotations {
 
 		}
 	}";
-			AssertSingleDiagnostic( s_preamble + test, 13, 9, MutabilityInspectionResult.Mutable(
+			AssertSingleDiagnostic( s_preamble + test, 43, 9, MutabilityInspectionResult.Mutable(
 				"bad",
 				"System.DateTime",
 				MutabilityTarget.Member,
@@ -77,10 +104,8 @@ namespace D2L.CodeStyle.Annotations {
 		[Test]
 		public void DocumentWithStatic_ClassIsNotImmutableButImplementsImmutableInterfaceInChain_Diag() {
 			const string test = @"
-	using System;
-
 	namespace test {
-		[Objects.Immutable] interface IFooBase {} 
+		[Immutable] interface IFooBase {} 
 		interface IFoo : IFooBase {} 
 		class Test : IFoo {
 
@@ -89,7 +114,7 @@ namespace D2L.CodeStyle.Annotations {
 
 		}
 	}";
-			AssertSingleDiagnostic( s_preamble + test, 14, 9, MutabilityInspectionResult.Mutable( 
+			AssertSingleDiagnostic( s_preamble + test, 44, 9, MutabilityInspectionResult.Mutable( 
 				"bad",
 				"System.DateTime",
 				MutabilityTarget.Member,
@@ -100,10 +125,8 @@ namespace D2L.CodeStyle.Annotations {
 		[Test]
 		public void DocumentWithStatic_ClassIsImmutableAndImplementsImmutableInterface_NoDiag() {
 			const string test = @"
-	using System;
-
 	namespace test {
-		[Objects.Immutable] interface IFooBase {} 
+		[Immutable] interface IFooBase {} 
 		interface IFoo : IFooBase {} 
 		class Test : IFoo {
 
@@ -114,6 +137,291 @@ namespace D2L.CodeStyle.Annotations {
 	}";
 			AssertNoDiagnostic( s_preamble + test );
 		}
+
+		#region Unaudited Reason Verification Diagnostic
+
+		[Test]
+		public void DocumentWithStatic_ClassIsImmutableWithNoExceptionsAndHasUnauditedField_NoDiag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable]
+		class Test {
+ 
+			[Mutability.Unaudited( Because.ItsUgly )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			AssertNoDiagnostic( s_preamble + test );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassIsImmutableWithExceptionsAndHasUnauditedFieldThatIsExcepted_NoDiag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItsUgly )]
+		class Test {
+ 
+			[Mutability.Unaudited( Because.ItsUgly )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			AssertNoDiagnostic( s_preamble + test );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassIsImmutableWithExceptionsAndHasUnauditedFieldThatIsNotExcepted_Diag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItsUgly )]
+		class Test {
+ 
+			[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test, new[] {
+				new DiagnosticResult {
+					Id = Diagnostics.InvalidUnauditedReasonInImmutable.Id,
+					Message = "One or more members on this type have unaudited reasons that are not excepted. Resolve the Unaudited members or relax exceptions on this type to a superset of { ItHasntBeenLookedAt }.",
+					Locations = new [] {
+						new DiagnosticResultLocation( "Test0.cs", line: 45, column: 9 )
+					},
+					Severity = DiagnosticSeverity.Error
+				}
+			} );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassImplementsImmutableInterfaceWithExceptionsAndHasUnauditedFieldThatIsNotExcepted_Diag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItsUgly )]
+		interface ITest { }
+ 
+		class Test : ITest {
+ 
+			[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test, new[] {
+				new DiagnosticResult {
+					Id = Diagnostics.InvalidUnauditedReasonInImmutable.Id,
+					Message = "One or more members on this type have unaudited reasons that are not excepted. Resolve the Unaudited members or relax exceptions on this type to a superset of { ItHasntBeenLookedAt }.",
+					Locations = new [] {
+						new DiagnosticResultLocation( "Test0.cs", line: 47, column: 9 )
+					},
+					Severity = DiagnosticSeverity.Error
+				}
+			} );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassImplementsMultipleImmutableInterfaceWithExceptionsAndHasUnauditedFieldThatIsNotExcepted_Diag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItsUgly )]
+		interface ITest { }
+ 
+		[Immutable( Except = Except.ItsSketchy | Except.ItsUgly )]
+		interface ITest2 { }
+ 
+		class Test : ITest, ITest2 {
+ 
+			[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test, new[] {
+				new DiagnosticResult {
+					Id = Diagnostics.InvalidUnauditedReasonInImmutable.Id,
+					Message = "One or more members on this type have unaudited reasons that are not excepted. Resolve the Unaudited members or relax exceptions on this type to a superset of { ItHasntBeenLookedAt }.",
+					Locations = new [] {
+						new DiagnosticResultLocation( "Test0.cs", line: 50, column: 9 )
+					},
+					Severity = DiagnosticSeverity.Error
+				}
+			} );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassImplementsMultipleImmutableInterfaceWithExceptionsAndHasUnauditedFieldThatIsOnlyExceptedByOne_Diag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt )]
+		interface ITest { }
+ 
+		[Immutable( Except = Except.None )]
+		interface ITest2 { }
+ 
+		class Test : ITest, ITest2 {
+ 
+			[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test, new[] {
+				new DiagnosticResult {
+					Id = Diagnostics.InvalidUnauditedReasonInImmutable.Id,
+					Message = "One or more members on this type have unaudited reasons that are not excepted. Resolve the Unaudited members or relax exceptions on this type to a superset of { ItHasntBeenLookedAt }.",
+					Locations = new [] {
+						new DiagnosticResultLocation( "Test0.cs", line: 50, column: 9 )
+					},
+					Severity = DiagnosticSeverity.Error
+				}
+			} );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassImplementsMultipleImmutableInterfaceWithExceptionsAndHasUnauditedFieldThatIsExceptedByBoth_NoDiag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt )]
+		interface ITest { }
+ 
+		[Immutable( Except = Except.ItsUgly | Except.ItHasntBeenLookedAt )]
+		interface ITest2 { }
+ 
+		class Test : ITest, ITest2 {
+ 
+			[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassImplementsImmutableInterfaceWithExceptionsAndHasItsOwnImmutableExceptionsAndHasUnauditedFieldThatIsNotExcepted_Diag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt | Except.ItsUgly )]
+		interface ITest { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt )]
+		class Test : ITest {
+ 
+			[Mutability.Unaudited( Because.ItsSketchy )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test, new[] {
+				new DiagnosticResult {
+					Id = Diagnostics.InvalidUnauditedReasonInImmutable.Id,
+					Message = "One or more members on this type have unaudited reasons that are not excepted. Resolve the Unaudited members or relax exceptions on this type to a superset of { ItsSketchy }.",
+					Locations = new [] {
+						new DiagnosticResultLocation( "Test0.cs", line: 48, column: 9 )
+					},
+					Severity = DiagnosticSeverity.Error
+				}
+			} );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassImplementsImmutableInterfaceWithExceptionsAndHasItsOwnImmutableExceptionsAndHasUnauditedFieldThatIsExceptedByBoth_NoDiag() {
+			const string test = @"
+	namespace test {
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt | Except.ItsUgly  )]
+		interface ITest { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt )]
+		class Test : ITest {
+ 
+			[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassHasImmutableMemberWithSameExceptions_NoDiag() {
+			const string test = @"
+	namespace test {
+		[Immutable( Except = Except.ItHasntBeenLookedAt )]
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt )]
+		class Test {
+ 
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassHasImmutableMemberWithSubsetOfExceptions_NoDiag() {
+			const string test = @"
+	namespace test {
+		[Immutable( Except = Except.ItHasntBeenLookedAt )]
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt | Except.ItsUgly )]
+		class Test {
+ 
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test );
+		}
+
+		[Test]
+		public void DocumentWithStatic_ClassHasImmutableMemberWithProperSupersetOfExceptions_Diag() {
+			const string test = @"
+	namespace test {
+		[Immutable( Except = Except.ItHasntBeenLookedAt | Except.ItsUgly )]
+		sealed class Foo { }
+ 
+		[Immutable( Except = Except.ItHasntBeenLookedAt )]
+		class Test {
+ 
+			public readonly Foo bad = default( Foo );
+ 
+		}
+	}";
+			VerifyCSharpDiagnostic( s_preamble + test, new[] {
+				new DiagnosticResult {
+					Id = Diagnostics.InvalidUnauditedReasonInImmutable.Id,
+					Message = "One or more members on this type have unaudited reasons that are not excepted. Resolve the Unaudited members or relax exceptions on this type to a superset of { ItHasntBeenLookedAt, ItsUgly }.",
+					Locations = new [] {
+						new DiagnosticResultLocation( "Test0.cs", line: 46, column: 9 )
+					},
+					Severity = DiagnosticSeverity.Error
+				}
+			} );
+		}
+
+		#endregion
 
 		private void AssertNoDiagnostic( string file ) {
 			VerifyCSharpDiagnostic( file );


### PR DESCRIPTION
This adds support to the analyzer to now report an error diagnostic if either:
a) a member is marked Unaudited with a reason not being excepted by the type
b) a member has a type that allows a proper superset of exceptions than the type it's a member in