### PR TITLE
Require that [Immutable] be applied transitively

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -36,6 +36,7 @@
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousMemberUsagesAnalyzer.cs" />
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousMethods.cs" />
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousProperties.cs" />
+    <Compile Include="Immutability\AddImmutableAttributeCodeFix.cs" />
     <Compile Include="Immutability\ExplicitImmutableAttributeTransitivityAnalyzer.cs" />
     <Compile Include="Immutability\ImmutableGenericArgument.cs" />
     <Compile Include="Immutability\ImmutableContainerMethods.cs" />

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -36,6 +36,7 @@
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousMemberUsagesAnalyzer.cs" />
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousMethods.cs" />
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousProperties.cs" />
+    <Compile Include="Immutability\ExplicitImmutableAttributeTransitivityAnalyzer.cs" />
     <Compile Include="Immutability\ImmutableGenericArgument.cs" />
     <Compile Include="Immutability\ImmutableContainerMethods.cs" />
     <Compile Include="Language\ImmutableGenericArgumentAnalyzer.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -341,5 +341,15 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true,
 			description: "Avoid using of dangerous properties"
 		);
+
+		public static readonly DiagnosticDescriptor MissingTransitiveImmutableAttribute = new DiagnosticDescriptor(
+			id: "D2L0040",
+			title: "Missing an explicit transitive [Immutable] attribute",
+			messageFormat: "{0} should be [Immutable] because the {1} {2} is.",
+			category: "",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "The implications of [Immutable] apply transitively to derived classes and interface implementations. We require that [Immutable] is explicity applied transitively for clarity and simplicity."
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableAttributeCodeFix.cs
@@ -1,0 +1,145 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace D2L.CodeStyle.Analyzers.Immutability {
+	[ExportCodeFixProvider(
+		LanguageNames.CSharp,
+		Name = nameof( AddImmutableAttributeCodeFix )
+	)]
+	public sealed class AddImmutableAttributeCodeFix : CodeFixProvider {
+		public override ImmutableArray<string> FixableDiagnosticIds
+			=> ImmutableArray.Create(
+				Diagnostics.MissingTransitiveImmutableAttribute.Id
+			);
+
+		public override FixAllProvider GetFixAllProvider() {
+			return WellKnownFixAllProviders.BatchFixer;
+		}
+
+		public override async Task RegisterCodeFixesAsync(
+			CodeFixContext context
+		) {
+			var root = await context.Document
+				.GetSyntaxRootAsync( context.CancellationToken )
+				.ConfigureAwait( false ) as CompilationUnitSyntax;
+
+			foreach( var diagnostic in context.Diagnostics ) {
+				var identifierSpan = diagnostic.Location.SourceSpan;
+
+				var decl = root.FindNode( identifierSpan ) as TypeDeclarationSyntax;
+
+				context.RegisterCodeFix(
+					CodeAction.Create(
+						title: "Add [Immutable]",
+						createChangedDocument: ct => Fix(
+							context.Document,
+							root,
+							decl,
+							ct
+						)
+					),
+					diagnostic
+				);
+			}
+		}
+
+		// Syntax for "[Immutable]"
+		private static readonly AttributeListSyntax ImmutableAttributeSyntax =
+			SyntaxFactory.AttributeList(
+				SyntaxFactory.SingletonSeparatedList(
+					SyntaxFactory.Attribute(
+						SyntaxFactory.IdentifierName( "Immutable" )
+					)
+				)
+			);
+
+		// Syntax for "using static D2L.CodeStyle.Annotations.Objects;"
+		private static readonly UsingDirectiveSyntax TheNecessaryUsingDirective =
+			SyntaxFactory.UsingDirective(
+				SyntaxFactory.ParseName( "D2L.CodeStyle.Annotations.Objects" )
+			).WithStaticKeyword(
+				SyntaxFactory.Token( SyntaxKind.StaticKeyword )
+			);
+
+		private static Task<Document> Fix(
+			Document orig,
+			CompilationUnitSyntax root,
+			TypeDeclarationSyntax decl,
+			CancellationToken ct
+		) {
+			var newDecl = AddImmutableAttribute( decl );
+
+			var newRoot = root.ReplaceNode( decl, newDecl );
+
+			if ( !newRoot.Usings.Any( IsTheNecessaryUsingDirective ) ) {
+				newRoot = newRoot.WithUsings(
+					newRoot.Usings.Add( TheNecessaryUsingDirective )
+				);
+			}
+
+			var newDoc = orig.WithSyntaxRoot( newRoot );
+
+			return Task.FromResult( newDoc );
+		}
+
+		public static bool IsTheNecessaryUsingDirective( UsingDirectiveSyntax u ) {
+			if ( u.StaticKeyword == null ) {
+				return false;
+			}
+
+			// Using a string here is pretty lame but I think it's ok.
+			return u.Name.ToString() == "D2L.CodeStyle.Annotations.Objects";
+		}
+		
+		public static TypeDeclarationSyntax AddImmutableAttribute(
+			TypeDeclarationSyntax decl
+		) {
+			if ( decl is ClassDeclarationSyntax cls ) {
+				return AddImmutableAttribute( cls );
+			} else if ( decl is StructDeclarationSyntax st ) {
+				return AddImmutableAttribute( st );
+			} else {
+				return AddImmutableAttribute( decl as InterfaceDeclarationSyntax );
+			}
+		}
+
+		#region AddImmutableAttribute overloads
+
+		// TypeDeclarationSyntax (the base class of these 3 types) doesn't
+		// have WithAttributeLists... so we need to copy+paste some code.
+
+		private static TypeDeclarationSyntax AddImmutableAttribute(
+			ClassDeclarationSyntax decl
+		) {
+			return decl.WithAttributeLists(
+				decl.AttributeLists.Add( ImmutableAttributeSyntax )
+			);
+		}
+
+		private static TypeDeclarationSyntax AddImmutableAttribute(
+			StructDeclarationSyntax decl
+		) {
+			return decl.WithAttributeLists(
+				decl.AttributeLists.Add( ImmutableAttributeSyntax )
+			);
+		}
+
+		private static TypeDeclarationSyntax AddImmutableAttribute(
+			InterfaceDeclarationSyntax decl
+		) {
+			return decl.WithAttributeLists(
+				decl.AttributeLists.Add( ImmutableAttributeSyntax )
+			);
+		}
+
+		#endregion
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableAttributeCodeFix.cs
@@ -114,46 +114,32 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		public static TypeDeclarationSyntax AddImmutableAttribute(
 			TypeDeclarationSyntax decl
 		) {
+			var leadingTrivia = decl.GetLeadingTrivia();
+
+			// Need to strip the trivia first before adding attribute lists
+			// because if it doesn't have any attr lists now it won't be able
+			// to remove the trivia from whatever the first token is when we
+			// add an attribute list.
+			decl = decl.WithoutLeadingTrivia();
+
+			// TypeDeclarationSyntax (the base class of these 3 types) doesn't
+			// have AddAttributeLists... so we need to copy+paste some code.
+
 			if ( decl is ClassDeclarationSyntax cls ) {
-				return AddImmutableAttribute( cls );
+				decl = cls.AddAttributeLists( ImmutableAttributeSyntax );
+
 			} else if ( decl is StructDeclarationSyntax st ) {
-				return AddImmutableAttribute( st );
+				decl = st.AddAttributeLists( ImmutableAttributeSyntax );
+
 			} else if ( decl is InterfaceDeclarationSyntax iface ) {
-				return AddImmutableAttribute( iface );
+				decl = iface.AddAttributeLists( ImmutableAttributeSyntax );
+
 			} else {
 				throw new NotImplementedException();
 			}
+
+			// Re-add any leading trivia
+			return decl.WithLeadingTrivia( leadingTrivia );
 		}
-
-		#region AddImmutableAttribute overloads
-
-		// TypeDeclarationSyntax (the base class of these 3 types) doesn't
-		// have WithAttributeLists... so we need to copy+paste some code.
-
-		private static TypeDeclarationSyntax AddImmutableAttribute(
-			ClassDeclarationSyntax decl
-		) {
-			return decl.WithAttributeLists(
-				decl.AttributeLists.Add( ImmutableAttributeSyntax )
-			);
-		}
-
-		private static TypeDeclarationSyntax AddImmutableAttribute(
-			StructDeclarationSyntax decl
-		) {
-			return decl.WithAttributeLists(
-				decl.AttributeLists.Add( ImmutableAttributeSyntax )
-			);
-		}
-
-		private static TypeDeclarationSyntax AddImmutableAttribute(
-			InterfaceDeclarationSyntax decl
-		) {
-			return decl.WithAttributeLists(
-				decl.AttributeLists.Add( ImmutableAttributeSyntax )
-			);
-		}
-
-		#endregion
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableAttributeCodeFix.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +10,18 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.Immutability {
+	// BUG: if there are two partial declarations, each declaring some
+	// implemented interfaces that have [Immutable] we may emit two, one for
+	// each decl which would make this code fix insert multiple [Immutable]
+	// attributes if the user does a "Fix All" in VS. This will break because
+	// [Immutable] has AllowMultiple = false.
+	//
+	// To fix it maybe we could make this fixer find all decl syntaxes
+	// and use some method to pick one (e.g. look at the BaseList syntax,
+	// ToString() it and pick the lowest lexicographically) and only suggest a
+	// fix on that decl. VS will take care of de-duping these fixes in a
+	// "Fix All".
+
 	[ExportCodeFixProvider(
 		LanguageNames.CSharp,
 		Name = nameof( AddImmutableAttributeCodeFix )

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableAttributeCodeFix.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -106,8 +107,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return AddImmutableAttribute( cls );
 			} else if ( decl is StructDeclarationSyntax st ) {
 				return AddImmutableAttribute( st );
+			} else if ( decl is InterfaceDeclarationSyntax iface ) {
+				return AddImmutableAttribute( iface );
 			} else {
-				return AddImmutableAttribute( decl as InterfaceDeclarationSyntax );
+				throw new NotImplementedException();
 			}
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using D2L.CodeStyle.Analyzers.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.Analyzers.Immutability {
+	// [Immutable] is a pledge (with checking) that values of your type *or any
+	// subtype* are immutable. In other words the effects/checks for
+	// [Immutable] apply transitively to your subtypes. Rather than this
+	// being implicit, we make it explicit by requiring your subtypes to be
+	// annotated with [Immutable]. This is useful documentation and keeps the
+	// implementation for the mutability analysis simple.
+
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	internal sealed class ExplicitImmutableAttributeTransitivityAnalyzer : DiagnosticAnalyzer {
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+			=> ImmutableArray.Create(
+				Diagnostics.MissingTransitiveImmutableAttribute
+			);
+
+		public override void Initialize( AnalysisContext context ) {
+			//context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction( CompilationStart );
+		}
+
+		public void CompilationStart(
+			CompilationStartAnalysisContext context
+		) {
+			var immutableAttribute = context.Compilation.GetTypeByMetadataName(
+				"D2L.CodeStyle.Annotations.Objects+Immutable"
+			);
+
+			// If we implement an interface with [Immutable] or derive a base
+			// class with it this symbol would have been found... if it wasn't
+			// we don't need to analyze anything.
+			if ( immutableAttribute == null ) {
+				return;
+			}
+
+			context.RegisterSyntaxNodeAction(
+				ctx => AnalyzeTypeDeclaration( ctx, hasTheImmutableAttribute ),
+				SyntaxKind.ClassDeclaration,
+				SyntaxKind.StructDeclaration,
+				SyntaxKind.InterfaceDeclaration
+			);
+
+			// helper methods:
+
+			bool hasTheImmutableAttribute( ITypeSymbol type ) {
+				return type.GetAttributes().Any( isTheImmutableAttribute );
+			}
+
+			bool isTheImmutableAttribute( AttributeData attr ) {
+				return attr.AttributeClass == immutableAttribute;
+			}
+		}
+
+		public void AnalyzeTypeDeclaration(
+			SyntaxNodeAnalysisContext context,
+			Func<ITypeSymbol, bool> hasTheImmutableAttribute
+		) {
+			var decl = (TypeDeclarationSyntax)context.Node;
+			var type = context.SemanticModel.GetDeclaredSymbol( decl );
+
+			var typeHasImmutableAttr = hasTheImmutableAttribute( type );
+
+			if( typeHasImmutableAttr ) {
+				// Nothing to do: we already have the [Immutable] attribute.
+				return;
+			}
+
+			// So we don't have [Immutable]: check if we should for some reason
+
+			foreach( var iface in type.Interfaces ) {
+				if( hasTheImmutableAttribute( iface ) ) {
+					context.ReportDiagnostic(
+						CreateDiagnostic(
+							declaredThing: type,
+							declSyntax: decl,
+							otherThing: iface,
+							otherThingKind: "interface"
+						)
+					);
+					return;
+				}
+			}
+
+			// Only thing left to check is the base type
+
+			if( type.BaseType == null ) {
+				return;
+			}
+
+			if ( hasTheImmutableAttribute( type.BaseType ) ) {
+				context.ReportDiagnostic(
+					CreateDiagnostic(
+						declaredThing: type,
+						declSyntax: decl,
+						otherThing: type.BaseType,
+						otherThingKind: "base class"
+					)
+				);
+				return;
+			}
+		}
+
+		public Diagnostic CreateDiagnostic(
+			ITypeSymbol declaredThing,
+			TypeDeclarationSyntax declSyntax,
+			ITypeSymbol otherThing,
+			string otherThingKind
+		) {
+			return Diagnostic.Create(
+				Diagnostics.MissingTransitiveImmutableAttribute,
+				declSyntax.Identifier.GetLocation(),
+				declaredThing.GetFullTypeName(),
+				otherThingKind,
+				otherThing.GetFullTypeName()
+			);
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -23,7 +23,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 		public override void Initialize( AnalysisContext context ) {
-			//context.EnableConcurrentExecution();
+			context.EnableConcurrentExecution();
 			context.RegisterCompilationStartAction( CompilationStart );
 		}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -54,6 +54,7 @@
     <EmbeddedResource Include="Specs\ImmutableGenericArgumentAnalyzer.cs" />
     <EmbeddedResource Include="Specs\ImmutableGenericDeclarationAnalyzer.cs" />
     <EmbeddedResource Include="Specs\DangerousMemberUsagesAnalyzer.DangerousProperties.cs" />
+    <EmbeddedResource Include="Specs\ExplicitImmutableAttributeTransitivityAnalyzer.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="Extensions\TypeSymbolExtensionsTests.cs" />
     <Compile Include="ApiUsage\NotNullAnalyzerTests.cs" />

--- a/tests/D2L.CodeStyle.Analyzers.Test/SpecRunner.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/SpecRunner.cs
@@ -272,7 +272,7 @@ namespace D2L.CodeStyle.Analyzers {
 
 				return new DiagnosticExpectation(
 					name: name,
-					arguments: arguments.Split( ',' ).ToImmutableArray()
+					arguments: arguments.Split( ',' ).Select( arg => arg.Trim() ).ToImmutableArray()
 				);
 			}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -66,4 +66,19 @@ namespace Tests {
 	// and it's unlikely to come up in practice if you make small changes
 	// between compiles.
 	public sealed class IndirectlySadClass : SadDeriver { }
+
+	public partial class
+	/* MissingTransitiveImmutableAttribute(Tests.PartialClass, interface, Tests.ISomethingImmutable) */ PartialClass /**/
+		: ISomethingImmutable { }
+
+	// This one doesn't get the diagnostic. We attach it to the one that specified
+	// the interface.
+	public partial class PartialClass { }
+
+	// We will emit another diagnostic here though... this makes sense but the
+	// code fix will try to apply multiple [Immutable] attributes which isn't
+	// allowed...
+	public partial class
+	/* MissingTransitiveImmutableAttribute(Tests.PartialClass, base class, Tests.HappyImplementor) */ PartialClass /**/
+		: HappyImplementor { }
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -1,0 +1,69 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.Immutability.ExplicitImmutableAttributeTransitivityAnalyzer
+
+using System;
+using static D2L.CodeStyle.Annotations.Objects;
+
+namespace D2L.CodeStyle.Annotations {
+	public static class Objects {
+		// stub for tests
+		[AttributeUsage(
+			validOn: AttributeTargets.Class
+				   | AttributeTargets.Interface
+				   | AttributeTargets.Struct
+		)]
+		public sealed class Immutable : Attribute { }
+	}
+}
+
+namespace Tests {
+	public interface IVanilla { }
+	public interface IVanilla2 { }
+	public class VanillaBase : IVanilla { }
+	public class VanillaDerived : VanillaBase { }
+	public sealed class VanillaDerived2 : VanillaDerived, IVanilla2 { }
+	public struct VanillaStruct : IVanilla, IVanilla2 { }
+
+	[Immutable]
+	public interface ISomethingImmutable { }
+
+	[Immutable]
+	public class HappyImplementor : ISomethingImmutable { }
+
+	[Immutable]
+	public sealed class HappyDeriver : HappyImplementor { }
+
+	[Immutable]
+	public struct HappyStructImplementor : ISomethingImmutable { }
+
+	public sealed class
+		/* MissingTransitiveImmutableAttribute(Tests.SadImplementor, interface, Tests.ISomethingImmutable) */ SadImplementor /**/
+		: ISomethingImmutable { }
+
+	public struct
+		/* MissingTransitiveImmutableAttribute(Tests.SadStructImplementor, interface, Tests.ISomethingImmutable) */ SadStructImplementor /**/
+		: ISomethingImmutable { }
+
+	public sealed class
+		/* MissingTransitiveImmutableAttribute(Tests.SadDeriver, base class, Tests.HappyImplementor) */ SadDeriver /**/
+		: HappyImplementor { }
+
+	public sealed class
+		/* MissingTransitiveImmutableAttribute(Tests.SadImplementor2, interface, Tests.ISomethingImmutable) */ SadImplementor2 /**/
+		: VanillaBase, IVanilla, IVanilla2, ISomethingImmutable { }
+
+	public sealed class
+		/* MissingTransitiveImmutableAttribute(Tests.SadImplementor3, base class, Tests.HappyImplementor) */ SadImplementor3 /**/
+		: HappyImplementor, IVanilla, IVanilla2 { }
+
+	public interface
+		/* MissingTransitiveImmutableAttribute(Tests.SadExtender, interface, Tests.ISomethingImmutable) */ SadExtender /**/
+		: ISomethingImmutable { }
+
+	// This won't emit an error because SadDeriver hasn't added [Immutable].
+	// There is a diagnostic for that mistake, but once its fixed we would
+	// get a diagnostic here. It would be nicer to developers to report all
+	// the violations, probably, but this keeps the implementation very simple
+	// and it's unlikely to come up in practice if you make small changes
+	// between compiles.
+	public sealed class IndirectlySadClass : SadDeriver { }
+}


### PR DESCRIPTION
Right now I'm trying to fix a bug in analysis but over time some logic has gotten moved around to places it shouldn't be. The result is that the fix I made for the other bug is hard to get in now. Untangling things is getting harder because the analysis has gotten really complex in my opinion.

This very simple analyzer will allow me to remove some recursion from the analyzer and help me kill some helper methods I think have grown out of control (and lost their purpose.)

From what I saw a while ago we won't need too many additional `[Immutable]` and I talked to multiple people yesterday who agreed it was probably better to have those annotations anyway.

Note that the mutability analysis is still going to be recursive. E.g. the intent is for this to always be analyzed as cool:

```cs
[Immutable]
public class BaseClassThatPeopleCanTrustToBeImmutable {
   // ...

   public SealedClassThatHappensToBeImmutable Foo { get; }
}

public sealed class SealedClassThatHappensToBeImmutable {
  // ...
}
```

Before I merge this I'll push a code-fix for adding `[Immutable]` with Alt+Enter. I've written it I just have to try it out to make sure the whitespace is good. I'll make sure the LMS passes this analyzer before merging as well. Getting this up "early" in case there are any strong feelings.