### PR TITLE
Add diagnostic type for unnecessary mutability annotations

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -261,5 +261,15 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true,
 			description: "The default constructor for ImmutableArray<T> doesn't correctly initialize the object and leads to runtime errors. Use ImmutableArray<T>.Empty for empty arrays, ImmutableArray.Create() for simple cases and ImmutableArray.Builder<T> for more complicated cases."
 		);
+
+		public static readonly DiagnosticDescriptor UnnecessaryMutabilityAnnotation = new DiagnosticDescriptor(
+			id: "D2L0030",
+			title: "Unnecessary mutability annotation should be removed to keep the code base clean",
+			messageFormat: "The {0} annotation is not necessary because {1} is immutable. Please remove this attribute to keep our code base clean.",
+			category: "Cleanliness",
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: "Unnecessary mutability annotations should be removed to keep the code base clean"
+		);
 	}
 }


### PR DESCRIPTION
Sample message may look like:

-----

The `Mutability.Audited` annotation is not necessary because `fieldName` is immutable. Please remove this attribute to keep our code base clean.