### PR TITLE
Bump D2L.CodeStyle.Analyzers from 0.70 to 0.71

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -10,9 +10,9 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.70.0.0" )]
-[assembly: AssemblyFileVersion( "0.70.0.0" )]
-[assembly: AssemblyInformationalVersion( "0.70.0.0" )]
+[assembly: AssemblyVersion( "0.71.0.0" )]
+[assembly: AssemblyFileVersion( "0.71.0.0" )]
+[assembly: AssemblyInformationalVersion( "0.71.0.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]
 [assembly: InternalsVisibleTo( "DynamicProxyGenAssembly2" )]


### PR DESCRIPTION
version 0.70 is already published, although it was not updated in the repo

http://nuget.build.d2l/feeds/stable/D2L.CodeStyle.Analyzers/
https://www.nuget.org/packages/D2L.CodeStyle.Analyzers/
