### PR TITLE
Experimental "ID Type" parameter mismatch

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/IdTypesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/IdTypesAnalyzer.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using D2L.CodeStyle.Analyzers.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.Analyzers.ApiUsage {
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	internal sealed class IdTypesAnalyzer : DiagnosticAnalyzer {
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+			Diagnostics.IdTypeParameterMismatch
+		);
+
+		private static readonly ImmutableDictionary<string, ImmutableHashSet<string>> PARAM_TO_VARIABLE_BLACKLIST = new Dictionary<string, string[]> {
+			{ "userId", new[] { "orgId", "orgUnitId" } },
+			{ "orgId", new[] { "orgUnitId", "userId" } },
+			{ "orgUnitId", new[] { "userId" } },
+			
+		}.ToImmutableDictionary( x => x.Key.ToUpperInvariant(), x => x.Value.Select( y => y.ToUpperInvariant() ).ToImmutableHashSet() );
+
+		private static readonly IImmutableSet<string> INTERESTING_PARAM_NAMES = PARAM_TO_VARIABLE_BLACKLIST.Keys.ToImmutableHashSet();
+		private static readonly IImmutableSet<string> INTERESTING_VARAIBLE_NAMES = PARAM_TO_VARIABLE_BLACKLIST.SelectMany( x => x.Value ).ToImmutableHashSet();
+
+		public override void Initialize( AnalysisContext context ) {
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction( RegisterIdTypedAnalyzer );
+		}
+
+		public static void RegisterIdTypedAnalyzer( CompilationStartAnalysisContext context ) {
+			context.RegisterSyntaxNodeAction(
+				ctx => AnalyzeInvocation( ctx, ( InvocationExpressionSyntax )ctx.Node ),
+				SyntaxKind.InvocationExpression
+			);
+		}
+
+		private static void AnalyzeInvocation(
+			SyntaxNodeAnalysisContext ctx,
+			InvocationExpressionSyntax invocation	
+		) {
+			ArgumentListSyntax argumentList = invocation.ArgumentList;
+			if( argumentList == null ) {
+				return;
+			}
+
+			SeparatedSyntaxList<ArgumentSyntax> arguments = argumentList.Arguments;
+			foreach( var argument in arguments ) {
+				IdentifierNameSyntax argumentExpression = argument.Expression as IdentifierNameSyntax;
+				if( argumentExpression == null ) {
+					continue;
+				}
+
+				string variableName = argumentExpression.Identifier.Text;
+				string variableNameNormalized = variableName.ToUpperInvariant();
+				if( !INTERESTING_VARAIBLE_NAMES.Contains( variableNameNormalized ) ) {
+					continue;
+				}
+
+				IParameterSymbol parameter = argument.DetermineParameter(
+					ctx.SemanticModel,
+					allowParams: true
+				);
+				if( parameter.IsNullOrErrorType() ) {
+					continue;
+				}
+
+				string parameterName = parameter.Name;
+				string parameterNameNormalized = parameterName.ToUpperInvariant();
+				if ( !INTERESTING_PARAM_NAMES.Contains( parameterNameNormalized ) ) {
+					continue;
+				}
+
+				if( !PARAM_TO_VARIABLE_BLACKLIST[parameterNameNormalized].Contains( variableNameNormalized ) ) {
+					continue;
+				}
+
+				ctx.ReportDiagnostic( Diagnostic.Create( Diagnostics.IdTypeParameterMismatch, argumentExpression.GetLocation() ) );
+			}
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -31,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ApiUsage\IdTypesAnalyzer.cs" />
     <Compile Include="Visibility\CorsHeaderAppenderUsageAnalyzer.cs" />
     <Compile Include="Immutability\ImmutableGenericAttributeAnalyzer.cs" />
     <Compile Include="ApiUsage\JsonParamBinderAttribute\JsonParamBinderAnalyzer.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -281,5 +281,15 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true,
 			description: "ICorsHeaderAppender should not be used, as it can introduce security vulnerabilities."
 		);
+
+		public static readonly DiagnosticDescriptor IdTypeParameterMismatch = new DiagnosticDescriptor(
+			id: "D2L0032",
+			title: "A user/org identifier was passed to a mismatched parameter",
+			messageFormat: "A user/org identifier was passed to a mismatched parameter",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "A user/org identifier was passed to a mismatched parameter"
+		);
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -48,6 +48,7 @@
     <EmbeddedResource Include="Specs\ImmutableCollectionsAnalyzer.cs" />
     <EmbeddedResource Include="Specs\ImmutableGenericAttributeAnalyzer.cs" />
     <EmbeddedResource Include="Specs\CorsHeaderAppenderUsageAnalyzer.cs" />
+    <EmbeddedResource Include="Specs\IdTypesAnalyzer.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="Extensions\TypeSymbolExtensionsTests.cs" />
     <Compile Include="ApiUsage\NotNullAnalyzerTests.cs" />

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/IdTypesAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/IdTypesAnalyzer.cs
@@ -1,0 +1,26 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.ApiUsage.IdTypesAnalyzer
+
+namespace D2L.CodeStyle.Analyzers.Specs {
+	public class Foo {
+		public void Foo() {
+			long orgId = 1;
+			long orgUnitId = 2;
+			long userId = 3;
+			long foo = 4;
+
+			Bar( orgId, orgUnitId, userId );
+			Bar( orgId, orgId, userId );
+			Bar( foo, foo, foo );
+			Baz( foo, foo, foo );
+			Baz( orgId, orgUnitId, userId );
+			Bar( /* IdTypeParameterMismatch */ orgUnitId /**/, orgUnitId, userId );
+			Bar( orgId, orgUnitId, /* IdTypeParameterMismatch */ orgUnitId /**/ );
+			Bar( orgId, orgUnitId, /* IdTypeParameterMismatch */ orgId /**/ );
+			Bar( /* IdTypeParameterMismatch */ userId /**/, orgUnitId, userId );
+			Bar( orgId, /* IdTypeParameterMismatch */ userId /**/, userId );
+		}
+
+		public void Bar( long orgId, long orgUnitId, long userId ) { }
+		public void Baz( long foo, long bar, long baz );
+	}
+}


### PR DESCRIPTION
This is much better solved with the id type structs and named parameters, but trying to detect cases where orgId and userId parameters were swapped, for instance

Many false positives AFAICT, laregly due to passing orgUnitId into orgId parameters, but orgId means orgUnitId.