### PR TITLE
Bump Analyzers assembly version number (0.73.0)

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -10,9 +10,9 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible( false )]
 
-[assembly: AssemblyVersion( "0.72.5.0" )]
-[assembly: AssemblyFileVersion( "0.72.5.0" )]
-[assembly: AssemblyInformationalVersion( "0.72.5.0" )]
+[assembly: AssemblyVersion( "0.73.0.0" )]
+[assembly: AssemblyFileVersion( "0.73.0.0" )]
+[assembly: AssemblyInformationalVersion( "0.73.0.0" )]
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]
 [assembly: InternalsVisibleTo( "DynamicProxyGenAssembly2" )]


### PR DESCRIPTION
Changes: ASP.NET `Transfer` methods are now considered dangerous