### PR TITLE
Adding support for immutable type parameters

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -202,5 +202,34 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 
 			return false;
 		}
+
+		public static bool IsGenericType( this ISymbol symbol ) {
+			if( symbol is INamedTypeSymbol ) {
+				var namedType = symbol as INamedTypeSymbol;
+				return ( namedType.TypeParameters.Length > 0 );
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Find the matching type argument in the base interface
+		/// that corresponds to this type parameter.  That is,
+		/// if we have Foo<S, T>: IFoo<S>, IBar<T>, this will
+		/// match up the Foo S, to the IFoo S, but will get -1
+		/// from IBar since it doesn't have S.
+		/// </summary>
+		public static int IndexOfArgument( 
+			this INamedTypeSymbol intf, string name 
+		) {
+
+			for (int ordinal = 0; ordinal < intf.TypeArguments.Length; ordinal++ ) {
+				if (string.Equals(intf.TypeArguments[ordinal].Name, name, StringComparison.Ordinal)) {
+					return ordinal;
+				}
+			}
+
+			return -1;
+		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -87,7 +87,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 			foreach( var typeArgument in type.TypeArguments ) {
 				// Can happen with generics, but I don't fully understand when
 				// it does, exactly.
-				if ( typeArgument.ContainingAssembly == null ) {
+				if( typeArgument.ContainingAssembly == null ) {
 					continue;
 				}
 
@@ -109,7 +109,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 					continue;
 				}
 
-				var arg = attr.ConstructorArguments[0];
+				var arg = attr.ConstructorArguments[ 0 ];
 				//Using ToString, otherwise it sometimes fails to match, and the test behaviour does not match the real behaviour
 				if( arg.Value.ToString().Equals( type.ToString() ) ) {
 					attribute = attr;
@@ -204,8 +204,8 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 		}
 
 		public static bool IsGenericType( this ISymbol symbol ) {
-			if( symbol is INamedTypeSymbol ) {
-				var namedType = symbol as INamedTypeSymbol;
+
+			if( symbol is INamedTypeSymbol namedType ) {
 				return ( namedType.TypeParameters.Length > 0 );
 			}
 
@@ -219,12 +219,13 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 		/// match up the Foo S, to the IFoo S, but will get -1
 		/// from IBar since it doesn't have S.
 		/// </summary>
-		public static int IndexOfArgument( 
-			this INamedTypeSymbol intf, string name 
+		public static int IndexOfArgument(
+			this INamedTypeSymbol intf,
+			string name
 		) {
 
-			for (int ordinal = 0; ordinal < intf.TypeArguments.Length; ordinal++ ) {
-				if (string.Equals(intf.TypeArguments[ordinal].Name, name, StringComparison.Ordinal)) {
+			for( int ordinal = 0; ordinal < intf.TypeArguments.Length; ordinal++ ) {
+				if( string.Equals( intf.TypeArguments[ ordinal ].Name, name, StringComparison.Ordinal ) ) {
 					return ordinal;
 				}
 			}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -63,10 +63,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			if( mutabilityResult.IsMutable ) {
 				var reason = m_resultFormatter.Format( mutabilityResult );
 				var location = GetLocationOfClassIdentifierAndGenericParameters( root );
-				var diagnostic = Diagnostic.Create( 
-					Diagnostics.ImmutableClassIsnt, 
-					location, 
-					reason 
+				var diagnostic = Diagnostic.Create(
+					Diagnostics.ImmutableClassIsnt,
+					location,
+					reason
 				);
 				context.ReportDiagnostic( diagnostic );
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResult.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResult.cs
@@ -18,7 +18,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		IsAnArray,
 		IsPotentiallyMutable,
 		IsDynamic,
-		IsAGenericType
+		IsAGenericType,
+		IsMutableTypeParameter
 	}
 
 	public sealed class MutabilityInspectionResult {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResultFormatter.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspectionResultFormatter.cs
@@ -55,6 +55,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					return "not deterministically immutable";
 				case MutabilityCause.IsADelegate:
 					return "a delegate (which can hold onto mutable state)";
+				case MutabilityCause.IsMutableTypeParameter:
+					return "a type parameter that must be marked with `[Objects.Immutable]`";
 				default:
 					throw new NotImplementedException( $"unknown cause '{result.Cause}'" );
 			}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Concurrent;
-using D2L.CodeStyle.Analyzers.Extensions;
 
 namespace D2L.CodeStyle.Analyzers.Immutability {
 	[Flags]
@@ -29,24 +29,24 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		/// A list of immutable container types (i.e., types that hold other types)
 		/// </summary>
 		private static readonly ImmutableDictionary<string, string[]> ImmutableContainerTypes = new Dictionary<string, string[]> {
-			[ "D2L.LP.Utilities.DeferredInitializer" ] = new[] { "Value" },
-			[ "D2L.LP.Extensibility.Activation.Domain.IPlugins" ] = new[] { "[]" },
-			[ "System.Collections.Immutable.IImmutableSet" ] = new[] { "[]" },
-			[ "System.Collections.Immutable.ImmutableArray" ] = new[] { "[]" },
-			[ "System.Collections.Immutable.ImmutableDictionary" ] = new[] { "[].Key", "[].Value" },
-			[ "System.Collections.Immutable.ImmutableHashSet" ] = new[] { "[]" },
-			[ "System.Collections.Immutable.ImmutableList" ] = new[] { "[]" },
-			[ "System.Collections.Immutable.ImmutableQueue" ] = new[] { "[]" },
-			[ "System.Collections.Immutable.ImmutableSortedDictionary" ] = new[] { "[].Key", "[].Value" },
-			[ "System.Collections.Immutable.ImmutableSortedSet" ] = new[] { "[]" },
-			[ "System.Collections.Immutable.ImmutableStack" ] = new[] { "[]" },
-			[ "System.Collections.Generic.IReadOnlyCollection" ] = new[] { "[]" },
-			[ "System.Collections.Generic.IReadOnlyList" ] = new[] { "[]" },
-			[ "System.Collections.Generic.IReadOnlyDictionary" ] = new[] { "[].Key", "[].Value" },
-			[ "System.Collections.Generic.IEnumerable" ] = new[] { "[]" },
-			[ "System.Lazy" ] = new[] { "Value" },
-			[ "System.Nullable" ] = new[] { "Value" },
-			[ "System.Tuple" ] = new[] { "Item1", "Item2", "Item3", "Item4", "Item5", "Item6" }
+			["D2L.LP.Utilities.DeferredInitializer"] = new[] { "Value" },
+			["D2L.LP.Extensibility.Activation.Domain.IPlugins"] = new[] { "[]" },
+			["System.Collections.Immutable.IImmutableSet"] = new[] { "[]" },
+			["System.Collections.Immutable.ImmutableArray"] = new[] { "[]" },
+			["System.Collections.Immutable.ImmutableDictionary"] = new[] { "[].Key", "[].Value" },
+			["System.Collections.Immutable.ImmutableHashSet"] = new[] { "[]" },
+			["System.Collections.Immutable.ImmutableList"] = new[] { "[]" },
+			["System.Collections.Immutable.ImmutableQueue"] = new[] { "[]" },
+			["System.Collections.Immutable.ImmutableSortedDictionary"] = new[] { "[].Key", "[].Value" },
+			["System.Collections.Immutable.ImmutableSortedSet"] = new[] { "[]" },
+			["System.Collections.Immutable.ImmutableStack"] = new[] { "[]" },
+			["System.Collections.Generic.IReadOnlyCollection"] = new[] { "[]" },
+			["System.Collections.Generic.IReadOnlyList"] = new[] { "[]" },
+			["System.Collections.Generic.IReadOnlyDictionary"] = new[] { "[].Key", "[].Value" },
+			["System.Collections.Generic.IEnumerable"] = new[] { "[]" },
+			["System.Lazy"] = new[] { "Value" },
+			["System.Nullable"] = new[] { "Value" },
+			["System.Tuple"] = new[] { "Item1", "Item2", "Item3", "Item4", "Item5", "Item6" }
 		}.ToImmutableDictionary();
 
 		private readonly KnownImmutableTypes m_knownImmutableTypes;
@@ -143,9 +143,15 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					+ "are referenced, including transitive dependencies." );
 			}
 
-			// If we're not verifying immutability, we might be able to bail out early
-			var scope = type.GetImmutabilityScope();
-			if( !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && scope == ImmutabilityScope.SelfAndChildren ) {
+			// If we're not verifying immutability, we might be able to bail 
+			// out earl, but we will not exit early if the type is simply 
+			// marked immutable if the type is generic since we need to 
+			// actually examine the generic type parameters.
+			ImmutabilityScope scope = type.GetImmutabilityScope();
+			if( !type.IsGenericType() 
+				&& !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) 
+				&& scope == ImmutabilityScope.SelfAndChildren 
+			) {
 				ImmutableHashSet<string> immutableExceptions = type.GetAllImmutableExceptions();
 				return MutabilityInspectionResult.NotMutable( immutableExceptions );
 			}
@@ -199,7 +205,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					);
 
 				case TypeKind.Interface:
-					return MutabilityInspectionResult.MutableType( type, MutabilityCause.IsAnInterface );
+					return InspectInterface(
+						type,
+						typeStack
+						);
 
 				case TypeKind.Class:
 				case TypeKind.Struct: // equivalent to TypeKind.Structure
@@ -249,8 +258,15 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return MutabilityInspectionResult.NotMutable();
 			}
 
-			var scope = type.GetImmutabilityScope();
-			if( !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) && scope != ImmutabilityScope.None ) {
+			// We need to *not* bail early if the type is generic otherwise
+			// we will assume that anything marked with [Immutable] is
+			// sufficiently immutable, and we also need to ensure the
+			// immutability of the type parameters is also appropriate.
+			ImmutabilityScope scope = type.GetImmutabilityScope();
+			if( !type.IsGenericType() 
+				&& !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) 
+				&& scope != ImmutabilityScope.None 
+			) {
 				ImmutableHashSet<string> immutableExceptions = type.GetAllImmutableExceptions();
 				return MutabilityInspectionResult.NotMutable( immutableExceptions );
 			}
@@ -293,7 +309,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				}
 
 				// We descend into the base class last
-				if ( type.BaseType != null ) {
+				if( type.BaseType != null ) {
 					var baseResult = InspectConcreteType( type.BaseType, typeStack );
 
 					if( baseResult.IsMutable ) {
@@ -321,7 +337,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			ImmutableHashSet<string>.Builder unauditedReasonsBuilder = ImmutableHashSet.CreateBuilder<string>();
 
 			for( int i = 0; i < namedType.TypeArguments.Length; i++ ) {
-				var arg = namedType.TypeArguments[ i ];
+				var arg = namedType.TypeArguments[i];
 
 				var result = InspectType(
 					arg,
@@ -333,7 +349,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					if( result.Target == MutabilityTarget.Member ) {
 						// modify the result to prefix with container member.
 						var prefix = ImmutableContainerTypes[type.GetFullTypeName()];
-						result = result.WithPrefixedMember( prefix[ i ] );
+						result = result.WithPrefixedMember( prefix[i] );
 					} else {
 						// modify the result to target the type argument if the
 						// target is not a member
@@ -350,18 +366,60 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			return MutabilityInspectionResult.NotMutable( unauditedReasonsBuilder.ToImmutable() );
 		}
 
+		private MutabilityInspectionResult InspectInterface(
+			ITypeSymbol symbol,
+			HashSet<ITypeSymbol> typeStack
+		) {
+			var typeSymbol = symbol as INamedTypeSymbol;
+
+			// There is a 1:1 correlation between TypeParameters and TypeArguments.
+			// TypeParameters is the "S", or "T" definition.
+			// TypeArguments are the actual *types* passed to S or T.
+			for (int ordinal = 0; ordinal < typeSymbol.TypeParameters.Length; ordinal++) {
+
+				bool isToBeImmutable = IsTypeArgumentImmutable( 
+					typeSymbol.TypeParameters[ordinal], 
+					ordinal, 
+					typeSymbol );
+
+				if (!isToBeImmutable) {
+					continue;
+				}
+
+				ITypeSymbol parameterType = typeSymbol.TypeArguments[ordinal];
+				MutabilityInspectionResult result = InspectType( parameterType );
+				if( result.IsMutable ) {
+					return MutabilityInspectionResult.MutableType( 
+						parameterType, 
+						MutabilityCause.IsMutableTypeParameter );
+				}
+			}
+
+			// Detects if the interface itself is marked with Immutable
+			ImmutabilityScope scope = typeSymbol.GetImmutabilityScope();
+			if( scope != ImmutabilityScope.None) {
+				return MutabilityInspectionResult.NotMutable();
+			}
+
+			// If we've reached here, it's an interface with no type parameters
+			// that is not marked Immutable
+			return MutabilityInspectionResult.MutableType( symbol, MutabilityCause.IsAnInterface );
+		}
+
 		private MutabilityInspectionResult InspectTypeParameter(
 			ITypeSymbol symbol,
 			HashSet<ITypeSymbol> typeStack
 		) {
 			var typeParameter = symbol as ITypeParameterSymbol;
 
-			if( typeParameter.ConstraintTypes != null || typeParameter.ConstraintTypes.Length > 0 ) {
-				// there are constraints we can check. as type constraints are unionized, we only need one 
-				// type constraint to be immutable to succeed
+			if( typeParameter.ConstraintTypes != null 
+				|| typeParameter.ConstraintTypes.Length > 0 ) {
+				// there are constraints we can check. as type constraints are 
+				// unionized, we only need one type constraint to be immutable 
+				// to succeed
 				foreach( var constraintType in typeParameter.ConstraintTypes ) {
 
-					var result = InspectType(
+					MutabilityInspectionResult result = InspectType(
 						constraintType,
 						MutabilityInspectionFlags.Default,
 						typeStack
@@ -371,6 +429,37 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						return result;
 					}
 				}
+			}
+
+			// We have to walk all base types and interfaces to find the
+			// type param in the same position and examine those to see if
+			// the immutability attribute is present.
+			INamedTypeSymbol currentType = typeParameter.ContainingType;
+			while( currentType != null ) {
+				// Check all interfaces
+				foreach( INamedTypeSymbol intf in currentType.Interfaces ) {
+
+					// Find out if this interface exposes a type argument
+					// with the specified type name.  If it doesn't, this 
+					// interface doesn't contribute to the immutability chain.
+					var ordinal = intf.IndexOfArgument( typeParameter.Name );
+					if (ordinal < 0) {
+						continue;
+					}
+
+					var subTypeSymbol = intf.TypeArguments[ordinal] as ITypeParameterSymbol;
+					if( IsTypeArgumentImmutable( subTypeSymbol, ordinal, intf ) ) {
+						return MutabilityInspectionResult.NotMutable();
+					}
+				}
+
+				// Check the type
+				if( typeParameter.GetImmutabilityScope() != ImmutabilityScope.None ) {
+					return MutabilityInspectionResult.NotMutable();
+				}
+
+				// Walk up the type heirarchy
+				currentType = currentType.BaseType;
 			}
 
 			return MutabilityInspectionResult.MutableType(
@@ -485,6 +574,56 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		}
 
 		/// <summary>
+		/// Walks all ancestors to this type parameter to determine if it was
+		/// intended that the type be immutable.  If *any* ancestor says the
+		/// type was supposed to be immutable, then the type will be 
+		/// assumed to mandatory immutable.
+		/// </summary>
+		private static bool IsTypeArgumentImmutable(
+			ITypeParameterSymbol typeParameter,
+			int parameterOrdinal,
+			INamedTypeSymbol symbol
+		) {
+			if( symbol == default ) {
+				return false;
+			}
+
+			if (typeParameter == default) {
+				return false;
+			}
+
+			// We needt the TypeParameter here, otherwise we're inspecting
+			// the type and not the declaration.  We need to inspect the 
+			// declaration because that's the symbol that will have the
+			// [Immutable] attached to it.
+			var isMarkedImmutable = symbol.TypeParameters[parameterOrdinal]
+				.GetImmutabilityScope() != ImmutabilityScope.None;
+
+			if( isMarkedImmutable ) {
+				return true;
+			}
+
+			foreach( var intf in symbol.Interfaces ) {
+				int ordinal = intf.IndexOfArgument( typeParameter.Name );
+
+				if (ordinal < 0) {
+					continue;
+				}
+
+				// We pass through the type argument otherwise the "name"
+				// applied to the type will drift based on the declaration
+				// and be impossible to track.  Using this means that the
+				// name declared at the top is consistent all the way down.
+				var subTypeParameter = intf.TypeArguments[ordinal] as ITypeParameterSymbol;
+				if( IsTypeArgumentImmutable( subTypeParameter, ordinal, intf ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/// <summary>
 		/// Get the declaration syntax for a symbol. This is intended to be
 		/// used for fields and properties which can't have multiple
 		/// declaration nodes.
@@ -500,7 +639,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				);
 			}
 
-			SyntaxNode syntax = decls[ 0 ].GetSyntax();
+			SyntaxNode syntax = decls[0].GetSyntax();
 
 			var decl = syntax as T;
 			if( decl == null ) {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -144,7 +144,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			// If we're not verifying immutability, we might be able to bail 
-			// out earl, but we will not exit early if the type is simply 
+			// out early, but we will not exit early if the type is simply 
 			// marked immutable if the type is generic since we need to 
 			// actually examine the generic type parameters.
 			ImmutabilityScope scope = type.GetImmutabilityScope();
@@ -433,8 +433,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return MutabilityInspectionResult.MutableType( symbol, MutabilityCause.IsAGenericType );
 			}
 
-			if( typeParameter.ConstraintTypes != null
-				|| typeParameter.ConstraintTypes.Length > 0 ) {
+			if( typeParameter.ConstraintTypes != null ) {
+
 				// there are constraints we can check. as type constraints are 
 				// unionized, we only need one type constraint to be immutable 
 				// to succeed
@@ -453,7 +453,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			// We have to walk all base types and interfaces to find the
-			// type param in the same position and examine those to see if
+			// type param with the same name and examine those to see if
 			// the immutability attribute is present.
 			INamedTypeSymbol currentType = typeParameter.ContainingType;
 			while( currentType != null ) {
@@ -614,7 +614,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return false;
 			}
 
-			// We needt the TypeParameter here, otherwise we're inspecting
+			// We need the TypeParameter here, otherwise we're inspecting
 			// the type and not the declaration.  We need to inspect the 
 			// declaration because that's the symbol that will have the
 			// [Immutable] attached to it.
@@ -626,8 +626,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			foreach( INamedTypeSymbol intf in symbol.Interfaces ) {
-				int ordinal = intf.IndexOfArgument( typeParameter.Name );
 
+				int ordinal = intf.IndexOfArgument( typeParameter.Name );
 				if( ordinal < 0 ) {
 					continue;
 				}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -29,24 +29,24 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		/// A list of immutable container types (i.e., types that hold other types)
 		/// </summary>
 		private static readonly ImmutableDictionary<string, string[]> ImmutableContainerTypes = new Dictionary<string, string[]> {
-			["D2L.LP.Utilities.DeferredInitializer"] = new[] { "Value" },
-			["D2L.LP.Extensibility.Activation.Domain.IPlugins"] = new[] { "[]" },
-			["System.Collections.Immutable.IImmutableSet"] = new[] { "[]" },
-			["System.Collections.Immutable.ImmutableArray"] = new[] { "[]" },
-			["System.Collections.Immutable.ImmutableDictionary"] = new[] { "[].Key", "[].Value" },
-			["System.Collections.Immutable.ImmutableHashSet"] = new[] { "[]" },
-			["System.Collections.Immutable.ImmutableList"] = new[] { "[]" },
-			["System.Collections.Immutable.ImmutableQueue"] = new[] { "[]" },
-			["System.Collections.Immutable.ImmutableSortedDictionary"] = new[] { "[].Key", "[].Value" },
-			["System.Collections.Immutable.ImmutableSortedSet"] = new[] { "[]" },
-			["System.Collections.Immutable.ImmutableStack"] = new[] { "[]" },
-			["System.Collections.Generic.IReadOnlyCollection"] = new[] { "[]" },
-			["System.Collections.Generic.IReadOnlyList"] = new[] { "[]" },
-			["System.Collections.Generic.IReadOnlyDictionary"] = new[] { "[].Key", "[].Value" },
-			["System.Collections.Generic.IEnumerable"] = new[] { "[]" },
-			["System.Lazy"] = new[] { "Value" },
-			["System.Nullable"] = new[] { "Value" },
-			["System.Tuple"] = new[] { "Item1", "Item2", "Item3", "Item4", "Item5", "Item6" }
+			[ "D2L.LP.Utilities.DeferredInitializer" ] = new[] { "Value" },
+			[ "D2L.LP.Extensibility.Activation.Domain.IPlugins" ] = new[] { "[]" },
+			[ "System.Collections.Immutable.IImmutableSet" ] = new[] { "[]" },
+			[ "System.Collections.Immutable.ImmutableArray" ] = new[] { "[]" },
+			[ "System.Collections.Immutable.ImmutableDictionary" ] = new[] { "[].Key", "[].Value" },
+			[ "System.Collections.Immutable.ImmutableHashSet" ] = new[] { "[]" },
+			[ "System.Collections.Immutable.ImmutableList" ] = new[] { "[]" },
+			[ "System.Collections.Immutable.ImmutableQueue" ] = new[] { "[]" },
+			[ "System.Collections.Immutable.ImmutableSortedDictionary" ] = new[] { "[].Key", "[].Value" },
+			[ "System.Collections.Immutable.ImmutableSortedSet" ] = new[] { "[]" },
+			[ "System.Collections.Immutable.ImmutableStack" ] = new[] { "[]" },
+			[ "System.Collections.Generic.IReadOnlyCollection" ] = new[] { "[]" },
+			[ "System.Collections.Generic.IReadOnlyList" ] = new[] { "[]" },
+			[ "System.Collections.Generic.IReadOnlyDictionary" ] = new[] { "[].Key", "[].Value" },
+			[ "System.Collections.Generic.IEnumerable" ] = new[] { "[]" },
+			[ "System.Lazy" ] = new[] { "Value" },
+			[ "System.Nullable" ] = new[] { "Value" },
+			[ "System.Tuple" ] = new[] { "Item1", "Item2", "Item3", "Item4", "Item5", "Item6" }
 		}.ToImmutableDictionary();
 
 		private readonly KnownImmutableTypes m_knownImmutableTypes;
@@ -148,9 +148,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// marked immutable if the type is generic since we need to 
 			// actually examine the generic type parameters.
 			ImmutabilityScope scope = type.GetImmutabilityScope();
-			if( !type.IsGenericType() 
-				&& !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) 
-				&& scope == ImmutabilityScope.SelfAndChildren 
+			if( !type.IsGenericType()
+				&& !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute )
+				&& scope == ImmutabilityScope.SelfAndChildren
 			) {
 				ImmutableHashSet<string> immutableExceptions = type.GetAllImmutableExceptions();
 				return MutabilityInspectionResult.NotMutable( immutableExceptions );
@@ -208,7 +208,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					return InspectInterface(
 						type,
 						typeStack
-						);
+					);
 
 				case TypeKind.Class:
 				case TypeKind.Struct: // equivalent to TypeKind.Structure
@@ -263,9 +263,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// sufficiently immutable, and we also need to ensure the
 			// immutability of the type parameters is also appropriate.
 			ImmutabilityScope scope = type.GetImmutabilityScope();
-			if( !type.IsGenericType() 
-				&& !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute ) 
-				&& scope != ImmutabilityScope.None 
+			if( !type.IsGenericType()
+				&& !flags.HasFlag( MutabilityInspectionFlags.IgnoreImmutabilityAttribute )
+				&& scope != ImmutabilityScope.None
 			) {
 				ImmutableHashSet<string> immutableExceptions = type.GetAllImmutableExceptions();
 				return MutabilityInspectionResult.NotMutable( immutableExceptions );
@@ -344,7 +344,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			ImmutableHashSet<string>.Builder unauditedReasonsBuilder = ImmutableHashSet.CreateBuilder<string>();
 
 			for( int i = 0; i < namedType.TypeArguments.Length; i++ ) {
-				ITypeSymbol arg = namedType.TypeArguments[i];
+				ITypeSymbol arg = namedType.TypeArguments[ i ];
 
 				MutabilityInspectionResult result = InspectType(
 					arg,
@@ -355,8 +355,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				if( result.IsMutable ) {
 					if( result.Target == MutabilityTarget.Member ) {
 						// modify the result to prefix with container member.
-						string[] prefix = ImmutableContainerTypes[type.GetFullTypeName()];
-						result = result.WithPrefixedMember( prefix[i] );
+						string[] prefix = ImmutableContainerTypes[ type.GetFullTypeName() ];
+						result = result.WithPrefixedMember( prefix[ i ] );
 					} else {
 						// modify the result to target the type argument if the
 						// target is not a member
@@ -389,29 +389,29 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// There is a 1:1 correlation between TypeParameters and TypeArguments.
 			// TypeParameters is the "S", or "T" definition.
 			// TypeArguments are the actual *types* passed to S or T.
-			for( int ordinal = 0; ordinal < typeSymbol.TypeParameters.Length; ordinal++) {
+			for( int ordinal = 0; ordinal < typeSymbol.TypeParameters.Length; ordinal++ ) {
 
-				bool isToBeImmutable = IsTypeArgumentImmutable( 
-					typeSymbol.TypeParameters[ordinal], 
-					ordinal, 
+				bool isToBeImmutable = IsTypeArgumentImmutable(
+					typeSymbol.TypeParameters[ ordinal ],
+					ordinal,
 					typeSymbol );
 
-				if (!isToBeImmutable) {
+				if( !isToBeImmutable ) {
 					continue;
 				}
 
-				ITypeSymbol parameterType = typeSymbol.TypeArguments[ordinal];
+				ITypeSymbol parameterType = typeSymbol.TypeArguments[ ordinal ];
 				MutabilityInspectionResult result = InspectType( parameterType );
 				if( result.IsMutable ) {
-					return MutabilityInspectionResult.MutableType( 
-						parameterType, 
+					return MutabilityInspectionResult.MutableType(
+						parameterType,
 						MutabilityCause.IsMutableTypeParameter );
 				}
 			}
 
 			// Detects if the interface itself is marked with Immutable
 			ImmutabilityScope scope = typeSymbol.GetImmutabilityScope();
-			if( scope != ImmutabilityScope.None) {
+			if( scope != ImmutabilityScope.None ) {
 				return MutabilityInspectionResult.NotMutable();
 			}
 
@@ -429,11 +429,11 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// If we can't determine what the symbol is then we'll bail with
 			// a general mutability response, otherwise we're going to have a
 			// lot of NREs below.
-			if( typeParameter == default) {
+			if( typeParameter == default ) {
 				return MutabilityInspectionResult.MutableType( symbol, MutabilityCause.IsAGenericType );
 			}
 
-			if( typeParameter.ConstraintTypes != null 
+			if( typeParameter.ConstraintTypes != null
 				|| typeParameter.ConstraintTypes.Length > 0 ) {
 				// there are constraints we can check. as type constraints are 
 				// unionized, we only need one type constraint to be immutable 
@@ -457,6 +457,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// the immutability attribute is present.
 			INamedTypeSymbol currentType = typeParameter.ContainingType;
 			while( currentType != null ) {
+
 				// Check all interfaces
 				foreach( INamedTypeSymbol intf in currentType.Interfaces ) {
 
@@ -464,11 +465,11 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					// with the specified type name.  If it doesn't, this 
 					// interface doesn't contribute to the immutability chain.
 					int ordinal = intf.IndexOfArgument( typeParameter.Name );
-					if (ordinal < 0) {
+					if( ordinal < 0 ) {
 						continue;
 					}
 
-					var subTypeSymbol = intf.TypeArguments[ordinal] as ITypeParameterSymbol;
+					var subTypeSymbol = intf.TypeArguments[ ordinal ] as ITypeParameterSymbol;
 					if( IsTypeArgumentImmutable( subTypeSymbol, ordinal, intf ) ) {
 						return MutabilityInspectionResult.NotMutable();
 					}
@@ -609,7 +610,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return false;
 			}
 
-			if (typeParameter == default) {
+			if( typeParameter == default ) {
 				return false;
 			}
 
@@ -617,7 +618,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// the type and not the declaration.  We need to inspect the 
 			// declaration because that's the symbol that will have the
 			// [Immutable] attached to it.
-			bool isMarkedImmutable = symbol.TypeParameters[parameterOrdinal]
+			bool isMarkedImmutable = symbol.TypeParameters[ parameterOrdinal ]
 				.GetImmutabilityScope() != ImmutabilityScope.None;
 
 			if( isMarkedImmutable ) {
@@ -627,7 +628,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			foreach( INamedTypeSymbol intf in symbol.Interfaces ) {
 				int ordinal = intf.IndexOfArgument( typeParameter.Name );
 
-				if (ordinal < 0) {
+				if( ordinal < 0 ) {
 					continue;
 				}
 
@@ -635,7 +636,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				// applied to the type will drift based on the declaration
 				// and be impossible to track.  Using this means that the
 				// name declared at the top is consistent all the way down.
-				var subTypeParameter = intf.TypeArguments[ordinal] as ITypeParameterSymbol;
+				var subTypeParameter = intf.TypeArguments[ ordinal ] as ITypeParameterSymbol;
 				if( IsTypeArgumentImmutable( subTypeParameter, ordinal, intf ) ) {
 					return true;
 				}
@@ -660,7 +661,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				);
 			}
 
-			SyntaxNode syntax = decls[0].GetSyntax();
+			SyntaxNode syntax = decls[ 0 ].GetSyntax();
 
 			var decl = syntax as T;
 			if( decl == null ) {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -334,6 +334,13 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		) {
 			var namedType = type as INamedTypeSymbol;
 
+			// If we can't determine what the symbol is then we'll bail with
+			// a general mutability response, otherwise we're going to have a
+			// lot of NREs below.
+			if( namedType == default ) {
+				return MutabilityInspectionResult.MutableType( type, MutabilityCause.IsPotentiallyMutable );
+			}
+
 			ImmutableHashSet<string>.Builder unauditedReasonsBuilder = ImmutableHashSet.CreateBuilder<string>();
 
 			for( int i = 0; i < namedType.TypeArguments.Length; i++ ) {
@@ -372,10 +379,17 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		) {
 			var typeSymbol = symbol as INamedTypeSymbol;
 
+			// If we can't determine what the symbol is then we'll bail with
+			// a general mutability response, otherwise we're going to have a
+			// lot of NREs below.
+			if( typeSymbol == default ) {
+				return MutabilityInspectionResult.MutableType( symbol, MutabilityCause.IsPotentiallyMutable );
+			}
+
 			// There is a 1:1 correlation between TypeParameters and TypeArguments.
 			// TypeParameters is the "S", or "T" definition.
 			// TypeArguments are the actual *types* passed to S or T.
-			for (int ordinal = 0; ordinal < typeSymbol.TypeParameters.Length; ordinal++) {
+			for( int ordinal = 0; ordinal < typeSymbol.TypeParameters.Length; ordinal++) {
 
 				bool isToBeImmutable = IsTypeArgumentImmutable( 
 					typeSymbol.TypeParameters[ordinal], 
@@ -411,6 +425,13 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			HashSet<ITypeSymbol> typeStack
 		) {
 			var typeParameter = symbol as ITypeParameterSymbol;
+
+			// If we can't determine what the symbol is then we'll bail with
+			// a general mutability response, otherwise we're going to have a
+			// lot of NREs below.
+			if( typeParameter == default) {
+				return MutabilityInspectionResult.MutableType( symbol, MutabilityCause.IsAGenericType );
+			}
 
 			if( typeParameter.ConstraintTypes != null 
 				|| typeParameter.ConstraintTypes.Length > 0 ) {

--- a/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
@@ -19,6 +19,7 @@ namespace D2L.CodeStyle.Annotations {
 			validOn: AttributeTargets.Class
 			       | AttributeTargets.Interface
 			       | AttributeTargets.Struct
+			       | AttributeTargets.GenericParameter
 		)]
 		public sealed class Immutable : ImmutableAttributeBase { }
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -5,7 +5,7 @@ using D2L.CodeStyle.Annotations;
 using D2L.LP.Extensibility.Activation.Domain;
 
 [assembly: Objects.ImmutableGeneric(
-	type: typeof(SpecTests.GenericsTests.IFactory<Version>) 
+	type: typeof( SpecTests.GenericsTests.IFactory<Version> )
 )]
 
 [assembly: Objects.ImmutableGeneric(
@@ -18,9 +18,9 @@ namespace D2L.LP.Extensibility.Activation.Domain {
 
 namespace D2L.CodeStyle.Annotations {
 	public static class Objects {
-		public abstract class ImmutableAttributeBase : Attribute { 
+		public abstract class ImmutableAttributeBase : Attribute {
 			public Except Except { get; set; }
-    }
+		}
 		public sealed class Immutable : ImmutableAttributeBase { }
 		public sealed class ImmutableBaseClassAttribute : ImmutableAttributeBase { }
 
@@ -43,7 +43,7 @@ namespace D2L.CodeStyle.Annotations {
 	public static class Mutability {
 		public sealed class AuditedAttribute : Attribute { }
 		public sealed class UnauditedAttribute : Attribute {
-			public UnauditedAttribute( Because why ) {}
+			public UnauditedAttribute( Because why ) { }
 		}
 	}
 	public enum Because {
@@ -57,6 +57,17 @@ namespace D2L.CodeStyle.Annotations {
 }
 
 namespace SpecTests {
+
+	// Items used in multiple test spaces are defined outside of the spaces
+	sealed class ImmutableClass {
+		private readonly string m_ImmutableClass;
+	}
+
+	sealed class MutableClass {
+		private string m_MutableClass;
+	}
+
+
 
 	class AnnotationsTests {
 		[Objects.Immutable]
@@ -160,7 +171,7 @@ namespace SpecTests {
 
 		[Objects.Immutable]
 		class IndexerPropertyClass {
-			object this[ int index ] {
+			object this[int index] {
 				get { return null; }
 			}
 		}
@@ -256,7 +267,7 @@ namespace SpecTests {
 		sealed class W { readonly X x1, x2, x3; }
 		sealed class X { readonly Y y1, y2, y3; }
 		sealed class Y { readonly Z z1, z2, z3; }
-		sealed class Z {}
+		sealed class Z { }
 
 		#endregion
 	}
@@ -314,5 +325,169 @@ namespace SpecTests {
 			private readonly IImmutableMember m_auditedBad;
 		}
 
+	}
+
+	class GenericTypeFieldTests {
+		// Generic type parameter state with mutable and immutable concrete types
+
+		class GenericClassWithNoState<[Objects.Immutable] T> {
+			// Test to ensure that marking a type parameter and not holding it has no effect
+		}
+
+		class MutableGenericClassWithImmutableState<[Objects.Immutable] T> {
+			// Test to ensure that marking a type parameter and holding it, but 
+			// not being yourself immutable causes no problems
+			internal T m_GenericClassWithImmutableState;
+		}
+
+		[Objects.Immutable]
+		sealed class GenericClassWithImmutableState<[Objects.Immutable] T> {
+			internal readonly T m_GenericClassWithImmutableState;
+		}
+
+		[Objects.Immutable]
+		class /* ImmutableClassIsnt('m_ConcreteClassWithMutableGenericType.m_GenericClassWithImmutableState.m_MutableClass' is not read-only) */ ConcreteClassWithMutableGenericType /**/ {
+			internal readonly GenericClassWithImmutableState<MutableClass> m_ConcreteClassWithMutableGenericType;
+		}
+
+		[Objects.Immutable]
+		class ConcreteClassWithImmutableGenericType {
+			internal readonly GenericClassWithImmutableState<ImmutableClass> m_ConcreteClassWithImmutableGenericType;
+		}
+	}
+
+	class GenericTypeParameterTests {
+		// Ensures generic type parameters from an interface are examined
+
+		[Objects.Immutable]
+		interface ImmutableGenericInterface<[Objects.Immutable] T> {
+		}
+
+		[Objects.Immutable]
+		sealed class GenericClassWithImmutableInterface<T> : ImmutableGenericInterface<T> {
+			internal readonly T m_GenericClassWithImmutableInterface;
+		}
+
+		[Objects.Immutable]
+		class ConcreteClassWithImmutableInterfaceImmutableType {
+			internal readonly ImmutableGenericInterface<ImmutableClass> m_ConcreteClassWithImmutableInterfaceImmutableType;
+		}
+
+		[Objects.Immutable]
+		class /* ImmutableClassIsnt('m_ConcreteClassWithImmutableInterfaceMutableType''s type ('SpecTests.MutableClass') is a type parameter that must be marked with `[Objects.Immutable]`) */ ConcreteClassWithImmutableInterfaceMutableType /**/ {
+			internal readonly ImmutableGenericInterface<MutableClass> m_ConcreteClassWithImmutableInterfaceMutableType;
+		}
+
+		[Objects.Immutable]
+		class /* ImmutableClassIsnt('m_mutableClass.m_MutableClass' is not read-only) */ ConcreteImmutableFromInterface /**/ : ImmutableGenericInterface<MutableClass> {
+			private readonly MutableClass m_mutableClass;
+		}
+	}
+
+	class MultipleGenericParameterTests {
+		// Tests when there is a mixed set of mutable and immutable type parameters
+
+		[Objects.Immutable]
+		sealed class MultiGenericClassWithOneImmutable<[Objects.Immutable] T, S> {
+			internal readonly T m_MultiGenericClassWithOneImmutable;
+		}
+
+		[Objects.Immutable]
+		sealed class MultiImmutable<[Objects.Immutable] S, [Objects.Immutable] T> {
+			internal readonly S m_MultiGenericClassWithOneImmutableS;
+			internal readonly T m_MultiGenericClassWithOneImmutableT;
+		}
+
+		[Objects.Immutable]
+		sealed class MultiImmutableState {
+			private readonly MultiImmutable<ImmutableClass, ImmutableClass> m_MultiImmutableState;
+		}
+
+		[Objects.Immutable]
+		sealed class ConcreteHoldingMixedModeGeneric {
+			internal readonly MultiGenericClassWithOneImmutable<ImmutableClass, MutableClass> m_ConcreteHoldingMixedModeGeneric;
+		}
+
+		[Objects.Immutable]
+		sealed class /* ImmutableClassIsnt('m_ConcreteHoldingMixedModeGenericWrongOrder.m_MultiGenericClassWithOneImmutable.m_MutableClass' is not read-only) */ ConcreteHoldingMixedModeGenericWrongOrder /**/ {
+			internal readonly MultiGenericClassWithOneImmutable<MutableClass, ImmutableClass> m_ConcreteHoldingMixedModeGenericWrongOrder;
+		}
+	}
+
+	class MultipleGenericInterfaceParameterTests {
+		[Objects.Immutable]
+		interface MultiGeneric<[Objects.Immutable] S, T> {
+		}
+
+		sealed class MultiGenericFromInterface<S, T> : MultiGeneric<S, T> {
+			internal readonly S m_MultiGenericFromInterface;
+		}
+
+		[Objects.Immutable]
+		sealed class ConcreteUsingMultiGenericFromInterface {
+			internal readonly MultiGenericFromInterface<ImmutableClass, NonReadOnlyClass> m_ConcreteUsingMultiGenericFromInterface;
+		}
+
+		[Objects.Immutable]
+		sealed class /* ImmutableClassIsnt('m_ConcreteUsingMultiGenericFromInterfaceWrongOrder.m_MultiGenericFromInterface.m_MutableClass' is not read-only) */ ConcreteUsingMultiGenericFromInterfaceWrongOrder /**/ {
+			internal readonly MultiGenericFromInterface<MutableClass, ImmutableClass> m_ConcreteUsingMultiGenericFromInterfaceWrongOrder;
+		}
+
+		[Objects.Immutable]
+		interface MultiImmutable<[Objects.Immutable] S, [Objects.Immutable] T> {
+		}
+
+		[Objects.Immutable]
+		sealed class MultiImmutableFromInterface<S, T> : MultiImmutable<S, T> {
+			internal readonly S m_MultiGenericFromInterfaceS;
+			internal readonly T m_MultiGenericFromInterfaceT;
+		}
+
+		[Objects.Immutable]
+		sealed class MultiImmutableState {
+			internal readonly MultiImmutableFromInterface<ImmutableClass, ImmutableClass> m_MultiImmutableState;
+		}
+
+	}
+
+	class GenericBaseClassTests {
+		// Generic type parameter state with mutable and immutable concrete types
+
+		[Objects.ImmutableBaseClass]
+		class ImmutableBase<[Objects.Immutable] T> {
+			internal readonly T m_ImmutableBase;
+		}
+
+		[Objects.Immutable]
+		sealed class /* ImmutableClassIsnt('m_ImmutableBase.m_MutableClass' is not read-only) */ MutableImpl /**/ : ImmutableBase<MutableClass> {
+		}
+
+		[Objects.Immutable]
+		sealed class ImmutableImpl : ImmutableBase<ImmutableClass> {
+		}
+	}
+
+	class BaseParameterInspectionTests {
+
+		[Objects.Immutable]
+		interface IImmutableRoot<[Objects.Immutable] W> {
+		}
+
+		interface IMiddle<T> : IImmutableRoot<T> {
+		}
+
+		interface IMutableRoot<T> {
+		}
+
+		[Objects.ImmutableBaseClass]
+		class MixinBase<U, V> : IMutableRoot<U>, IMiddle<V> {
+			private readonly V m_V;
+		}
+
+		class ImmutableConcrete : MixinBase<MutableClass, ImmutableClass> {
+		}
+
+		class /* ImmutableClassIsnt('m_V.m_MutableClass' is not read-only) */ MutableConcrete /**/ : MixinBase<ImmutableClass, MutableClass> {
+		}
 	}
 }


### PR DESCRIPTION
-A generic type parameter can now me marked [Immutable] so it can be held inside an immutable generic
-Usages of the generic will ensure the type passed in to the immutable generic parameter is itself immutable
-Adding tests for multiple immutable generic parameters.
-Adding tests for superfluous parameter annotation.
-Adding tests for mixin parameters and ordering.