### PR TITLE
Add first-pass at RequireNamedArgsAnalyzer

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -31,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Language\RequireNamedArgumentsAnalyzer.cs" />
     <Compile Include="Visibility\CorsHeaderAppenderUsageAnalyzer.cs" />
     <Compile Include="Immutability\ImmutableGenericAttributeAnalyzer.cs" />
     <Compile Include="ApiUsage\JsonParamBinderAttribute\JsonParamBinderAnalyzer.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -281,5 +281,15 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true,
 			description: "ICorsHeaderAppender should not be used, as it can introduce security vulnerabilities."
 		);
+
+		public static readonly DiagnosticDescriptor UseNamedArgsForInvocationWithLotsOfArgs = new DiagnosticDescriptor(
+			id: "D2L0032",
+			title: "This function takes lots of arguments which makes it confusing. Please used named arguments so future readers can figure it out and so that it's clearer that the arguments are in the right order.",
+			messageFormat: "This function takes lots of arguments which makes it confusing. Please used named arguments so future readers can figure it out and so that it's clearer that the arguments are in the right order.",
+			category: "Readability",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "This function takes lots of arguments which makes it confusing. Please used named arguments so future readers can figure it out and so that it's clearer that the arguments are in the right order."
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -14,7 +14,7 @@ namespace D2L.CodeStyle.Analyzers.Language {
 		);
 
 		// TODO: shrink this number over time. Maybe 5 would be good?
-		public const int TOO_MANY_UNNAMED_ARGS = 10;
+		public const int TOO_MANY_UNNAMED_ARGS = 64;
 
 		public override void Initialize( AnalysisContext context ) {
 			context.EnableConcurrentExecution();

--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -91,13 +91,14 @@ namespace D2L.CodeStyle.Analyzers.Language {
 					allowParams: false
 				);
 
-				// We presumably can't name this param anyway
+				// Not sure if this can happen but it'd be hard to name this
+				// param so ignore it.
 				if ( param == null ) {
 					continue;
 				}
 
 				// IParameterSymbol.Name is documented to be possibly empty in
-				// which case it is unnamed, so ignore it.
+				// which case it is "unnamed", so ignore it.
 				if ( param.Name == "" ) {
 					continue;
 				}

--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using D2L.CodeStyle.Analyzers.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.Analyzers.Language {
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	public sealed class RequireNamedArgumentsAnalyzer : DiagnosticAnalyzer {
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+			Diagnostics.UseNamedArgsForInvocationWithLotsOfArgs
+		);
+
+		// TODO: shrink this number over time. Maybe 5 would be good?
+		public const int TOO_MANY_UNNAMED_ARGS = 10;
+
+		public override void Initialize( AnalysisContext context ) {
+			context.EnableConcurrentExecution();
+
+			context.RegisterSyntaxNodeAction(
+				AnalyzeInvocation,
+				SyntaxKind.InvocationExpression
+			);
+		}
+
+		private static void AnalyzeInvocation(
+			SyntaxNodeAnalysisContext ctx
+		) {
+			var expr = (InvocationExpressionSyntax)ctx.Node;
+
+			if ( expr.ArgumentList == null ) {
+				return;
+			}
+
+			// Don't complain about single argument functions because they're
+			// very likely to be understandable
+			if ( expr.ArgumentList.Arguments.Count <= 1 ) {
+				return;
+			}
+
+			var unnamedArgs = GetUnnamedArgs(
+				ctx.SemanticModel,
+				expr.ArgumentList
+			).ToImmutableArray();
+
+			if ( unnamedArgs.Length >= TOO_MANY_UNNAMED_ARGS ) {
+				ctx.ReportDiagnostic(
+					Diagnostic.Create(
+						descriptor: Diagnostics.UseNamedArgsForInvocationWithLotsOfArgs,
+						location: expr.GetLocation()
+					)
+				);
+			}
+
+			// TODO: literal args should always be named
+
+			// TODO: if there are duplicate typed args then they should be named
+			// These will create a bit more cleanup. Fix should probably name
+			// all the args instead to avoid craziness with overloading.
+		}
+		
+		/// <summary>
+		/// Get the arguments which are unnamed and not "params"
+		/// </summary>
+		private static IEnumerable<ArgumentSyntax> GetUnnamedArgs(
+			SemanticModel model,
+			ArgumentListSyntax args
+		) {
+			foreach( var arg in args.Arguments ) {
+				// Ignore args that are already named. This will mean that args
+				// can be partially named which is sometimes helpful (the named
+				// args have to be at the end of the list though.)
+				if ( arg.NameColon != null ) {
+					continue;
+				}
+
+				var param = arg.DetermineParameter(
+					model,
+
+					// Don't map params arguments. It's okay that they are
+					// unnamed. Some things like ImmutableArray.Create() could
+					// take a large number of args and we don't want anything to
+					// be named. Named params really suck so we may still
+					// encourage it but APIs that take params and many other
+					// args would suck anyway.
+					allowParams: false
+				);
+
+				// We presumably can't name this param anyway
+				if ( param == null ) {
+					continue;
+				}
+
+				// IParameterSymbol.Name is documented to be possibly empty in
+				// which case it is unnamed, so ignore it.
+				if ( param.Name == "" ) {
+					continue;
+				}
+
+				yield return arg;
+			}
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -73,7 +73,10 @@ namespace D2L.CodeStyle.Analyzers.Language {
 				// can be partially named which is sometimes helpful (the named
 				// args have to be at the end of the list though.)
 				if ( arg.NameColon != null ) {
-					continue;
+					// We can stop as soon as we see one; named arguments have
+					// to be at the end of the arguments so the rest will be
+					// named too.
+					yield break;
 				}
 
 				var param = arg.DetermineParameter(

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -48,6 +48,7 @@
     <EmbeddedResource Include="Specs\ImmutableCollectionsAnalyzer.cs" />
     <EmbeddedResource Include="Specs\ImmutableGenericAttributeAnalyzer.cs" />
     <EmbeddedResource Include="Specs\CorsHeaderAppenderUsageAnalyzer.cs" />
+    <EmbeddedResource Include="Specs\RequireNamedArgumentsAnalyzer.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="Extensions\TypeSymbolExtensionsTests.cs" />
     <Compile Include="ApiUsage\NotNullAnalyzerTests.cs" />

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -17,7 +17,12 @@ namespace D2L {
 
 		public void funcWithParams( int a, int b, int c, params int[] ps ) { }
 
+		public delegate void delegate0Args();
+		public delegate void delegate1Args( int a1 );
+		public delegate void delegate10Args( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10 );
+
 		public static void Test() {
+			#region "low" number of args doesn't require naming
 			_arg0();
 			_arg1( 1 );
 			_arg2( 1, 2 );
@@ -28,10 +33,14 @@ namespace D2L {
 			_arg7( 1, 2, 3, 4, 5, 6, 7 );
 			_arg8( 1, 2, 3, 4, 5, 6, 7, 8 );
 			_arg9( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
+			#endregion
+
+			#region diagnostic for too many unnamed args
 			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg10( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ) /**/;
 			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ) /**/;
+			#endregion
 
-			// when there are lots of arguments we'd rather just see
+			#region all named args is usually preferred if there are lots of args
 			_arg10(
 				a1: 1,
 				a2: 2,
@@ -44,16 +53,27 @@ namespace D2L {
 				a9: 9,
 				a10: 10
 			);
+			#endregion
 
-			// begruddingly allowed (may make more sense when the limit isn't 10)
+			#region named args don't count against the unnamed args budget
 			_arg10( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10 );
 			_arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10, a11: 11 );
+			#endregion
 
 			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, a11: 11 ) /**/;
 
+			#region params don't count against the unnamed args budget
 			funcWithParams( 1, 2, 3 );
 			funcWithParams( 1, 2, 3, 4 );
 			funcWithParams( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
+			#endregion
+
+			#region delegates
+			((delegate0Args)null)();
+			((delegate1Args)null)( 1 );
+			/* UseNamedArgsForInvocationWithLotsOfArgs */ ((delegate10Args)null)( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ) /**/;
+			((delegate10Args)null)( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10 );
+			#endregion
 		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -1,0 +1,53 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.Language.RequireNamedArgumentsAnalyzer
+
+namespace D2L {
+	public static class Foo {
+		public void _arg0() { }
+		public void _arg1( int a1 ) { }
+		public void _arg2( int a1, int a2 ) { }
+		public void _arg3( int a1, int a2, int a3 ) { }
+		public void _arg4( int a1, int a2, int a3, int a4 ) { }
+		public void _arg5( int a1, int a2, int a3, int a4, int a5 ) { }
+		public void _arg6( int a1, int a2, int a3, int a4, int a5, int a6 ) { }
+		public void _arg7( int a1, int a2, int a3, int a4, int a5, int a6, int a7 ) { }
+		public void _arg8( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8 ) { }
+		public void _arg9( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9 ) { }
+		public void _arg10( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10 ) { }
+		public void _arg11( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11 ) { }
+
+		public static void Test() {
+			_arg0();
+			_arg1( 1 );
+			_arg2( 1, 2 );
+			_arg3( 1, 2, 3 );
+			_arg4( 1, 2, 3, 4 );
+			_arg5( 1, 2, 3, 4, 5 );
+			_arg6( 1, 2, 3, 4, 5, 6 );
+			_arg7( 1, 2, 3, 4, 5, 6, 7 );
+			_arg8( 1, 2, 3, 4, 5, 6, 7, 8 );
+			_arg9( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
+			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg10( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ) /**/;
+			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ) /**/;
+
+			// when there are lots of arguments we'd rather just see
+			_arg10(
+				a1: 1,
+				a2: 2,
+				a3: 3,
+				a4: 4,
+				a5: 5,
+				a6: 6,
+				a7: 7,
+				a8: 8,
+				a9: 9,
+				a10: 10
+			);
+
+			// begruddingly allowed (may make more sense when the limit isn't 10)
+			_arg10( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10 );
+			_arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10, a11: 11 );
+
+			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, a11: 11 ) /**/;
+		}
+	}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -7,19 +7,17 @@ namespace D2L {
 		public void _arg2( int a1, int a2 ) { }
 		public void _arg3( int a1, int a2, int a3 ) { }
 		public void _arg4( int a1, int a2, int a3, int a4 ) { }
-		public void _arg5( int a1, int a2, int a3, int a4, int a5 ) { }
-		public void _arg6( int a1, int a2, int a3, int a4, int a5, int a6 ) { }
-		public void _arg7( int a1, int a2, int a3, int a4, int a5, int a6, int a7 ) { }
-		public void _arg8( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8 ) { }
-		public void _arg9( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9 ) { }
-		public void _arg10( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10 ) { }
-		public void _arg11( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11 ) { }
+
+		// These will shrink as we shrink the max *blush*
+		public void _arg63( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17, int a18, int a19, int a20, int a21, int a22, int a23, int a24, int a25, int a26, int a27, int a28, int a29, int a30, int a31, int a32, int a33, int a34, int a35, int a36, int a37, int a38, int a39, int a40, int a41, int a42, int a43, int a44, int a45, int a46, int a47, int a48, int a49, int a50, int a51, int a52, int a53, int a54, int a55, int a56, int a57, int a58, int a59, int a60, int a61, int a62, int a63 );
+		public void _arg64( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17, int a18, int a19, int a20, int a21, int a22, int a23, int a24, int a25, int a26, int a27, int a28, int a29, int a30, int a31, int a32, int a33, int a34, int a35, int a36, int a37, int a38, int a39, int a40, int a41, int a42, int a43, int a44, int a45, int a46, int a47, int a48, int a49, int a50, int a51, int a52, int a53, int a54, int a55, int a56, int a57, int a58, int a59, int a60, int a61, int a62, int a63, int a64 );
+		public void _arg65( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17, int a18, int a19, int a20, int a21, int a22, int a23, int a24, int a25, int a26, int a27, int a28, int a29, int a30, int a31, int a32, int a33, int a34, int a35, int a36, int a37, int a38, int a39, int a40, int a41, int a42, int a43, int a44, int a45, int a46, int a47, int a48, int a49, int a50, int a51, int a52, int a53, int a54, int a55, int a56, int a57, int a58, int a59, int a60, int a61, int a62, int a63, int a64, int a65 );
 
 		public void funcWithParams( int a, int b, int c, params int[] ps ) { }
 
 		public delegate void delegate0Args();
 		public delegate void delegate1Args( int a1 );
-		public delegate void delegate10Args( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10 );
+		public delegate void delegate64Args( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17, int a18, int a19, int a20, int a21, int a22, int a23, int a24, int a25, int a26, int a27, int a28, int a29, int a30, int a31, int a32, int a33, int a34, int a35, int a36, int a37, int a38, int a39, int a40, int a41, int a42, int a43, int a44, int a45, int a46, int a47, int a48, int a49, int a50, int a51, int a52, int a53, int a54, int a55, int a56, int a57, int a58, int a59, int a60, int a61, int a62, int a63, int a64 );
 
 		public static void Test() {
 			#region "low" number of args doesn't require naming
@@ -28,20 +26,16 @@ namespace D2L {
 			_arg2( 1, 2 );
 			_arg3( 1, 2, 3 );
 			_arg4( 1, 2, 3, 4 );
-			_arg5( 1, 2, 3, 4, 5 );
-			_arg6( 1, 2, 3, 4, 5, 6 );
-			_arg7( 1, 2, 3, 4, 5, 6, 7 );
-			_arg8( 1, 2, 3, 4, 5, 6, 7, 8 );
-			_arg9( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
+			_arg63( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 );
 			#endregion
 
 			#region diagnostic for too many unnamed args
-			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg10( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ) /**/;
-			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ) /**/;
+			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg64( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64 ) /**/;
+			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg65( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65 ) /**/;
 			#endregion
 
 			#region all named args is usually preferred if there are lots of args
-			_arg10(
+			_arg64(
 				a1: 1,
 				a2: 2,
 				a3: 3,
@@ -51,16 +45,72 @@ namespace D2L {
 				a7: 7,
 				a8: 8,
 				a9: 9,
-				a10: 10
+				a10: 10,
+				a11: 11,
+				a12: 12,
+				a13: 13,
+				a14: 14,
+				a15: 15,
+				a16: 16,
+				a17: 17,
+				a18: 18,
+				a19: 19,
+				a20: 20,
+				a21: 21,
+				a22: 22,
+				a23: 23,
+				a24: 24,
+				a25: 25,
+				a26: 26,
+				a27: 27,
+				a28: 28,
+				a29: 29,
+				a30: 30,
+				a31: 31,
+				a32: 32,
+				a33: 33,
+				a34: 34,
+				a35: 35,
+				a36: 36,
+				a37: 37,
+				a38: 38,
+				a39: 39,
+				a40: 40,
+				a41: 41,
+				a42: 42,
+				a43: 43,
+				a44: 44,
+				a45: 45,
+				a46: 46,
+				a47: 47,
+				a48: 48,
+				a49: 49,
+				a50: 50,
+				a51: 51,
+				a52: 52,
+				a53: 53,
+				a54: 54,
+				a55: 55,
+				a56: 56,
+				a57: 57,
+				a58: 58,
+				a59: 59,
+				a60: 60,
+				a61: 61,
+				a62: 62,
+				a63: 63,
+				a64: 64
 			);
 			#endregion
 
 			#region named args don't count against the unnamed args budget
-			_arg10( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10 );
-			_arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10, a11: 11 );
+			_arg64( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, a64: 64 );
+			_arg65( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, a64: 64, a65: 65 );
 			#endregion
 
-			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, a11: 11 ) /**/;
+			#region need to have enough named args, though
+			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg65( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, a65: 65 ) /**/;
+			#endregion
 
 			#region params don't count against the unnamed args budget
 			funcWithParams( 1, 2, 3 );
@@ -71,8 +121,8 @@ namespace D2L {
 			#region delegates
 			((delegate0Args)null)();
 			((delegate1Args)null)( 1 );
-			/* UseNamedArgsForInvocationWithLotsOfArgs */ ((delegate10Args)null)( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ) /**/;
-			((delegate10Args)null)( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10 );
+			/* UseNamedArgsForInvocationWithLotsOfArgs */ ((delegate64Args)null)( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64 ) /**/;
+			((delegate10Args)null)( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, a64: 64 );
 			#endregion
 		}
 	}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -15,6 +15,8 @@ namespace D2L {
 		public void _arg10( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10 ) { }
 		public void _arg11( int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11 ) { }
 
+		public void funcWithParams( int a, int b, int c, params int[] ps ) { }
+
 		public static void Test() {
 			_arg0();
 			_arg1( 1 );
@@ -48,6 +50,10 @@ namespace D2L {
 			_arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, a10: 10, a11: 11 );
 
 			/* UseNamedArgsForInvocationWithLotsOfArgs */ _arg11( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, a11: 11 ) /**/;
+
+			funcWithParams( 1, 2, 3 );
+			funcWithParams( 1, 2, 3, 4 );
+			funcWithParams( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
 		}
 	}
 }


### PR DESCRIPTION
Over time I'd like to expand this:
- shrink the limit from 10 to something like 5
- two args of the same type (or convertable?) => name them
- literal args must be named