### PR TITLE
Create MutabilityInspector.InspectConcreteType

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -56,10 +56,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			var flags = MutabilityInspectionFlags.Default 
-				| MutabilityInspectionFlags.AllowUnsealed // `symbol` is the concrete type
 				| MutabilityInspectionFlags.IgnoreImmutabilityAttribute; // we're _validating_ the attribute
 
-			var mutabilityResult = inspector.InspectType( symbol, flags );
+			var mutabilityResult = inspector.InspectConcreteType( symbol, flags );
 
 			if( mutabilityResult.IsMutable ) {
 				var reason = m_resultFormatter.Format( mutabilityResult );

--- a/src/D2L.CodeStyle.Analyzers/Immutability/UnsafeStaticsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/UnsafeStaticsAnalyzer.cs
@@ -310,13 +310,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				}
 			}
 
+			MutabilityInspectionResult result;
+
 			// When we know the concrete type as in "new T()" we don't have to
 			// be paranoid about mutable derived classes.
 			if ( initializationExpression is ObjectCreationExpressionSyntax ) {
-				flags |= MutabilityInspectionFlags.AllowUnsealed;
+				result = inspector.InspectConcreteType( fieldOrPropertyType, flags );
+			} else {
+				result = inspector.InspectType( fieldOrPropertyType, flags );
 			}
 
-			var result = inspector.InspectType( fieldOrPropertyType, flags );
 			if ( result.IsMutable ) {
 				result = result.WithPrefixedMember( fieldOrPropertyName );
 				yield return CreateDiagnostic( 


### PR DESCRIPTION
This moves all usage of AllowUnsealed into the mutability inspector. The
next step is to move the logic for AllowUnsealed "up" to
InspectConcreteType from InspectType and remove the flag entirely.