### PR TITLE
Making System.IO.Abstractions.IFileSystem be treated as Immutable

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -14,7 +14,8 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 			"System.StringComparer",
 			"System.Text.ASCIIEncoding",
 			"System.Text.Encoding",
-			"System.Text.UTF8Encoding"
+			"System.Text.UTF8Encoding",
+			"System.IO.Abstractions.IFileSystem"
 		);
 
 		public static ImmutabilityScope GetImmutabilityScope( this ITypeSymbol type ) {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -92,6 +92,11 @@ namespace SpecTests {
 		class ImmutableEncoding : System.Text.Encoding {
 			private readonly int m_bad;
 		}
+
+		[Objects.Immutable]
+		class EnclosedExternalImmutable {
+			private readonly System.Text.Encoding m_encoding;
+		}
 	}
 
 	class ImmutableBaseClassTests {


### PR DESCRIPTION
-Adding a test to explicitly show enclosed externally marked classes behave as expected.