### PR TITLE
Add a code fix for immutable exception inheritance

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -69,6 +69,7 @@
     <Compile Include="ApiUsage\DependencyInjection\Domain\RegisterPluginForExtensionPointExpression.cs" />
     <Compile Include="ApiUsage\DependencyInjection\Domain\RegisterSubInterfaceExpression.cs" />
     <Compile Include="Diagnostics.cs" />
+    <Compile Include="Immutability\AddImmutableExceptionsCodeFix.cs" />
     <Compile Include="Immutability\ImmutableHelpers.cs" />
     <Compile Include="Immutability\KnownImmutableTypes.cs" />
     <Compile Include="Immutability\MutabilityInspectionResult.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -185,7 +185,7 @@ namespace D2L.CodeStyle.Analyzers {
 		public static readonly DiagnosticDescriptor ImmutableExceptionInheritanceIsInvalid = new DiagnosticDescriptor(
 			id: "D2L0024",
 			title: "Immutable exceptions are not valid for this type.",
-			messageFormat: "This type is marked immutable, but it has more permissive immutability than its base type '{0}'. {1}",
+			messageFormat: "This type is marked immutable, but it has more permissive immutability than its base type '{0}'.",
 			category: "Safety",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true,

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
@@ -41,10 +41,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 				var maxExceptionsAllowed = diagnostic.Properties["excepts"];
 
-				if ( maxExceptionsAllowed == "" ) {
-					maxExceptionsAllowed = "None";
-				}
-
 				context.RegisterCodeFix(
 					CodeAction.Create(
 						title: "Restrict unaudited reasons allowed by [Immutable] annotation",
@@ -96,9 +92,12 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			return SyntaxFactory.ParseName( "Except." + name );
 		}
 
+		private static readonly NameSyntax ExceptNone
+			= SyntaxFactory.ParseName( "Except.None" );
+
 		public static ExpressionSyntax CombineReasons( ImmutableArray<NameSyntax> values ) {
 			if ( values.IsEmpty ) {
-				throw new InvalidOperationException();
+				return ExceptNone;
 			}
 
 			ExpressionSyntax result = values[0];

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace D2L.CodeStyle.Analyzers.Immutability {
+	[ExportCodeFixProvider(
+		LanguageNames.CSharp,
+		Name = nameof( AddImmutableExceptionsCodeFix )
+	)]
+	public sealed class AddImmutableExceptionsCodeFix : CodeFixProvider {
+		public override ImmutableArray<string> FixableDiagnosticIds
+			=> ImmutableArray.Create(
+				Diagnostics.ImmutableExceptionInheritanceIsInvalid.Id
+			);
+
+		public override FixAllProvider GetFixAllProvider() {
+			return WellKnownFixAllProviders.BatchFixer;
+		}
+
+		public override async Task RegisterCodeFixesAsync(
+			CodeFixContext context
+		) {
+			var root = await context.Document
+				.GetSyntaxRootAsync( context.CancellationToken )
+				.ConfigureAwait( false );
+
+			var model = await context.Document
+				.GetSemanticModelAsync( context.CancellationToken )
+				.ConfigureAwait( false );
+
+			foreach( var diagnostic in context.Diagnostics ) {
+				var attr = root.FindNode(
+					diagnostic.Location.SourceSpan
+				) as AttributeSyntax;
+
+				var maxExceptionsAllowed = diagnostic.Properties["excepts"];
+
+				if ( maxExceptionsAllowed == "" ) {
+					maxExceptionsAllowed = "None";
+				}
+
+				context.RegisterCodeFix(
+					CodeAction.Create(
+						title: "Restrict unaudited reasons allowed by [Immutable] annotation",
+						createChangedDocument: ct => Fix(
+							context.Document,
+							root,
+							attr,
+							maxExceptionsAllowed: maxExceptionsAllowed
+						)
+					),
+					diagnostic
+				);
+			}
+		}
+
+		public static Task<Document> Fix(
+			Document orig,
+			SyntaxNode root,
+			AttributeSyntax attr,
+			string maxExceptionsAllowed
+		) {
+			var syntaxForExcepts = maxExceptionsAllowed
+				.Split( ',' )
+				.Select( GetSyntaxForExceptName )
+				.ToImmutableArray();
+
+			var expr = CombineReasons( syntaxForExcepts );
+
+			var newAttr = attr.WithArgumentList(
+				SyntaxFactory.AttributeArgumentList(
+					SyntaxFactory.SingletonSeparatedList(
+						SyntaxFactory.AttributeArgument(
+							expr
+						).WithNameEquals( SyntaxFactory.NameEquals( "Except" ) )
+					)
+				)
+			);
+
+			var newRoot = root.ReplaceNode( attr, newAttr );
+
+			var newDoc = orig.WithSyntaxRoot( newRoot );
+
+			return Task.FromResult( newDoc );
+		}
+
+		public static NameSyntax GetSyntaxForExceptName( string name ) {
+			return SyntaxFactory.ParseName( "Except." + name );
+		}
+
+		public static ExpressionSyntax CombineReasons( ImmutableArray<NameSyntax> values ) {
+			if ( values.IsEmpty ) {
+				throw new InvalidOperationException();
+			}
+
+			ExpressionSyntax result = values[0];
+
+			// Construct something like BinOp(BinOp(A, op, B), op, C)
+			// This is the layout that the parser would normally create for
+			// "A | B | C".
+			for( int idx = 1; idx < values.Length; idx++ ) {
+				result = SyntaxFactory.BinaryExpression(
+					SyntaxKind.BitwiseOrExpression,
+					result,
+					values[idx]
+				);
+			}
+
+			return result;
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
@@ -39,7 +39,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					diagnostic.Location.SourceSpan
 				) as AttributeSyntax;
 
-				var maxExceptionsAllowed = diagnostic.Properties["excepts"];
+				var maxExceptionsAllowed = diagnostic
+					.Properties[ImmutabilityExceptionInheritanceAnalyzer.CODE_FIX_DATA_KEY];
 
 				context.RegisterCodeFix(
 					CodeAction.Create(

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
@@ -73,6 +73,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			var expr = CombineReasons( syntaxForExcepts );
 
+			// Note: the argument on attr is ignored. We may add exceptions
+			// that are allowed by our super-types but weren't allowed
+			// previously. :(
 			var newAttr = attr.WithArgumentList(
 				SyntaxFactory.AttributeArgumentList(
 					SyntaxFactory.SingletonSeparatedList(

--- a/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/AddImmutableExceptionsCodeFix.cs
@@ -73,9 +73,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			var expr = CombineReasons( syntaxForExcepts );
 
-			// Note: the argument on attr is ignored. We may add exceptions
-			// that are allowed by our super-types but weren't allowed
-			// previously. :(
+			// newAttr will always have fewer exceptions than attr: see the
+			// note in the analyzer attached to maximalExceptions
 			var newAttr = attr.WithArgumentList(
 				SyntaxFactory.AttributeArgumentList(
 					SyntaxFactory.SingletonSeparatedList(

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityExceptionInheritanceAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityExceptionInheritanceAnalyzer.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace D2L.CodeStyle.Analyzers.Immutability {
 	[DiagnosticAnalyzer( LanguageNames.CSharp )]
@@ -22,70 +21,128 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		}
 
 		private void RegisterAnalysis( CompilationStartAnalysisContext context ) {
+			var immutableAttribute = context.Compilation
+				.GetTypeByMetadataName( "D2L.CodeStyle.Annotations.Objects+Immutable" );
+
+			if ( immutableAttribute == null ) {
+				// If we can't find the symbol then we (and any interface we
+				// implement or base class, recursively) couldn't have
+				// [Immutable] so we don't need to bother with analysis.
+				return;
+			}
 
 			context.RegisterSyntaxNodeAction(
-				AnalyzeTypeDeclaration,
+				ctx => AnalyzeTypeDeclaration( ctx, immutableAttribute ),
 				SyntaxKind.ClassDeclaration,
 				SyntaxKind.InterfaceDeclaration,
 				SyntaxKind.StructDeclaration
 			);
 		}
 
-		private void AnalyzeTypeDeclaration( SyntaxNodeAnalysisContext context ) {
-
+		private void AnalyzeTypeDeclaration(
+			SyntaxNodeAnalysisContext context,
+			INamedTypeSymbol immutableAttribute
+		) {
 			// TypeDeclarationSyntax is the base class of
 			// ClassDeclarationSyntax and StructDeclarationSyntax
-			var root = (TypeDeclarationSyntax)context.Node;
+			var declSyntax = (TypeDeclarationSyntax)context.Node;
 
-			var symbol = context.SemanticModel
-				.GetDeclaredSymbol( root );
+			var declType = context.SemanticModel
+				.GetDeclaredSymbol( declSyntax );
 
 			ImmutableHashSet<string> directExceptions;
-			if( !symbol.TryGetDirectImmutableExceptions( out directExceptions ) ) {
+			if( !declType.TryGetDirectImmutableExceptions( out directExceptions ) ) {
 				// Type has no direct exceptions defined, so there's nothing to analyze
 				return;
 			}
 
-			var allInheritedExceptions = symbol.GetInheritedImmutableExceptions();
+			if ( directExceptions.IsEmpty ) {
+				// If we don't allow any exceptions then we couldn't possibly
+				// trigger this diagnostic.
+				return;
+			}
+
+			// Check that all of our allowed exceptions are also allowed by our
+			// super-types. Emit at most one diagnostic (mentioning one of the
+			// more restrictive super-types) per declaration syntax.
+
+			var allInheritedExceptions = declType.GetInheritedImmutableExceptions();
+
+			var maximalExceptions = new HashSet<string>( directExceptions );
+			ISymbol aSuperTypeWithFewerAllowedExceptions = null;
 
 			foreach( var inheritedExceptions in allInheritedExceptions ) {
-				
 				if( !directExceptions.IsSubsetOf( inheritedExceptions.Value ) ) {
-
-					var suggestedFix = inheritedExceptions.Value.IsEmpty
-						? "Set the [Immutable] exceptions on this type to Except.None."
-						: $"Reduce the [Immutable] exceptions on this type to a subset of {{ {string.Join( ", ", inheritedExceptions.Value.OrderBy( v => v ) )} }}.";
-
-					var location = GetLocationOfClassIdentifierAndGenericParameters( root );
-					var diagnostic = Diagnostic.Create(
-						Diagnostics.ImmutableExceptionInheritanceIsInvalid,
-						location,
-						inheritedExceptions.Key.Name,
-						suggestedFix
-					);
-
-					context.ReportDiagnostic( diagnostic );
+					aSuperTypeWithFewerAllowedExceptions = inheritedExceptions.Key;
+					maximalExceptions.IntersectWith( inheritedExceptions.Value );
 				}
 			}
-		}
 
-		private Location GetLocationOfClassIdentifierAndGenericParameters(
-			TypeDeclarationSyntax decl
-		) {
-			var location = decl.Identifier.GetLocation();
-
-			if( decl.TypeParameterList != null ) {
-				location = Location.Create(
-					decl.SyntaxTree,
-					TextSpan.FromBounds(
-						location.SourceSpan.Start,
-						decl.TypeParameterList.GetLocation().SourceSpan.End
-					)
-				);
+			if ( aSuperTypeWithFewerAllowedExceptions == null ) {
+				// We didn't find anything wrong.
+				return;
 			}
 
-			return location;
+			var location = GetImmutableAttributeSyntax(
+				context.SemanticModel,
+				immutableAttribute,
+				declSyntax
+			).GetLocation();
+
+			var fixInfo = GetInfoForFix( maximalExceptions );
+
+			var diagnostic = Diagnostic.Create(
+				Diagnostics.ImmutableExceptionInheritanceIsInvalid,
+				location,
+				messageArgs: new[] { aSuperTypeWithFewerAllowedExceptions.Name },
+				properties: fixInfo
+			);
+
+			context.ReportDiagnostic( diagnostic );
 		}
 
+		/// <summary>
+		/// Format necessary context for the code fix
+		/// </summary>
+		/// <param name="maximalExceptions">The largest set of exception kinds
+		/// we are allowed to have</param>
+		/// <returns>Object that can be passed to the code fix</returns>
+		private ImmutableDictionary<string, string> GetInfoForFix(
+			IEnumerable<string> maximalExceptions
+		) {
+			var sortedMaximalExceptions = maximalExceptions
+				.OrderBy( v => v );
+
+			var serializedExceptions = string.Join(
+				",",
+				sortedMaximalExceptions
+			);
+
+			return ImmutableDictionary.Create<string, string>()
+				.Add( "excepts", serializedExceptions )
+				.ToImmutableDictionary();
+		}
+
+		private static AttributeSyntax GetImmutableAttributeSyntax(
+			SemanticModel model,
+			INamedTypeSymbol immutableAttribute,
+			TypeDeclarationSyntax decl
+		) {
+			var attrs = decl.AttributeLists
+				.SelectMany( al => al.Attributes );
+
+			foreach( var attr in attrs ) {
+				var attrType = model.GetSymbolInfo( attr )
+					.Symbol // the symbol for one of the attribute constructors
+					.ContainingType; // the symbol for the attributes type
+
+				if( attrType == immutableAttribute ) {
+					return attr;
+				}
+			}
+
+			// Not reached in practice
+			throw new Exception( "Couldn't find the attribute" );
+		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityExceptionInheritanceAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityExceptionInheritanceAnalyzer.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace D2L.CodeStyle.Analyzers.Immutability {
 	[DiagnosticAnalyzer( LanguageNames.CSharp )]
 	public sealed class ImmutabilityExceptionInheritanceAnalyzer : DiagnosticAnalyzer {
+		public const string CODE_FIX_DATA_KEY = "excepts";
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
 				Diagnostics.ImmutableExceptionInheritanceIsInvalid
@@ -126,7 +127,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			return ImmutableDictionary.Create<string, string>()
-				.Add( "excepts", serializedExceptions )
+				.Add( CODE_FIX_DATA_KEY, serializedExceptions )
 				.ToImmutableDictionary();
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityExceptionInheritanceAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityExceptionInheritanceAnalyzer.cs
@@ -68,7 +68,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			var allInheritedExceptions = declType.GetInheritedImmutableExceptions();
 
+			// We start maximalExceptions with the values from
+			// directExceptions. We only ever change it by intersecting it with
+			// other sets which means it will never be bigger than
+			// directExceptions. This is nice because we may suggest a fix which
+			// involves setting the exceptions to this set, i.e. we will never
+			// suggest to *add* new kinds of exceptions.
 			var maximalExceptions = new HashSet<string>( directExceptions );
+
 			ISymbol aSuperTypeWithFewerAllowedExceptions = null;
 
 			foreach( var inheritedExceptions in allInheritedExceptions ) {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableHelpers.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableHelpers.cs
@@ -190,7 +190,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return;
 			}
 
-			throw new Exception( $"Unknown expression syntax type '{expr.GetType()}' when parsing flags: '{expr}'" );
+			// Ignore this because the user may be typing something.
+			return;
 		}
 
 	}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityExceptionInheritanceAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityExceptionInheritanceAnalyzer.cs
@@ -47,8 +47,8 @@ namespace SpecTests {
 
 		sealed class ClassNotMarkedImmutableImplementingExceptedImmutable : IExceptedImmutableInterface { }
 
-		[Objects.Immutable]
-		sealed class /* ImmutableExceptionInheritanceIsInvalid(IExceptedImmutableInterface,Reduce the [Immutable] exceptions on this type to a subset of { ItHasntBeenLookedAt }.) */ ClassWithoutSpecifiedExceptionsImplementingExceptedImmutable /**/ : IExceptedImmutableInterface { }
+		[/* ImmutableExceptionInheritanceIsInvalid(IExceptedImmutableInterface) */ Objects.Immutable /**/]
+		sealed class ClassWithoutSpecifiedExceptionsImplementingExceptedImmutable : IExceptedImmutableInterface { }
 
 		[Objects.Immutable( Except = Objects.Except.ItHasntBeenLookedAt )]
 		sealed class ClassWithSpecifiedExceptionsImplementingExceptedImmutableSame : IExceptedImmutableInterface { }
@@ -56,11 +56,11 @@ namespace SpecTests {
 		[Objects.Immutable( Except = Objects.Except.ItHasntBeenLookedAt )]
 		sealed class ClassWithSpecifiedExceptionsImplementingExceptedImmutableSubset : IExceptedImmutableInterface { }
 
-		[Objects.Immutable( Except = Objects.Except.ItsOnDeathRow )]
-		sealed class /* ImmutableExceptionInheritanceIsInvalid(IExceptedImmutableInterface,Reduce the [Immutable] exceptions on this type to a subset of { ItHasntBeenLookedAt }.) */ ClassWithSpecifiedExceptionsImplementingExceptedImmutableNewException /**/ : IExceptedImmutableInterface { }
+		[/* ImmutableExceptionInheritanceIsInvalid(IExceptedImmutableInterface) */ Objects.Immutable( Except = Objects.Except.ItsOnDeathRow ) /**/]
+		sealed class  ClassWithSpecifiedExceptionsImplementingExceptedImmutableNewException : IExceptedImmutableInterface { }
 
-		[Objects.Immutable( Except = Objects.Except.ItHasntBeenLookedAt | Objects.Except.ItsOnDeathRow )]
-		interface /* ImmutableExceptionInheritanceIsInvalid(IExceptedImmutableInterface,Reduce the [Immutable] exceptions on this type to a subset of { ItHasntBeenLookedAt }.) */ InheritingSupersetOfExceptions /**/ : IExceptedImmutableInterface { }
+		[/* ImmutableExceptionInheritanceIsInvalid(IExceptedImmutableInterface) */ Objects.Immutable( Except = Objects.Except.ItHasntBeenLookedAt | Objects.Except.ItsOnDeathRow ) /**/]
+		interface  InheritingSupersetOfExceptions : IExceptedImmutableInterface { }
 
 		[Objects.Immutable( Except = Objects.Except.None )]
 		interface InheritingSubsetOfExceptions : IExceptedImmutableInterface { }
@@ -69,8 +69,8 @@ namespace SpecTests {
 		class A { }
 		class B : A { }
 
-		[Objects.Immutable( Except = Objects.Except.ItsUgly )]
-		class /* ImmutableExceptionInheritanceIsInvalid(A,Set the [Immutable] exceptions on this type to Except.None.) */ InheritingFromBaseOfBaseType /**/ : B { }
+		[/* ImmutableExceptionInheritanceIsInvalid(A) */ Objects.Immutable( Except = Objects.Except.ItsUgly ) /**/]
+		class  InheritingFromBaseOfBaseType : B { }
 
 	}
 
@@ -86,8 +86,8 @@ namespace SpecTests {
 		[Objects.Immutable( Except = Objects.Except.ItsUgly )]
 		class MultipleInheritanceSubsetOfBoth : IFoo, IBaz { }
 
-		[Objects.Immutable( Except = Objects.Except.ItHasntBeenLookedAt )]
-		class /* ImmutableExceptionInheritanceIsInvalid(IBaz,Reduce the [Immutable] exceptions on this type to a subset of { ItsUgly }.) */ MultipleInheritanceSubsetOfOne /**/ : IFoo, IBaz { }
+		[/* ImmutableExceptionInheritanceIsInvalid(IBaz) */ Objects.Immutable( Except = Objects.Except.ItHasntBeenLookedAt ) /**/]
+		class  MultipleInheritanceSubsetOfOne : IFoo, IBaz { }
 
 	}
 


### PR DESCRIPTION
This changes the diagnostic for exceptions to not have a suggested fix, but instead register a code fix that does that.

Changes:
- the diagnostic now is at the attribute, i.e. `[__Immutable__]` is underlined instead. This helps the code fix know where to put the changes.
- the suggested fix string was cut from the diagnostic
- rather than potentially emitting up to one diagnostic per super-type we emit (at most) one diagnostic per immutable attribute. This way we only register one fix and it takes into account all super-types. Only one arbitrary super-type is called out in the diagnostic, though.
- a helper method was changed not to throw. If we are worried about the exact syntax used it should probably have its own analyzer. I was getting analyzer crashes when I typed `[Immutable( Except = Except )]` before I had finished adding `.None` which isn't cool.