### PR TITLE
Force users to reference D2L.CodeStyle.Annotations

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Build/MandatoryReferencesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Build/MandatoryReferencesAnalyzer.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.Analyzers.Build {
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	public sealed class MandatoryReferencesAnalyzer : DiagnosticAnalyzer {
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+			ImmutableArray.Create( Diagnostics.MustReferenceAnnotations );
+
+		public override void Initialize( AnalysisContext ctx ) {
+			ctx.EnableConcurrentExecution();
+			ctx.RegisterCompilationAction( AnalyzeCompilation );
+		}
+
+		public static void AnalyzeCompilation(
+			CompilationAnalysisContext ctx
+		) {
+			bool hasAnnotationsReference = ctx.Compilation
+				.References
+				.Any( IsTheAnnotationsAssembly );
+
+			if ( !hasAnnotationsReference ) {
+				ctx.ReportDiagnostic(
+					Diagnostic.Create(
+						Diagnostics.MustReferenceAnnotations,
+						Location.None
+					)
+				);
+			}
+		}
+
+		public static bool IsTheAnnotationsAssembly( MetadataReference mr ) {
+			return mr.Display.EndsWith( "\\D2L.CodeStyle.Annotations.dll" );
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Build/MandatoryReferencesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Build/MandatoryReferencesAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -29,10 +30,45 @@ namespace D2L.CodeStyle.Analyzers.Build {
 					)
 				);
 			}
+
+			// TODO:
+			// * How does VS sometimes offer you "Add reference to foo.dll" as
+			//   a fix?
+			// * Does it look at what other projects in the solution reference
+			//   to get a symbol? That'd be  too complicated to implement here.
+			// * Can we use their fix somehow?
+			// * Should we open up a GitHub issue for this?
 		}
 
 		public static bool IsTheAnnotationsAssembly( MetadataReference mr ) {
-			return mr.Display.EndsWith( "\\D2L.CodeStyle.Annotations.dll" );
+			// There are 3 types of MetadataReference in Roslyn currently:
+			// * UnresolvedMetadataReference: this will have a Dispaly of
+			//   "Unresolved: <name>"
+			// * PortableExecutableReference: it will be a path
+			// * CompilationReference: it will be the name of the assembly.
+			//   This gets used when you use Roslyn "manually", I'm not sure it
+			//   comes up in practice...
+			// So we're going to assume/require that Annotations is referenced
+			// by a path on disk to a DLL.
+			var pathOrName = mr.Display;
+
+			string path;
+
+			try {
+				path = Path.GetFullPath( pathOrName );
+			} catch { // all exceptions
+				// if we can't parse the path for some reason, assume this
+				// isn't the annotations assembly to be safe.
+				return false;
+			}
+
+			string filename = Path.GetFileName( path );
+
+			// We're only checking that you reference something with this
+			// file name... maybe we could do something better with strong
+			// naming? That might make rollying out changes to the
+			// annotations a bit more annoying though.
+			return filename == "D2L.CodeStyle.Annotations.dll";
 		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -36,6 +36,7 @@
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousMemberUsagesAnalyzer.cs" />
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousMethods.cs" />
     <Compile Include="ApiUsage\DangerousMemberUsages\DangerousProperties.cs" />
+    <Compile Include="Build\MandatoryReferencesAnalyzer.cs" />
     <Compile Include="Immutability\AddImmutableAttributeCodeFix.cs" />
     <Compile Include="Immutability\ExplicitImmutableAttributeTransitivityAnalyzer.cs" />
     <Compile Include="Immutability\ImmutableGenericArgument.cs" />

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -351,5 +351,15 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true,
 			description: "The implications of [Immutable] apply transitively to derived classes and interface implementations. We require that [Immutable] is explicity applied transitively for clarity and simplicity."
 		);
+
+		public static readonly DiagnosticDescriptor MustReferenceAnnotations = new DiagnosticDescriptor(
+			id: "D2L0041",
+			title: "To use D2L.CodeStyle.Analyzers you must also reference the assembly D2L.CodeStyle.Annotations",
+			messageFormat: "To use D2L.CodeStyle.Analyzers you must also reference the assembly D2L.CodeStyle.Annotations",
+			category: "Build",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "To use D2L.CodeStyle.Analyzers you must also reference the assembly D2L.CodeStyle.Annotations"
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -30,16 +30,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		public void CompilationStart(
 			CompilationStartAnalysisContext context
 		) {
+			// Never fails because we force people to reference D2L.CodeStyle.Annotations
 			var immutableAttribute = context.Compilation.GetTypeByMetadataName(
 				"D2L.CodeStyle.Annotations.Objects+Immutable"
 			);
-
-			// If we implement an interface with [Immutable] or derive a base
-			// class with it this symbol would have been found... if it wasn't
-			// we don't need to analyze anything.
-			if ( immutableAttribute == null ) {
-				return;
-			}
 
 			context.RegisterSyntaxNodeAction(
 				ctx => AnalyzeTypeDeclaration( ctx, hasTheImmutableAttribute ),


### PR DESCRIPTION
This is required so that GetTypeByMetadataName resolves for our
annotations. Without explicitly referencing annotations the semantic
model does not have complete information for those attributes.