### PR TITLE
D2L0033: Interface implementation parameter names should match the interface

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Compile Include="Language\UseNamedArgumentsCodeFix.cs" />
     <Compile Include="Language\RequireNamedArgumentsAnalyzer.cs" />
+    <Compile Include="Language\ParamNamesShouldMatchInterfaceAnalyzer.cs" />
     <Compile Include="Visibility\CorsHeaderAppenderUsageAnalyzer.cs" />
     <Compile Include="Immutability\ImmutableGenericAttributeAnalyzer.cs" />
     <Compile Include="ApiUsage\JsonParamBinderAttribute\JsonParamBinderAnalyzer.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -291,5 +291,15 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true,
 			description: "This function takes lots of arguments which makes it confusing. Please used named arguments so future readers can figure it out and so that it's clearer that the arguments are in the right order."
 		);
+
+		public static readonly DiagnosticDescriptor InterfaceImplementationParamNameMismatch = new DiagnosticDescriptor(
+			id: "D2L0033",
+			title: "Interface implementation parameter names should match the interface",
+			messageFormat: "Expected implementation parameter name to be '{0}', saw '{1}'",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "Interface implementation parameter names should match the interface"
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -297,7 +297,7 @@ namespace D2L.CodeStyle.Analyzers {
 			title: "Interface implementation parameter names should match the interface",
 			messageFormat: "Expected implementation parameter name to be '{0}', saw '{1}'",
 			category: "Correctness",
-			defaultSeverity: DiagnosticSeverity.Error,
+			defaultSeverity: DiagnosticSeverity.Warning,
 			isEnabledByDefault: true,
 			description: "Interface implementation parameter names should match the interface"
 		);

--- a/src/D2L.CodeStyle.Analyzers/Language/ParamNamesShouldMatchInterfaceAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/ParamNamesShouldMatchInterfaceAnalyzer.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace D2L.CodeStyle.Analyzers.Language {

--- a/src/D2L.CodeStyle.Analyzers/Language/ParamNamesShouldMatchInterfaceAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/ParamNamesShouldMatchInterfaceAnalyzer.cs
@@ -60,6 +60,11 @@ namespace D2L.CodeStyle.Analyzers.Language {
 						continue;
 					}
 
+					// don't know when this happens
+					if( implParameter.DeclaringSyntaxReferences.Length == 0 ) {
+						continue;
+					}
+
 					Location location = implParameter.DeclaringSyntaxReferences.First().GetSyntax().GetLocation();
 					context.ReportDiagnostic( Diagnostic.Create(
 						Diagnostics.InterfaceImplementationParamNameMismatch,

--- a/src/D2L.CodeStyle.Analyzers/Language/ParamNamesShouldMatchInterfaceAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/ParamNamesShouldMatchInterfaceAnalyzer.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.Analyzers.Language {
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	internal sealed class ParamNamesShouldMatchInterfaceAnalyzer : DiagnosticAnalyzer {
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+			Diagnostics.InterfaceImplementationParamNameMismatch
+		);
+
+		public override void Initialize( AnalysisContext context ) {
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction( RegisterAnalyzer );
+		}
+
+		private static void RegisterAnalyzer( CompilationStartAnalysisContext context ) {
+			context.RegisterSyntaxNodeAction(
+				ctx => AnalyzeClassDefinition(
+					ctx,
+					( INamedTypeSymbol )ctx.SemanticModel.GetDeclaredSymbol( ctx.Node )
+				),
+				SyntaxKind.ClassDeclaration
+			);
+		}
+
+		private static void AnalyzeClassDefinition(
+			SyntaxNodeAnalysisContext context,
+			INamedTypeSymbol typeSymbol
+		) {
+			if( !typeSymbol.Interfaces.Any() ) {
+				return;
+			}
+
+			ImmutableArray<IMethodSymbol> interfaceMethods = CollectInterfaceMethods( typeSymbol );
+			foreach( var interfaceMethod in interfaceMethods ) {
+				IMethodSymbol implMethod = (IMethodSymbol)typeSymbol.FindImplementationForInterfaceMember( interfaceMethod );
+
+				// In the middle of coding and haven't implemented an interface method yet
+				if( implMethod == null ) {
+					continue;
+				}
+
+				// Nothing to do
+				if( implMethod.Parameters.Length == 0 ) {
+					continue;
+				}
+
+				ImmutableArray<IParameterSymbol> implParameters = implMethod.Parameters;
+				ImmutableArray<IParameterSymbol> interfaceParameters = interfaceMethod.Parameters;
+				for( int i = 0; i < implParameters.Length; ++i ) {
+					IParameterSymbol implParameter = implParameters[ i ];
+					IParameterSymbol interfaceParameter = interfaceParameters[ i ];
+
+					if( implParameter.Name.Equals( interfaceParameter.Name, StringComparison.InvariantCultureIgnoreCase ) ) {
+						continue;
+					}
+
+					Location location = implParameter.DeclaringSyntaxReferences.First().GetSyntax().GetLocation();
+					context.ReportDiagnostic( Diagnostic.Create(
+						Diagnostics.InterfaceImplementationParamNameMismatch,
+						location,
+						interfaceParameter.Name,
+						implParameter.Name
+					) );
+				}
+			}
+		}
+
+		private static ImmutableArray<IMethodSymbol> CollectInterfaceMethods(
+			INamedTypeSymbol typeSymbol
+		) {
+			return typeSymbol
+				.AllInterfaces
+				.SelectMany( @interface => @interface
+					.GetMembers()
+					.OfType<IMethodSymbol>()
+					.Where( m => m.MethodKind == MethodKind.Ordinary )
+				)
+				.ToImmutableArray();
+		}
+	}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -48,7 +48,11 @@
     <EmbeddedResource Include="Specs\ImmutableCollectionsAnalyzer.cs" />
     <EmbeddedResource Include="Specs\ImmutableGenericAttributeAnalyzer.cs" />
     <EmbeddedResource Include="Specs\CorsHeaderAppenderUsageAnalyzer.cs" />
+<<<<<<< HEAD
     <EmbeddedResource Include="Specs\RequireNamedArgumentsAnalyzer.cs" />
+=======
+    <EmbeddedResource Include="Specs\ParamNamesShouldMatchInterfaceAnalyzer.cs" />
+>>>>>>> D2L0032: Interface implementation parameter names should match the interface
     <Compile Include="TestBase.cs" />
     <Compile Include="Extensions\TypeSymbolExtensionsTests.cs" />
     <Compile Include="ApiUsage\NotNullAnalyzerTests.cs" />

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ParamNamesShouldMatchInterfaceAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ParamNamesShouldMatchInterfaceAnalyzer.cs
@@ -1,0 +1,67 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.Language.ParamNamesShouldMatchInterfaceAnalyzer
+
+namespace D2L.CodeStyle.Analyzers.Specs {
+	public interface IFoo {
+		int Foo( int a, int b, int c );
+		string Foo( int a, int b, int c );
+		string Foo( string g, string h, string i );
+
+		int Bar( int d, int e, int f );
+
+		void Foo();
+	}
+
+	public class GoodExplicit : IFoo {
+		int IFoo.Foo( int a, int b, int c ) { return 0; }
+		string IFoo.Foo( int a, int b, int c ) { return null; }
+		string IFoo.Foo( string g, string h, string i ) { return null; }
+
+		int IFoo.Bar( int d, int e, int f ) { return 0; }
+
+		void IFoo.Foo() { }
+	}
+
+	public class GoodImplict : IFoo {
+		public int Foo( int a, int b, int c ) { return 0; }
+		public string Foo( int a, int b, int c ) { return null; }
+		public string Foo( string g, string h, string i ) { return null; }
+
+		public int Bar( int d, int e, int f ) { return 0; }
+
+		public void Foo() { }
+	}
+
+	public class BadExplicit : IFoo {
+		int IFoo.Foo( /* InterfaceImplementationParamNameMismatch(a,b) */ int b /**/, /* InterfaceImplementationParamNameMismatch(b,a) */ int a /**/, int c ) { return 0; }
+		string IFoo.Foo( int a, int b, int c ) { return null; }
+		string IFoo.Foo( string g, string h, /* InterfaceImplementationParamNameMismatch(i,x) */ string x /**/ ) { return null; }
+
+		int IFoo.Bar( int d, int e, int f ) { return 0; }
+
+		void IFoo.Foo() { }
+	}
+
+	public class BadImplicit : IFoo {
+		public int Foo( /* InterfaceImplementationParamNameMismatch(a,b) */ int b /**/, /* InterfaceImplementationParamNameMismatch(b,a) */ int a /**/, int c ) { return 0; }
+		public string Foo( int a, int b, int c ) { return null; }
+		public string Foo( string g, string h, /* InterfaceImplementationParamNameMismatch(i,x) */ string x /**/ ) { return null; }
+
+		public int Bar( int d, int e, int f ) { return 0; }
+
+		public void Foo() { }
+	}
+
+	public class BadBase {
+		public int Foo( /* InterfaceImplementationParamNameMismatch(a,b) */ int b /**/, /* InterfaceImplementationParamNameMismatch(b,a) */ int a /**/, int c ) { return 0; }
+		public string Foo( int a, int b, int c ) { return null; }
+		public string Foo( string g, string h, /* InterfaceImplementationParamNameMismatch(i,x) */ string x /**/ ) { return null; }
+
+		public int Bar( int d, int e, int f ) { return 0; }
+
+		public void Foo() { }
+	}
+
+	public class BadSub : BadBase, IFoo { }
+
+	public class UnfinishedImplementationDoesntThrow : IFoo { }
+}


### PR DESCRIPTION
… param names

- [x] .view files spitting out _Expected implementation parameter name to be 'rc'_ (Legit case, PR open)
- [x] Definitely cases where interface method isn't matched still
- [x] ~Cache interface method collection?~
- [x] Reduce noise for different casing