### PR TITLE
Test Nested Mutability.Unaudited Reasons

### DIFF
--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
@@ -478,6 +478,25 @@ sealed class Foo {
 		}
 
 		[Test]
+		public void InspectType_TypeHasUniqueNestedUnauditedMembers_DoesNotReturnNestedUnauditedReasonsAsSeenUnauditedReasons() {
+
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+	[Mutability.Unaudited( Because.ItsSketchy )]
+	public Bar XYZ { get; }
+}
+
+sealed class Bar {
+	[Mutability.Unaudited( Because.ItsUgly )]
+	public Func<string> Baz { get; }
+}";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			AssertUnauditedReasonsResult( ty, "ItsSketchy" );
+		}
+
+		[Test]
 		public void InspectType_TypeHasUnauditedMembersAndDefaultImmutableMember_ReturnsDefaultImmutabilityExceptionsAsSeenUnauditedReasons() {
 			const string source = AnnotationsPreamble + @"
 sealed class Foo {


### PR DESCRIPTION
Adding this test to ensure when I choose to analyze past `Mutability.Unaudited` and `Mutability.Audited` we don't accidentally surface nested unaudited reasons. This would break current behaviour around the "Immutable Except" logic.