### PR TITLE
Fixing immutable generic

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -60,6 +60,12 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 		}
 
 		private static bool IsMarkedImmutableGeneric( this ITypeSymbol symbol ) {
+			AttributeData ignore;
+			return TryGetImmutableGenericAnnotation( symbol, out ignore );
+		}
+
+		private static bool TryGetImmutableGenericAnnotation( this ITypeSymbol symbol, out AttributeData attribute ) {
+			attribute = null;
 			var type = symbol as INamedTypeSymbol;
 			if( type == null ) {
 				return false;
@@ -73,8 +79,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 			 *  (1) symbol's assembly,
 			 *  (2) any of symbol's type arguments's assemblies
 			 */
-			AttributeData ignore;
-			if( type.ContainingAssembly.TryGetImmutableGenericAnnotation( type, out ignore ) ) {
+			if( type.ContainingAssembly.TryGetImmutableGenericAnnotation( type, out attribute ) ) {
 				return true;
 			}
 
@@ -85,11 +90,11 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 					continue;
 				}
 
-				if( typeArgument.ContainingAssembly.TryGetImmutableGenericAnnotation( type, out ignore ) ) {
+				if( typeArgument.ContainingAssembly.TryGetImmutableGenericAnnotation( type, out attribute ) ) {
 					return true;
 				}
 			}
-
+			attribute = null;
 			return false;
 		}
 
@@ -126,7 +131,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 			}
 
 			AttributeData immutableGeneric;
-			if( type.ContainingAssembly.TryGetImmutableGenericAnnotation( type, out immutableGeneric ) ) {
+			if( TryGetImmutableGenericAnnotation( type, out immutableGeneric ) ) {
 				yield return immutableGeneric;
 			}
 		}

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -104,7 +104,8 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 				}
 
 				var arg = attr.ConstructorArguments[0];
-				if( arg.Value.Equals( type ) ) {
+				//Using ToString, otherwise it sometimes fails to match, and the test behaviour does not match the real behaviour
+				if( arg.Value.ToString().Equals( type.ToString() ) ) {
 					attribute = attr;
 					return true;
 				}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -8,6 +8,10 @@ using D2L.LP.Extensibility.Activation.Domain;
 	type: typeof(SpecTests.GenericsTests.IFactory<Version>) 
 )]
 
+[assembly: Objects.ImmutableGeneric(
+	type: typeof( IComparable<SpecTests.GenericsTests.ILocallyDefined> )
+)]
+
 namespace D2L.LP.Extensibility.Activation.Domain {
 	public sealed class SingletonAttribute : Attribute { }
 }
@@ -111,6 +115,8 @@ namespace SpecTests {
 
 		interface IGenericImmutableWithTypeConstraint<T> : IImmutable where T : IImmutable { }
 
+		interface ILocallyDefined { }
+
 		class GenericClassWithoutStateIsSafe<T> : IGenericImmutable<T> { }
 
 		class /* ImmutableClassIsnt('foo''s type ('T') is a generic type) */ GenericClassWithStateIsUnsafe<T> /**/ : IGenericImmutable<T> {
@@ -189,6 +195,10 @@ namespace SpecTests {
 
 		public sealed class /* ImmutableClassIsnt('bad' is not read-only) */ MutableButSubClassesImmutableGeneric /**/ : IFactory<Version> {
 			private int bad;
+		}
+
+		public sealed class ImplementsImmutableGeneric : IComparable<ILocallyDefined> {
+			private readonly IImmutable m_safeDependency;
 		}
 		#endregion
 


### PR DESCRIPTION
The fix is small, but it was super annoying to find.

Basically, there was already an attempt to check for `ImmutableGeneric` in the `Except` analyzing code.  However, it used the wrong helper method to do the check, and ended up only checking the assembly containing the generic type, not the assembly containing the type param.  In practice, this meant that we could only do `ImmutableGeneric( type: typeof(IFactory<IFoo>))` in LP.Foundation where IFactory is defined.

On the spec tests, though, everything was in the same assembly, so the problem did not appear.

Further compounding this, when I tried to write tests to show the problem, the `Equals` method on `ITypeSymbol` was not behaving the way I expected it to.  When running against a real DLL in Visual Studio, it would correctly detect that the types were the same (between the inspected class and the ImmutableGeneric attribute on the class).  But in the tests, Equals was returning false, and I didn't see a reason why.  `ToString` returns a qualified type name, such as "SpecTests.GenericsTests.IFactory<System.Version>", which works in both tests and real code.