### PR TITLE
Adding support for immutable type parameters

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -202,5 +202,34 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 
 			return false;
 		}
+
+		public static bool IsGenericType( this ISymbol symbol ) {
+			if( symbol is INamedTypeSymbol ) {
+				var namedType = symbol as INamedTypeSymbol;
+				return ( namedType.TypeParameters.Length > 0 );
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Find the matching type argument in the base interface
+		/// that corresponds to this type parameter.  That is,
+		/// if we have Foo<S, T>: IFoo<S>, IBar<T>, this will
+		/// match up the Foo S, to the IFoo S, but will get -1
+		/// from IBar since it doesn't have S.
+		/// </summary>
+		public static int IndexOfArgument( 
+			this INamedTypeSymbol intf, string name 
+		) {
+
+			for (int ordinal = 0; ordinal < intf.TypeArguments.Length; ordinal++ ) {
+				if (string.Equals(intf.TypeArguments[ordinal].Name, name, StringComparison.Ordinal)) {
+					return ordinal;
+				}
+			}
+
+			return -1;
+		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -63,10 +63,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			if( mutabilityResult.IsMutable ) {
 				var reason = m_resultFormatter.Format( mutabilityResult );
 				var location = GetLocationOfClassIdentifierAndGenericParameters( root );
-				var diagnostic = Diagnostic.Create( 
-					Diagnostics.ImmutableClassIsnt, 
-					location, 
-					reason 
+				var diagnostic = Diagnostic.Create(
+					Diagnostics.ImmutableClassIsnt,
+					location,
+					reason
 				);
 				context.ReportDiagnostic( diagnostic );
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResult.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResult.cs
@@ -18,7 +18,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		IsAnArray,
 		IsPotentiallyMutable,
 		IsDynamic,
-		IsAGenericType
+		IsAGenericType,
+		IsMutableTypeParameter
 	}
 
 	public sealed class MutabilityInspectionResult {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResultFormatter.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResultFormatter.cs
@@ -55,6 +55,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					return "not deterministically immutable";
 				case MutabilityCause.IsADelegate:
 					return "a delegate (which can hold onto mutable state)";
+				case MutabilityCause.IsMutableTypeParameter:
+					return "a type parameter that must be marked with `[Objects.Immutable]`";
 				default:
 					throw new NotImplementedException( $"unknown cause '{result.Cause}'" );
 			}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -31,6 +31,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		private static readonly ImmutableDictionary<string, string[]> ImmutableContainerTypes = new Dictionary<string, string[]> {
 			["D2L.LP.Utilities.DeferredInitializer"] = new[] { "Value" },
 			["D2L.LP.Extensibility.Activation.Domain.IPlugins"] = new[] { "[]" },
+			["System.Collections.Immutable.IImmutableSet"] = new[] { "[]" },
 			["System.Collections.Immutable.ImmutableArray"] = new[] { "[]" },
 			["System.Collections.Immutable.ImmutableDictionary"] = new[] { "[].Key", "[].Value" },
 			["System.Collections.Immutable.ImmutableHashSet"] = new[] { "[]" },

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -261,8 +261,18 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return MutabilityInspectionResult.NotMutable();
 			}
 
+			// We can't short-circuit below if this is a generic type because
+			// while the type can be marked immutable we can't be certain
+			// all type parameters have been marked immutable at some point
+			// in their heirarchy.
+			bool isGenericType = false;
+			if( type is INamedTypeSymbol ) {
+				var namedType = type as INamedTypeSymbol;
+				isGenericType = ( namedType.TypeParameters.Length > 0 );
+			}
+
 			var scope = type.GetImmutabilityScope();
-			if( !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && scope != ImmutabilityScope.None ) {
+			if( !isGenericType && !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && scope != ImmutabilityScope.None ) {
 				ImmutableHashSet<string> immutableExceptions = type.GetAllImmutableExceptions();
 				return MutabilityInspectionResult.NotMutable( immutableExceptions );
 			}

--- a/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
@@ -19,6 +19,7 @@ namespace D2L.CodeStyle.Annotations {
 			validOn: AttributeTargets.Class
 			       | AttributeTargets.Interface
 			       | AttributeTargets.Struct
+			       | AttributeTargets.GenericParameter
 		)]
 		public sealed class Immutable : ImmutableAttributeBase { }
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -5,7 +5,7 @@ using D2L.CodeStyle.Annotations;
 using D2L.LP.Extensibility.Activation.Domain;
 
 [assembly: Objects.ImmutableGeneric(
-	type: typeof(SpecTests.GenericsTests.IFactory<Version>) 
+	type: typeof( SpecTests.GenericsTests.IFactory<Version> )
 )]
 
 [assembly: Objects.ImmutableGeneric(
@@ -18,9 +18,9 @@ namespace D2L.LP.Extensibility.Activation.Domain {
 
 namespace D2L.CodeStyle.Annotations {
 	public static class Objects {
-		public abstract class ImmutableAttributeBase : Attribute { 
+		public abstract class ImmutableAttributeBase : Attribute {
 			public Except Except { get; set; }
-    }
+		}
 		public sealed class Immutable : ImmutableAttributeBase { }
 		public sealed class ImmutableBaseClassAttribute : ImmutableAttributeBase { }
 
@@ -43,7 +43,7 @@ namespace D2L.CodeStyle.Annotations {
 	public static class Mutability {
 		public sealed class AuditedAttribute : Attribute { }
 		public sealed class UnauditedAttribute : Attribute {
-			public UnauditedAttribute( Because why ) {}
+			public UnauditedAttribute( Because why ) { }
 		}
 	}
 	public enum Because {
@@ -57,6 +57,17 @@ namespace D2L.CodeStyle.Annotations {
 }
 
 namespace SpecTests {
+
+	// Items used in multiple test spaces are defined outside of the spaces
+	sealed class ImmutableClass {
+		private readonly string m_ImmutableClass;
+	}
+
+	sealed class MutableClass {
+		private string m_MutableClass;
+	}
+
+
 
 	class AnnotationsTests {
 		[Objects.Immutable]
@@ -160,7 +171,7 @@ namespace SpecTests {
 
 		[Objects.Immutable]
 		class IndexerPropertyClass {
-			object this[ int index ] {
+			object this[int index] {
 				get { return null; }
 			}
 		}
@@ -256,7 +267,7 @@ namespace SpecTests {
 		sealed class W { readonly X x1, x2, x3; }
 		sealed class X { readonly Y y1, y2, y3; }
 		sealed class Y { readonly Z z1, z2, z3; }
-		sealed class Z {}
+		sealed class Z { }
 
 		#endregion
 	}
@@ -315,4 +326,86 @@ namespace SpecTests {
 		}
 
 	}
+
+	class GenericTypeFieldTests {
+		// Generic type parameter state with mutable and immutable concrete types
+
+		[Objects.Immutable]
+		sealed class GenericClassWithImmutableState<[Objects.Immutable] T> {
+			internal readonly T m_GenericClassWithImmutableState;
+		}
+
+		[Objects.Immutable]
+		class /* ImmutableClassIsnt('m_ConcreteClassWithMutableGenericType.m_GenericClassWithImmutableState.m_MutableClass' is not read-only) */ ConcreteClassWithMutableGenericType /**/ {
+			internal readonly GenericClassWithImmutableState<MutableClass> m_ConcreteClassWithMutableGenericType;
+		}
+
+		[Objects.Immutable]
+		class ConcreteClassWithImmutableGenericType {
+			internal readonly GenericClassWithImmutableState<ImmutableClass> m_ConcreteClassWithImmutableGenericType;
+		}
+	}
+
+	class GenericTypeParameterTests {
+		// Ensures generic type parameters from an interface are examined
+
+		[Objects.Immutable]
+		interface ImmutableGenericInterface<[Objects.Immutable] T> {
+		}
+
+		[Objects.Immutable]
+		sealed class GenericClassWithImmutableInterface<T> : ImmutableGenericInterface<T> {
+			internal readonly T m_GenericClassWithImmutableInterface;
+		}
+
+		[Objects.Immutable]
+		class ConcreteClassWithImmutableInterfaceImmutableType {
+			internal readonly ImmutableGenericInterface<ImmutableClass> m_ConcreteClassWithImmutableInterfaceImmutableType;
+		}
+
+		[Objects.Immutable]
+		class /* ImmutableClassIsnt('m_ConcreteClassWithImmutableInterfaceMutableType''s type ('SpecTests.MutableClass') is a type parameter that must be marked with `[Objects.Immutable]`) */ ConcreteClassWithImmutableInterfaceMutableType /**/ {
+			internal readonly ImmutableGenericInterface<MutableClass> m_ConcreteClassWithImmutableInterfaceMutableType;
+		}
+	}
+
+	class MultipleGenericParameterTests {
+		// Tests when there is a mixed set of mutable and immutable type parameters
+
+		[Objects.Immutable]
+		sealed class MultiGenericClassWithOneImmutable<[Objects.Immutable] T, S> {
+			internal readonly T m_MultiGenericClassWithOneImmutable;
+		}
+
+		[Objects.Immutable]
+		sealed class ConcreteHoldingMixedModeGeneric {
+			internal readonly MultiGenericClassWithOneImmutable<ImmutableClass, MutableClass> m_ConcreteHoldingMixedModeGeneric;
+		}
+
+		[Objects.Immutable]
+		sealed class /* ImmutableClassIsnt('m_ConcreteHoldingMixedModeGenericWrongOrder.m_MultiGenericClassWithOneImmutable.m_MutableClass' is not read-only) */ ConcreteHoldingMixedModeGenericWrongOrder /**/ {
+			internal readonly MultiGenericClassWithOneImmutable<MutableClass, ImmutableClass> m_ConcreteHoldingMixedModeGenericWrongOrder;
+		}
+	}
+
+	class MultipleGenericInterfaceParameterTests {
+		[Objects.Immutable]
+		interface MultiGeneric<[Objects.Immutable] S, T> {
+		}
+
+		sealed class MultiGenericFromInterface<S, T> : MultiGeneric<S, T> {
+			internal readonly S m_MultiGenericFromInterface;
+		}
+
+		[Objects.Immutable]
+		sealed class ConcreteUsingMultiGenericFromInterface {
+			internal readonly MultiGenericFromInterface<ImmutableClass, NonReadOnlyClass> m_ConcreteUsingMultiGenericFromInterface;
+		}
+
+		[Objects.Immutable]
+		sealed class /* ImmutableClassIsnt('m_ConcreteUsingMultiGenericFromInterfaceWrongOrder.m_MultiGenericFromInterface.m_MutableClass' is not read-only) */ ConcreteUsingMultiGenericFromInterfaceWrongOrder /**/ {
+			internal readonly MultiGenericFromInterface<MutableClass, ImmutableClass> m_ConcreteUsingMultiGenericFromInterfaceWrongOrder;
+		}
+	}
+
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -330,11 +330,11 @@ namespace SpecTests {
 	class GenericTypeFieldTests {
 		// Generic type parameter state with mutable and immutable concrete types
 
-		sealed class GenericClassWithNoState<[Objects.Immutable] T> {
+		class GenericClassWithNoState<[Objects.Immutable] T> {
 			// Test to ensure that marking a type parameter and not holding it has no effect
 		}
 
-		sealed class MutableGenericClassWithImmutableState<[Objects.Immutable] T> {
+		class MutableGenericClassWithImmutableState<[Objects.Immutable] T> {
 			// Test to ensure that marking a type parameter and holding it, but 
 			// not being yourself immutable causes no problems
 			internal T m_GenericClassWithImmutableState;
@@ -377,6 +377,17 @@ namespace SpecTests {
 		class /* ImmutableClassIsnt('m_ConcreteClassWithImmutableInterfaceMutableType''s type ('SpecTests.MutableClass') is a type parameter that must be marked with `[Objects.Immutable]`) */ ConcreteClassWithImmutableInterfaceMutableType /**/ {
 			internal readonly ImmutableGenericInterface<MutableClass> m_ConcreteClassWithImmutableInterfaceMutableType;
 		}
+
+		/*
+		[Objects.Immutable]
+		class ConcreteImmutableFromInterface: ImmutableGenericInterface<MutableClass> {
+		}
+
+		[Objects.Immutable]
+		class ConcreteImmutableFromInterface : ImmutableGenericInterface<MutableClass> {
+			private readonly MutableClass m_mutableClass;
+		}
+		*/
 	}
 
 	class MultipleGenericParameterTests {
@@ -445,4 +456,20 @@ namespace SpecTests {
 
 	}
 
+	class GenericBaseClassTests {
+		// Generic type parameter state with mutable and immutable concrete types
+
+		[Objects.ImmutableBaseClass]
+		class ImmutableBase<[Objects.Immutable] T> {
+			internal readonly T m_ImmutableBase;
+		}
+
+		[Objects.Immutable]
+		sealed class /* ImmutableClassIsnt('m_ImmutableBase.m_MutableClass' is not read-only) */ MutableImpl /**/ : ImmutableBase<MutableClass> {
+		}
+
+		[Objects.Immutable]
+		sealed class ImmutableImpl : ImmutableBase<ImmutableClass> {
+		}
+	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -466,4 +466,28 @@ namespace SpecTests {
 		sealed class ImmutableImpl : ImmutableBase<ImmutableClass> {
 		}
 	}
+
+	class BaseParameterInspectionTests {
+
+		[Objects.Immutable]
+		interface IImmutableRoot<[Objects.Immutable] W> {
+		}
+
+		interface IMiddle<T> : IImmutableRoot<T> {
+		}
+
+		interface IMutableRoot<T> {
+		}
+
+		[Objects.ImmutableBaseClass]
+		class MixinBase<U, V> : IMutableRoot<U>, IMiddle<V> {
+			private readonly V m_V;
+		}
+
+		class ImmutableConcrete : MixinBase<MutableClass, ImmutableClass> {
+		}
+
+		class /* ImmutableClassIsnt('m_V.m_MutableClass' is not read-only) */ MutableConcrete /**/ : MixinBase<ImmutableClass, MutableClass> {
+		}
+	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -378,16 +378,10 @@ namespace SpecTests {
 			internal readonly ImmutableGenericInterface<MutableClass> m_ConcreteClassWithImmutableInterfaceMutableType;
 		}
 
-		/*
 		[Objects.Immutable]
-		class ConcreteImmutableFromInterface: ImmutableGenericInterface<MutableClass> {
-		}
-
-		[Objects.Immutable]
-		class ConcreteImmutableFromInterface : ImmutableGenericInterface<MutableClass> {
+		class /* ImmutableClassIsnt('m_mutableClass.m_MutableClass' is not read-only) */ ConcreteImmutableFromInterface /**/ : ImmutableGenericInterface<MutableClass> {
 			private readonly MutableClass m_mutableClass;
 		}
-		*/
 	}
 
 	class MultipleGenericParameterTests {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -330,6 +330,16 @@ namespace SpecTests {
 	class GenericTypeFieldTests {
 		// Generic type parameter state with mutable and immutable concrete types
 
+		sealed class GenericClassWithNoState<[Objects.Immutable] T> {
+			// Test to ensure that marking a type parameter and not holding it has no effect
+		}
+
+		sealed class MutableGenericClassWithImmutableState<[Objects.Immutable] T> {
+			// Test to ensure that marking a type parameter and holding it, but 
+			// not being yourself immutable causes no problems
+			internal T m_GenericClassWithImmutableState;
+		}
+
 		[Objects.Immutable]
 		sealed class GenericClassWithImmutableState<[Objects.Immutable] T> {
 			internal readonly T m_GenericClassWithImmutableState;
@@ -378,6 +388,17 @@ namespace SpecTests {
 		}
 
 		[Objects.Immutable]
+		sealed class MultiImmutable<[Objects.Immutable] S, [Objects.Immutable] T> {
+			internal readonly S m_MultiGenericClassWithOneImmutableS;
+			internal readonly T m_MultiGenericClassWithOneImmutableT;
+		}
+
+		[Objects.Immutable]
+		sealed class MultiImmutableState {
+			private readonly MultiImmutable<ImmutableClass, ImmutableClass> m_MultiImmutableState;
+		}
+
+		[Objects.Immutable]
 		sealed class ConcreteHoldingMixedModeGeneric {
 			internal readonly MultiGenericClassWithOneImmutable<ImmutableClass, MutableClass> m_ConcreteHoldingMixedModeGeneric;
 		}
@@ -406,6 +427,22 @@ namespace SpecTests {
 		sealed class /* ImmutableClassIsnt('m_ConcreteUsingMultiGenericFromInterfaceWrongOrder.m_MultiGenericFromInterface.m_MutableClass' is not read-only) */ ConcreteUsingMultiGenericFromInterfaceWrongOrder /**/ {
 			internal readonly MultiGenericFromInterface<MutableClass, ImmutableClass> m_ConcreteUsingMultiGenericFromInterfaceWrongOrder;
 		}
+
+		[Objects.Immutable]
+		interface MultiImmutable<[Objects.Immutable] S, [Objects.Immutable] T> {
+		}
+
+		[Objects.Immutable]
+		sealed class MultiImmutableFromInterface<S, T> : MultiImmutable<S, T> {
+			internal readonly S m_MultiGenericFromInterfaceS;
+			internal readonly T m_MultiGenericFromInterfaceT;
+		}
+
+		[Objects.Immutable]
+		sealed class MultiImmutableState {
+			internal readonly MultiImmutableFromInterface<ImmutableClass, ImmutableClass> m_MultiImmutableState;
+		}
+
 	}
 
 }


### PR DESCRIPTION
-A generic type parameter can now me marked [Immutable] so it can be held inside an immutable generic
-Usages of the generic will ensure the type passed in to the immutable generic parameter is itself immutable