### PR TITLE
Remove duplicated logic in UnsafeStaticsAnalyzer

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -103,6 +103,12 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			return InspectConcreteType( type, typesInCurrentCycle, flags );
 		}
 
+		public MutabilityInspectionResult InspectMember( ISymbol symbol ) {
+			var seen = new HashSet<ITypeSymbol>();
+
+			return InspectMemberRecursive( symbol, seen );
+		}
+
 		private MutabilityInspectionResult InspectType(
 			ITypeSymbol type,
 			MutabilityInspectionFlags flags,


### PR DESCRIPTION
Next step for this analyzer is to merge it with the ImmutabilityAnalyzer to enable some future simplifications to MutabilityInspector (dropping the flags) and sharing a cache.