### PR TITLE
Add associated symbol to MutabilityInspectionResult

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResult.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResult.cs
@@ -23,13 +23,13 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 	public sealed class MutabilityInspectionResult {
 
-		private readonly static MutabilityInspectionResult s_notMutableResult = new MutabilityInspectionResult( false, null, null, null, null, ImmutableHashSet<string>.Empty );
-
 		public bool IsMutable { get; }
 
 		public string MemberPath { get; }
 
 		public string TypeName { get; }
+
+		public ISymbol Symbol { get; }
 
 		public MutabilityCause? Cause { get; }
 
@@ -41,6 +41,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			bool isMutable,
 			string memberPath,
 			string typeName,
+			ISymbol symbol,
 			MutabilityTarget? target,
 			MutabilityCause? cause,
 			ImmutableHashSet<string> seenUnauditedReasons
@@ -48,27 +49,41 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			IsMutable = isMutable;
 			MemberPath = memberPath;
 			TypeName = typeName;
+			Symbol = symbol;
 			Target = target;
 			Cause = cause;
 			SeenUnauditedReasons = seenUnauditedReasons;
 		}
 
-		public static MutabilityInspectionResult NotMutable() {
-			return s_notMutableResult;
+		public static MutabilityInspectionResult NotMutable( ISymbol symbol ) {
+			return new MutabilityInspectionResult(
+				isMutable: false,
+				memberPath: null,
+				typeName: null,
+				symbol: symbol,
+				target: null,
+				cause: null,
+				seenUnauditedReasons: ImmutableHashSet<string>.Empty
+			); ;
 		}
 
-		public static MutabilityInspectionResult NotMutable( ImmutableHashSet<string> seenUnauditedReasons ) {
+		public static MutabilityInspectionResult NotMutable(
+			ISymbol symbol,
+			ImmutableHashSet<string> seenUnauditedReasons
+		) {
 			return new MutabilityInspectionResult(
-					false,
-					null,
-					null,
-					null,
-					null,
-					seenUnauditedReasons
+					isMutable: false,
+					memberPath: null,
+					typeName: null,
+					symbol: symbol,
+					target: null,
+					cause: null,
+					seenUnauditedReasons: seenUnauditedReasons
 				);
 		}
 
 		public static MutabilityInspectionResult Mutable(
+			ISymbol symbol,
 			string mutableMemberPath,
 			string membersTypeName,
 			MutabilityTarget kind,
@@ -78,6 +93,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				true,
 				mutableMemberPath,
 				membersTypeName,
+				symbol,
 				kind,
 				cause,
 				ImmutableHashSet<string>.Empty
@@ -89,6 +105,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			MutabilityCause cause
 		) {
 			return Mutable(
+				type,
 				null,
 				type.GetFullTypeName(),
 				MutabilityTarget.Type,
@@ -101,6 +118,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			MutabilityCause cause
 		) {
 			return Mutable(
+				field,
 				field.Name,
 				field.Type.GetFullTypeName(),
 				MutabilityTarget.Member,
@@ -113,6 +131,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			MutabilityCause cause
 		) {
 			return Mutable(
+				property,
 				property.Name,
 				property.Type.GetFullTypeName(),
 				MutabilityTarget.Member,
@@ -124,6 +143,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			ISymbol member
 		) {
 			return Mutable(
+				member,
 				member.Name,
 				null,
 				MutabilityTarget.Member,
@@ -144,6 +164,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				this.IsMutable,
 				newMember,
 				this.TypeName,
+				this.Symbol,
 				this.Target,
 				this.Cause,
 				this.SeenUnauditedReasons
@@ -155,6 +176,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				this.IsMutable,
 				this.MemberPath,
 				this.TypeName,
+				this.Symbol,
 				newTarget,
 				this.Cause,
 				this.SeenUnauditedReasons

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -382,12 +382,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			ExpressionSyntax expr,
 			HashSet<ITypeSymbol> typeStack
 		) {
-			if( expr.Kind() == SyntaxKind.NullLiteralExpression ) {
-				// This is perhaps a bit suspicious, because fields and
-				// properties have to be readonly, but it is safe...
-				return MutabilityInspectionResult.NotMutable( null );
-			}
-
 			var model = m_compilation.GetSemanticModel( expr.SyntaxTree );
 
 			var typeInfo = model.GetTypeInfo( expr );
@@ -396,6 +390,12 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// the expression alone doesn't have a type. For example:
 			//   int[] foo = { 1, 2, 3 };
 			var exprType = typeInfo.Type ?? typeInfo.ConvertedType;
+
+			if( expr.Kind() == SyntaxKind.NullLiteralExpression ) {
+				// This is perhaps a bit suspicious, because fields and
+				// properties have to be readonly, but it is safe...
+				return MutabilityInspectionResult.NotMutable( exprType );
+			}
 
 			if( expr is ObjectCreationExpressionSyntax ) {
 				// If our initializer is "new Foo( ... )" we only need to

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -134,7 +134,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				// This only happens for code that otherwise won't compile. Our
 				// analyzer doesn't need to validate these types. It only needs
 				// to be strict for valid code.
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( type );
 			}
 
 			if( type == null ) {
@@ -146,11 +146,11 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			var scope = type.GetImmutabilityScope();
 			if( !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && scope == ImmutabilityScope.SelfAndChildren ) {
 				ImmutableHashSet<string> immutableExceptions = type.GetAllImmutableExceptions();
-				return MutabilityInspectionResult.NotMutable( immutableExceptions );
+				return MutabilityInspectionResult.NotMutable( type, immutableExceptions );
 			}
 
 			if( m_knownImmutableTypes.IsTypeKnownImmutable( type ) ) {
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( type );
 			}
 
 			if( IsAnImmutableContainerType( type ) ) {
@@ -189,7 +189,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 				case TypeKind.Enum:
 					// Enums are just fancy ints.
-					return MutabilityInspectionResult.NotMutable();
+					return MutabilityInspectionResult.NotMutable( type );
 
 				case TypeKind.TypeParameter:
 					return InspectTypeParameter(
@@ -212,7 +212,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					// (more fundamental) reasons. We only need to be strict
 					// for otherwise-successful builds, so we bail analysis in
 					// this case.
-					return MutabilityInspectionResult.NotMutable();
+					return MutabilityInspectionResult.NotMutable( type );
 
 				case TypeKind.Unknown:
 					// Looking at the Roslyn source this doesn't appear to
@@ -234,24 +234,24 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			MutabilityInspectionFlags flags = MutabilityInspectionFlags.Default
 		) {
 			if( type is IErrorTypeSymbol ) {
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( type );
 			}
 
 			// The concrete type System.Object is empty (and therefore safe.)
 			// For example, `private readonly object m_lock = new object();` is fine. 
 			if( type.SpecialType == SpecialType.System_Object ) {
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( type );
 			}
 
 			// System.ValueType is the base class of all value types (obscure detail)
 			if( type.SpecialType == SpecialType.System_ValueType ) {
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( type );
 			}
 
 			var scope = type.GetImmutabilityScope();
 			if( !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && scope != ImmutabilityScope.None ) {
 				ImmutableHashSet<string> immutableExceptions = type.GetAllImmutableExceptions();
-				return MutabilityInspectionResult.NotMutable( immutableExceptions );
+				return MutabilityInspectionResult.NotMutable( type, immutableExceptions );
 			}
 
 			return InspectType(
@@ -270,7 +270,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				// or a generic parameter to a type causes the cycle (via IsTypeMutableRecursive). This is safe if the checks above have 
 				// passed and the remaining members are read-only immutable. So we can skip the current check, and allow the type to continue 
 				// to be evaluated.
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( type );
 			}
 
 			// We have a type that is not marked immutable, is not an interface, is not an immutable container, etc..
@@ -304,7 +304,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				typeStack.Remove( type );
 			}
 
-			return MutabilityInspectionResult.NotMutable( seenUnauditedReasonsBuilder.ToImmutable() );
+			return MutabilityInspectionResult.NotMutable( type, seenUnauditedReasonsBuilder.ToImmutable() );
 		}
 
 		private bool IsAnImmutableContainerType( ITypeSymbol type ) {
@@ -346,7 +346,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				unauditedReasonsBuilder.UnionWith( result.SeenUnauditedReasons );
 			}
 
-			return MutabilityInspectionResult.NotMutable( unauditedReasonsBuilder.ToImmutable() );
+			return MutabilityInspectionResult.NotMutable( type, unauditedReasonsBuilder.ToImmutable() );
 		}
 
 		private MutabilityInspectionResult InspectTypeParameter(
@@ -385,7 +385,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			if( expr.Kind() == SyntaxKind.NullLiteralExpression ) {
 				// This is perhaps a bit suspicious, because fields and
 				// properties have to be readonly, but it is safe...
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( null );
 			}
 
 			var model = m_compilation.GetSemanticModel( expr.SyntaxTree );
@@ -419,7 +419,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			if( property.IsIndexer ) {
 				// Indexer properties are just glorified method syntax and dont' hold state
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( property );
 			}
 
 			var propertySyntax =
@@ -431,7 +431,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				// backing field that may be mutable. Otherwise, properties are
 				// just sugar for getter/setter methods and don't themselves
 				// contribute to mutability.
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( property );
 			}
 
 			if( !property.IsReadOnly ) {
@@ -523,11 +523,11 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		) {
 			// if the member is audited or unaudited, ignore it
 			if( Attributes.Mutability.Audited.IsDefined( symbol ) ) {
-				return MutabilityInspectionResult.NotMutable();
+				return MutabilityInspectionResult.NotMutable( symbol );
 			}
 			if( Attributes.Mutability.Unaudited.IsDefined( symbol ) ) {
 				string unauditedReason = BecauseHelpers.GetUnauditedReason( symbol );
-				return MutabilityInspectionResult.NotMutable( ImmutableHashSet.Create( unauditedReason ) );
+				return MutabilityInspectionResult.NotMutable( symbol, ImmutableHashSet.Create( unauditedReason ) );
 			}
 
 			switch( symbol.Kind ) {
@@ -546,7 +546,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case SymbolKind.Method:
 				case SymbolKind.NamedType:
 					// ignore these symbols, because they do not contribute to immutability
-					return MutabilityInspectionResult.NotMutable();
+					return MutabilityInspectionResult.NotMutable( symbol );
 
 				default:
 					// we've got a member (event, etc.) that we can't currently be smart about, so fail

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/ImmutabilityAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/ImmutabilityAnalyzerTests.cs
@@ -43,6 +43,7 @@ namespace D2L.CodeStyle.Annotations {
 		}
 	}";
 			AssertSingleDiagnostic( s_preamble + test, 13, 9, MutabilityInspectionResult.Mutable(
+				null,
 				"bad",
 				"System.DateTime",
 				MutabilityTarget.Member,
@@ -63,6 +64,7 @@ namespace D2L.CodeStyle.Annotations {
 		}
 	}";
 			AssertSingleDiagnostic( s_preamble + test, 13, 9, MutabilityInspectionResult.Mutable(
+				null,
 				"bad",
 				"System.DateTime",
 				MutabilityTarget.Member,
@@ -83,7 +85,8 @@ namespace D2L.CodeStyle.Annotations {
 
 		}
 	}";
-			AssertSingleDiagnostic( s_preamble + test, 14, 9, MutabilityInspectionResult.Mutable( 
+			AssertSingleDiagnostic( s_preamble + test, 14, 9, MutabilityInspectionResult.Mutable(
+				null,
 				"bad",
 				"System.DateTime",
 				MutabilityTarget.Member,

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectionResultFormatterTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectionResultFormatterTests.cs
@@ -9,88 +9,88 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 		private static readonly IEnumerable<TestCaseData> m_testCases = new[] {
 			new TestCaseData(
-				MutabilityInspectionResult.NotMutable(),
+				MutabilityInspectionResult.NotMutable( null ),
 				string.Empty
 			).SetName("not mutable"),
 
             // field cases
 
             new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Member, MutabilityCause.IsNotReadonly),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.Member, MutabilityCause.IsNotReadonly),
 				"'foo' is not read-only"
 			).SetName("field is not read-only"),
 
             // type cases
 
             new TestCaseData(
-				MutabilityInspectionResult.Mutable(null, "bar", MutabilityTarget.Type, MutabilityCause.IsAnArray),
+				MutabilityInspectionResult.Mutable(null, null, "bar", MutabilityTarget.Type, MutabilityCause.IsAnArray),
 				"its type ('bar') is an array"
 			).SetName("type is an array, null member"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("", "bar", MutabilityTarget.Type, MutabilityCause.IsAnArray),
+				MutabilityInspectionResult.Mutable(null, "", "bar", MutabilityTarget.Type, MutabilityCause.IsAnArray),
 				"its type ('bar') is an array"
 			).SetName("type is an array, empty member"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsAnArray),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.Type, MutabilityCause.IsAnArray),
 				"'foo''s type ('bar') is an array"
 			).SetName("type is an array"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsDynamic),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.Type, MutabilityCause.IsDynamic),
 				"'foo''s type ('bar') is dynamic"
 			).SetName("type is dynamic"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsAnInterface),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.Type, MutabilityCause.IsAnInterface),
 				"'foo''s type ('bar') is an interface that is not marked with `[Objects.Immutable]`"
 			).SetName("type is an interface"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsNotSealed),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.Type, MutabilityCause.IsNotSealed),
 				"'foo''s type ('bar') is not sealed"
 			).SetName("type is not sealed"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.Type, MutabilityCause.IsPotentiallyMutable),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.Type, MutabilityCause.IsPotentiallyMutable),
 				"'foo''s type ('bar') is not deterministically immutable"
 			).SetName("type is not not deterministically immutable"),
 
             // type argument cases
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable(null, "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnArray),
+				MutabilityInspectionResult.Mutable(null, null, "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnArray),
 				"its type argument ('bar') is an array"
 			).SetName("type argument is an array, null member"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnArray),
+				MutabilityInspectionResult.Mutable(null, "", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnArray),
 				"its type argument ('bar') is an array"
 			).SetName("type argument is an array, empty member"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnArray),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnArray),
 				"'foo''s type argument ('bar') is an array"
 			).SetName("type argument is an array"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsDynamic),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsDynamic),
 				"'foo''s type argument ('bar') is dynamic"
 			).SetName("type argument is dynamic"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnInterface),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsAnInterface),
 				"'foo''s type argument ('bar') is an interface that is not marked with `[Objects.Immutable]`"
 			).SetName("type argument is an interface"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsNotSealed),
+				MutabilityInspectionResult.Mutable(null,"foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsNotSealed),
 				"'foo''s type argument ('bar') is not sealed"
 			).SetName("type argument is not sealed"),
 
 			new TestCaseData(
-				MutabilityInspectionResult.Mutable("foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsPotentiallyMutable),
+				MutabilityInspectionResult.Mutable(null, "foo", "bar", MutabilityTarget.TypeArgument, MutabilityCause.IsPotentiallyMutable),
 				"'foo''s type argument ('bar') is not deterministically immutable"
 			).SetName("type argument is not not deterministically immutable"),
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
@@ -10,15 +10,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_PrimitiveType_NotMutable() {
 			var field = Field( "uint foo" );
+			var typeToInspect = field.Symbol.Type;
 
 			var inspector = new MutabilityInspector(
 				field.Compilation,
 				KnownImmutableTypes.Default
 			);
 
-			var expected = MutabilityInspectionResult.NotMutable();
+			var expected = MutabilityInspectionResult.NotMutable( typeToInspect );
 
-			var actual = inspector.InspectType( field.Symbol.Type );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -26,15 +27,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_NullablePrimitiveType_NotMutable() {
 			var field = Field( "uint? foo" );
+			var typeToInspect = field.Symbol.Type;
 
 			var inspector = new MutabilityInspector(
 				field.Compilation,
 				KnownImmutableTypes.Default
 			);
 
-			var expected = MutabilityInspectionResult.NotMutable();
+			var expected = MutabilityInspectionResult.NotMutable( typeToInspect );
 
-			var actual = inspector.InspectType( field.Symbol.Type );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -56,7 +58,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				KnownImmutableTypes.Default
 			);
 
-			var expected = MutabilityInspectionResult.NotMutable();
+			var expected = MutabilityInspectionResult.NotMutable( realType );
 
 			var actual = inspector.InspectType( realType );
 
@@ -66,7 +68,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_ArrayType_True() {
 			var field = Field( "int[] random" );
+			var typeToInspect = field.Symbol.Type;
+
 			var expected = MutabilityInspectionResult.Mutable(
+				typeToInspect,
 				null,
 				"System.Int32[]",
 				MutabilityTarget.Type,
@@ -78,7 +83,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				KnownImmutableTypes.Default
 			);
 
-			var actual = inspector.InspectType( field.Symbol.Type );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -86,15 +91,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_KnownImmutableType_False() {
 			var field = Field( "string random" );
+			var typeToInspect = field.Symbol.Type;
 
 			var inspector = new MutabilityInspector(
 				field.Compilation,
 				KnownImmutableTypes.Default
 			);
 
-			var expected = MutabilityInspectionResult.NotMutable();
+			var expected = MutabilityInspectionResult.NotMutable( typeToInspect );
 
-			var actual = inspector.InspectType( field.Symbol.Type );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -102,6 +108,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_Interface_True() {
 			var type = Type( "interface foo {}" );
+			var typeToInspect = type.Symbol;
 
 			var inspector = new MutabilityInspector(
 				type.Compilation,
@@ -109,13 +116,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			var expected = MutabilityInspectionResult.Mutable(
+				typeToInspect,
 				null,
 				$"{RootNamespace}.foo",
 				MutabilityTarget.Type,
 				MutabilityCause.IsAnInterface
 			);
 
-			var actual = inspector.InspectType( type.Symbol );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -123,15 +131,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_Enum_False() {
 			var type = Type( "enum blah {}" );
+			var typeToInspect = type.Symbol;
 
 			var inspector = new MutabilityInspector(
 				type.Compilation,
 				KnownImmutableTypes.Default
 			);
 
-			var expected = MutabilityInspectionResult.NotMutable();
+			var expected = MutabilityInspectionResult.NotMutable( typeToInspect );
 
-			var actual = inspector.InspectType( type.Symbol );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -146,6 +155,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			var expected = MutabilityInspectionResult.Mutable(
+				type.Symbol,
 				null,
 				$"{RootNamespace}.foo",
 				MutabilityTarget.Type,
@@ -160,15 +170,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_SealedClass_False() {
 			var type = Type( "sealed class foo {}" );
+			var typeToInspect = type.Symbol;
 
 			var inspector = new MutabilityInspector(
 				type.Compilation,
 				KnownImmutableTypes.Default
 			);
 
-			var expected = MutabilityInspectionResult.NotMutable();
+			var expected = MutabilityInspectionResult.NotMutable( typeToInspect );
 
-			var actual = inspector.InspectType( type.Symbol );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -183,6 +194,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			var expected = MutabilityInspectionResult.Mutable(
+				field.Symbol,
 				"random",
 				"System.String",
 				MutabilityTarget.Member,
@@ -197,6 +209,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_DoesNotLookAtMembersInExternalType() {
 			var field = Field( "public readonly System.Text.StringBuilder random" );
+			var typeToInspect = field.Symbol.Type;
 
 			var inspector = new MutabilityInspector(
 				field.Compilation,
@@ -204,13 +217,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			var expected = MutabilityInspectionResult.Mutable(
+				typeToInspect,
 				null,
 				"System.Text.StringBuilder",
 				MutabilityTarget.Type,
 				MutabilityCause.IsAnExternalUnmarkedType
 			);
 
-			var actual = inspector.InspectType( field.Symbol.Type );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -225,6 +239,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			var expected = MutabilityInspectionResult.Mutable(
+				field.Symbol,
 				"random",
 				"System.String",
 				MutabilityTarget.Member,
@@ -246,6 +261,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			var expected = MutabilityInspectionResult.Mutable(
+				prop.Symbol,
 				"random",
 				"System.String",
 				MutabilityTarget.Member,
@@ -260,15 +276,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_ImmutableGenericCollectionWithValueTypeElement_ReturnsFalse() {
 			var field = Field( "private readonly System.Collections.Immutable.ImmutableArray<int> random" );
+			var typeToInspect = field.Symbol.Type;
 
 			var inspector = new MutabilityInspector(
 				field.Compilation,
 				KnownImmutableTypes.Default
 			);
 
-			var expected = MutabilityInspectionResult.NotMutable();
+			var expected = MutabilityInspectionResult.NotMutable( typeToInspect );
 
-			var actual = inspector.InspectType( field.Symbol.Type );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -276,15 +293,16 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		[Test]
 		public void InspectType_IEnumerableGenericCollectionWithImmutableElement_ReturnsFalse() {
 			var field = Field( "private readonly System.Collections.Generic.IEnumerable<int> random" );
+			var typeToInspect = field.Symbol.Type;
 
 			var inspector = new MutabilityInspector(
 				field.Compilation,
 				KnownImmutableTypes.Default
 			);
 
-			var expected = MutabilityInspectionResult.NotMutable();
+			var expected = MutabilityInspectionResult.NotMutable( typeToInspect );
 
-			var actual = inspector.InspectType( field.Symbol.Type );
+			var actual = inspector.InspectType( typeToInspect );
 
 			AssertResultsAreEqual( expected, actual );
 		}
@@ -299,6 +317,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			var expected = MutabilityInspectionResult.Mutable(
+				prop.Symbol.Type,
 				"StringGetter",
 				"System.Func",
 				MutabilityTarget.Type,
@@ -618,6 +637,7 @@ sealed class Baz { }
 			);
 
 			var expected = MutabilityInspectionResult.NotMutable(
+				ty.Symbol,
 				ImmutableHashSet.Create( expectedUnauditedReasons )
 			);
 
@@ -631,6 +651,7 @@ sealed class Baz { }
 			Assert.AreEqual( expected.MemberPath, actual.MemberPath, "MemberPath does not match" );
 			Assert.AreEqual( expected.Target, actual.Target, "Target does not match" );
 			Assert.AreEqual( expected.Cause, actual.Cause, "Cause does not match" );
+			Assert.AreEqual( expected.Symbol, actual.Symbol, "TypeName does not match" );
 			Assert.AreEqual( expected.TypeName, actual.TypeName, "TypeName does not match" );
 			CollectionAssert.AreEquivalent( expected.SeenUnauditedReasons, actual.SeenUnauditedReasons, "SeenUnauditedReasons did not match" );
 		}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
@@ -329,6 +329,22 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			AssertResultsAreEqual( expected, actual );
 		}
 
+		[Test]
+		public void InspectField_StringInitializedNull_NotMutable() {
+			var field = Field( "public readonly string NullStringInitialized = null" );
+
+			var inspector = new MutabilityInspector(
+				field.Compilation,
+				KnownImmutableTypes.Default
+			);
+
+			var expected = MutabilityInspectionResult.NotMutable( field.Symbol.Type );
+
+			var actual = inspector.InspectField( field.Symbol );
+
+			AssertResultsAreEqual( expected, actual );
+		}
+
 		private const string AnnotationsPreamble = @"
 using System;
 using System.Collections.Generic;

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/UnsafeStaticsAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/UnsafeStaticsAnalyzerTests.cs
@@ -82,13 +82,16 @@ namespace D2L.CodeStyle.Annotations {
 
         }
     }";
+
 			var diag1 = CreateDiagnosticResult( 20, 44, "Default", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "Default.uhoh",
 				membersTypeName: "test.Tests.Foo",
 				kind: MutabilityTarget.Member,
 				cause: MutabilityCause.IsNotReadonly
 			) );
 			var diag2 = CreateDiagnosticResult( 22, 40, "good", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "good.uhoh",
 				membersTypeName: "test.Tests.Foo",
 				kind: MutabilityTarget.Member,
@@ -114,6 +117,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 22, 31, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad",
 				membersTypeName: "test.Tests.Foo",
 				kind: MutabilityTarget.Member,
@@ -179,6 +183,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 22, 40, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad.ClientsName",
 				membersTypeName: "test.Tests.Foo",
 				kind: MutabilityTarget.Member,
@@ -226,6 +231,7 @@ namespace D2L.CodeStyle.Annotations {
 			// inside GetFoo to see that its returning a concrete Foo and
 			// not some derived class.
 			AssertSingleDiagnostic( s_preamble + test, 22, 40, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad",
 				membersTypeName: "test.Tests.Foo",
 				kind: MutabilityTarget.Type,
@@ -330,6 +336,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 23, 41, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad.ClientsName",
 				membersTypeName: "System.String",
 				kind: MutabilityTarget.Member,
@@ -349,6 +356,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 17, 61, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad",
 				membersTypeName: "System.Collections.IList",
 				kind: MutabilityTarget.Type,
@@ -368,6 +376,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 17, 76, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad",
 				membersTypeName: "System.Collections.Generic.List",
 				kind: MutabilityTarget.Type,
@@ -387,6 +396,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 17, 87, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad",
 				membersTypeName: "System.Object",
 				kind: MutabilityTarget.TypeArgument,
@@ -445,6 +455,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 22, 13, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad",
 				membersTypeName: "test.Tests.Foo",
 				kind: MutabilityTarget.Member,
@@ -510,6 +521,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 22, 13, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad.ClientsName",
 				membersTypeName: "System.String",
 				kind: MutabilityTarget.Member,
@@ -569,6 +581,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 22, 13, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad",
 				membersTypeName: "test.Tests.Foo",
 				kind: MutabilityTarget.Member,
@@ -658,6 +671,7 @@ namespace D2L.CodeStyle.Annotations {
         }
     }";
 			AssertSingleDiagnostic( s_preamble + test, 23, 13, "bad", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "bad.ClientsName",
 				membersTypeName: "System.String",
 				kind: MutabilityTarget.Member,
@@ -701,6 +715,7 @@ namespace D2L.CodeStyle.Annotations {
 	}";
 
 			AssertSingleDiagnostic( s_preamble + test, 18, 41, "foo", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "foo.Instance",
 				membersTypeName: "test.Tests.Foo",
 				kind: MutabilityTarget.Member,
@@ -773,6 +788,7 @@ namespace D2L.CodeStyle.Annotations {
 	}";
 
 			AssertSingleDiagnostic( s_preamble + test, 23, 36, "foo", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "foo",
 				membersTypeName: "test.Tests.Safe",
 				kind: MutabilityTarget.Type,
@@ -834,6 +850,7 @@ namespace D2L.CodeStyle.Annotations {
 		}
 	}";
 			AssertSingleDiagnostic( s_preamble + test, 26, 32, "foo", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "foo.x",
 				membersTypeName: "System.Int32",
 				kind: MutabilityTarget.Member,
@@ -936,6 +953,7 @@ namespace test {
     }
 }";
 			AssertSingleDiagnostic( s_preamble + test, 15, 9, "PropertyWithSetter", MutabilityInspectionResult.Mutable(
+				null,
 				mutableMemberPath: "PropertyWithSetter",
 				membersTypeName: "Widget",
 				kind: MutabilityTarget.Member,


### PR DESCRIPTION
Save the symbol that was inspected in the `MutabilityInspectionResult`. 

In next PR I can refactor properties `MemberPath` ~and `TypeName`~, should be able to get this from the symbol. After that we can get the violating location from the symbol. Then more to come...

With these changes when you have a `MutabilityInspectionResult.NotMutable` you will know what is not mutable (same goes for mutable). This approach should allow us to structure the `MutabilityInspectionResult` to be nested (can capture results past first violation). I am planning to get the location of the violation from the symbol itself.

I don't think it makes sense for the Mutability inspector to return a `IEnumerable<MutabilityInspectionResult>` because its recursive nature will make things confusing. For example `InspectClassOrStruct` might seem intuitive to return `IEnumerable<MutabilityInspectionResult>`  but I would not expect that return type for `InspectProperty`.

There should be no change is how current logic works, except that you are adding the appropriate symbol the the `MutabilityInspectionResult`. Hope the explanation conveys what I'm trying to do.