### PR TITLE
Adding KnownImmutableTypes to the declaration analyzer

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Language/ImmutableGenericDeclarationAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/ImmutableGenericDeclarationAnalyzer.cs
@@ -22,13 +22,16 @@ namespace D2L.CodeStyle.Analyzers.Language {
 		private static void RegisterAnalyzer(
 			CompilationStartAnalysisContext context
 		) {
+			var knownImmutableTypes = new KnownImmutableTypes( context.Compilation.Assembly );
+
 			context.RegisterSyntaxNodeAction(
-				ctx => AnalyzeNode( ctx ),
+				ctx => AnalyzeNode( ctx, knownImmutableTypes ),
 				SyntaxKind.GenericName );
 		}
 
 		private static void AnalyzeNode(
-			SyntaxNodeAnalysisContext context
+			SyntaxNodeAnalysisContext context,
+			KnownImmutableTypes knownImmutableTypes
 		) {
 			var syntaxNode = context.Node as GenericNameSyntax;
 			SymbolInfo hostTypeSymbolInfo = context.SemanticModel.GetSymbolInfo( syntaxNode );
@@ -49,6 +52,10 @@ namespace D2L.CodeStyle.Analyzers.Language {
 				SymbolInfo argumentSymbolInfo = context.SemanticModel.GetSymbolInfo( typeArgumentNode.Arguments[ index ] );
 				var typeSymbol = argumentSymbolInfo.Symbol as ITypeSymbol;
 				if( typeSymbol == default ) {
+					continue;
+				}
+
+				if (knownImmutableTypes.IsTypeKnownImmutable(typeSymbol)) {
 					continue;
 				}
 

--- a/src/D2L.CodeStyle.Analyzers/Language/ImmutableGenericDeclarationAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/ImmutableGenericDeclarationAnalyzer.cs
@@ -55,7 +55,7 @@ namespace D2L.CodeStyle.Analyzers.Language {
 					continue;
 				}
 
-				if (knownImmutableTypes.IsTypeKnownImmutable(typeSymbol)) {
+				if( knownImmutableTypes.IsTypeKnownImmutable( typeSymbol ) ) {
 					continue;
 				}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutableGenericDeclarationAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutableGenericDeclarationAnalyzer.cs
@@ -32,7 +32,10 @@ namespace SpecTests {
 		class ConcreteMutableGeneric :/* GenericArgumentTypeMustBeImmutable(MutableClass) */ GenericBase<MutableClass> /**/{
 		}
 
-		class ConcreteImutableGeneric : GenericBase<ImmutableClass> {
+		class ConcreteImmutableGeneric : GenericBase<ImmutableClass> {
+		}
+
+		class ConcreteKnownImmutableGeneric: GenericBase<bool> {
 		}
 
 		[Objects.Immutable]
@@ -52,6 +55,9 @@ namespace SpecTests {
 		class ConcreteImmutableMultiGeneric : MultiGenericBase<ImmutableClass, ImmutableClass> {
 		}
 
+		class ConcreteKnownImmutableMultiGeneric: MultiGenericBase<bool, string> {
+		}
+
 		[Objects.Immutable]
 		interface ImmutableInterface<[Objects.Immutable] T> {
 		}
@@ -66,6 +72,9 @@ namespace SpecTests {
 		}
 
 		struct ImmutableStructImplementation : ImmutableInterface<ImmutableClass> {
+		}
+
+		struct KnownImmutableStructImplementation: ImmutableInterface<bool> {
 		}
 
 		[Objects.Immutable]
@@ -91,6 +100,9 @@ namespace SpecTests {
 		}
 
 		struct MixedImmutableStructMultiImplementation : MultiInterface<MutableClass, ImmutableClass> {
+		}
+
+		struct KnownMixedImmutableStructMultiImplementation: MultiInterface<bool, bool> {
 		}
 
 		class ClassMutableProperty {
@@ -156,5 +168,34 @@ namespace SpecTests {
 		interface InterfaceImmutableClassProperty {
 			GenericBase<ImmutableClass> Prop { get; set; }
 		}
+
+		class ClassKnownImmutableProperty {
+			GenericBase<bool> Prop { get; set; }
+		}
+
+		class ClassKnownImmutableInterfaceProperty {
+			ImmutableInterface<bool> Prop { get; set; }
+		}
+
+		class ClassKnownImmutableField {
+			GenericBase<bool> m_field;
+		}
+
+		struct StructKnownImmutableClassProperty {
+			GenericBase<bool> Prop { get; set; }
+		}
+
+		struct StructKnownImmutableInterfaceProperty {
+			ImmutableInterface<bool> Prop { get; set; }
+		}
+
+		struct StructKnownImmutableClassField {
+			GenericBase<bool> m_field;
+		}
+
+		struct StructKnownImmutableInterfaceField {
+			ImmutableInterface<bool> m_field;
+		}
+
 	}
 }


### PR DESCRIPTION
-Types that are known immutable do not need to be marked with [Immutable]