### PR TITLE
Missed a necessary exemption (ContentHttpHandlerMapper)

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Visibility/CorsHeaderAppenderUsageAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Visibility/CorsHeaderAppenderUsageAnalyzer.cs
@@ -135,6 +135,7 @@ namespace D2L.CodeStyle.Analyzers.Visibility {
 		/// </summary>
 		private static readonly ImmutableHashSet<string> WhitelistedClasses = new HashSet<string> {
 			"D2L.LP.Web.ContentHandling.Handlers.ContentHttpHandler",
+			"D2L.LP.Web.ContentHandling.Mapping.ContentHttpHandlerMapper",
 			"D2L.LP.Web.Files.FileViewing.StreamFileViewerResult",
 			"D2L.LP.Web.Files.FileViewing.Default.StreamFileViewerResultFactory"
 		}.ToImmutableHashSet();

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/CorsHeaderAppenderUsageAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/CorsHeaderAppenderUsageAnalyzer.cs
@@ -32,6 +32,18 @@ namespace D2L.LP.Web.ContentHandling.Handlers {
 
 }
 
+namespace D2L.LP.Web.ContentHandling.Mapping {
+
+	public class ContentHttpHandlerMapper { // Whitelisted by necessity
+
+		public ContentHttpHandlerMapper(
+			ICorsHeaderAppender corsHelper
+		) { }
+
+	}
+
+}
+
 namespace D2L.LP.Web.Files.FileViewing { // Whitelisted by necessity
 
 	public class StreamFileViewerResult {


### PR DESCRIPTION
Unfortunately, when I was writing the analyzer I neglected to consider that `ContentHttpHandler` isn't injected, but rather is directly instantiated in `ContentHttpHandlerMapper`... Hence this addition to the whitelisted classes list.

Apologies if you already pushed a new version and now need to do so again, Jacob. :(