### PR TITLE
Close XML comment </summary>

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/KnownImmutableTypes.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/KnownImmutableTypes.cs
@@ -46,7 +46,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 		/// <summary>
 		/// A list of known immutable special types.
-		/// </summary
+		/// </summary>
 		private readonly static ImmutableArray<SpecialType> ImmutableSpecialTypes = ImmutableArray.Create(
 			SpecialType.System_Enum,
 			SpecialType.System_Boolean,


### PR DESCRIPTION
GitHub syntax highlighting was showing the proceeding line as a comment due to the unclosed comment tag