### PR TITLE
D2L0046: DI registration requires a public constructor

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -394,5 +394,15 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true,
 			description: "We require that [Immutable] be explicity applied to all event types."
 		);
+
+		public static readonly DiagnosticDescriptor DependencyRegistraionMissingPublicConstructor = new DiagnosticDescriptor(
+			id: "D2L0046",
+			title: "Dependency Registration Missing Public Constructor",
+			messageFormat: "{0} must have a public constructor if it is to be registered for DI.",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "All injectable types need a public constructor in order to be activated."
+		);
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/DependencyRegistrationsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/DependencyRegistrationsAnalyzer.cs
@@ -201,6 +201,36 @@ namespace SpecTests {
 
 			// Unhandled registration methods should raise a diagnostic.
 			/* RegistrationKindUnknown */ reg.UnhandledRegisterMethod() /**/;
+
+			// Concrete types should have a public constructor
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingWithInternalConstructor) */ reg.Register<IImmutableSingleton, ThingWithInternalConstructor>( ObjectScope.Singleton ) /**/;
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingWithPrivateConstructor) */ reg.Register<IImmutableSingleton, ThingWithPrivateConstructor>( ObjectScope.Singleton ) /**/;
+			reg.Register<IImmutableSingleton, ThingWithInternalAndPublicConstructors>( ObjectScope.Singleton );
+			reg.Register<IImmutableSingleton, ThingWithPrivateAndPublicConstructors>( ObjectScope.Singleton );
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingFactoryWithInternalConstructor) */ reg.RegisterFactory<IImmutableSingleton, ThingFactoryWithInternalConstructor>( ObjectScope.Singleton ) /**/;
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingFactoryWithPrivateConstructor) */ reg.RegisterFactory<IImmutableSingleton, ThingFactoryWithPrivateConstructor>( ObjectScope.Singleton ) /**/;
+			reg.RegisterFactory<IImmutableSingleton, ThingFactoryWithInternalAndPublicConstructors>( ObjectScope.Singleton );
+			reg.RegisterFactory<IImmutableSingleton, ThingFactoryWithPrivateAndPublicConstructors>( ObjectScope.Singleton );
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingWithInternalConstructor) */ reg.RegisterPlugin<IImmutableSingleton, ThingWithInternalConstructor>( ObjectScope.Singleton ) /**/;
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingWithPrivateConstructor) */ reg.RegisterPlugin<IImmutableSingleton, ThingWithPrivateConstructor>( ObjectScope.Singleton ) /**/;
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingWithInternalConstructor) */ reg.RegisterPlugin<DefaultExtensionPoint<IImmutableSingleton>, IImmutableSingleton, ThingWithInternalConstructor>( ObjectScope.Singleton ) /**/;
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingWithPrivateConstructor) */ reg.RegisterPlugin<DefaultExtensionPoint<IImmutableSingleton>, IImmutableSingleton, ThingWithPrivateConstructor>( ObjectScope.Singleton ) /**/;
+			reg.RegisterPlugin<IImmutableSingleton, ThingWithInternalAndPublicConstructors>( ObjectScope.Singleton );
+			reg.RegisterPlugin<IImmutableSingleton, ThingWithPrivateAndPublicConstructors>( ObjectScope.Singleton );
+			reg.RegisterPlugin<DefaultExtensionPoint<IImmutableSingleton>, IImmutableSingleton, ThingWithInternalAndPublicConstructors>( ObjectScope.Singleton );
+			reg.RegisterPlugin<DefaultExtensionPoint<IImmutableSingleton>, IImmutableSingleton, ThingWithPrivateAndPublicConstructors>( ObjectScope.Singleton );
+
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingFactoryWithInternalConstructor) */ reg.RegisterPluginFactory<IImmutableSingleton, ThingFactoryWithInternalConstructor>( ObjectScope.Singleton ) /**/;
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingFactoryWithPrivateConstructor) */ reg.RegisterPluginFactory<IImmutableSingleton, ThingFactoryWithPrivateConstructor>( ObjectScope.Singleton ) /**/;
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingFactoryWithInternalConstructor) */ reg.RegisterPluginFactory<DefaultExtensionPoint<IImmutableSingleton>, IImmutableSingleton, ThingFactoryWithInternalConstructor>( ObjectScope.Singleton ) /**/;
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingFactoryWithPrivateConstructor) */ reg.RegisterPluginFactory<DefaultExtensionPoint<IImmutableSingleton>, IImmutableSingleton, ThingFactoryWithPrivateConstructor>( ObjectScope.Singleton ) /**/;
+			reg.RegisterPluginFactory<IImmutableSingleton, ThingFactoryWithInternalAndPublicConstructors>( ObjectScope.Singleton );
+			reg.RegisterPluginFactory<IImmutableSingleton, ThingFactoryWithPrivateAndPublicConstructors>( ObjectScope.Singleton );
+			reg.RegisterPluginFactory<DefaultExtensionPoint<IImmutableSingleton>, IImmutableSingleton, ThingFactoryWithInternalAndPublicConstructors>( ObjectScope.Singleton );
+			reg.RegisterPluginFactory<DefaultExtensionPoint<IImmutableSingleton>, IImmutableSingleton, ThingFactoryWithPrivateAndPublicConstructors>( ObjectScope.Singleton );
+
+			/* DependencyRegistraionMissingPublicConstructor(SpecTests.ThingWithInternalConstructor) */ reg.Register( typeof( IImmutableSingleton ), typeof( ThingWithInternalConstructor ), ObjectScope.Singleton ) /**/;
+			reg.Register( typeof( IComparer<> ), typeof( SomeComparer<> ), ObjectScope.AlwaysCreateNewInstance );
 		}
 
 		// Registrations in some classes/structs are ignored because they 
@@ -282,5 +312,41 @@ namespace SpecTests {
 	public sealed class ImmutableThingFactory : 
 		IFactory<ImmutableThing>, 
 		IFactory<ImmutableThing, Type> { }
+
+	internal sealed class ThingWithInternalConstructor : IImmutableSingleton {
+		internal ThingWithInternalConstructor() { }
+	}
+
+	internal sealed class ThingWithPrivateConstructor : IImmutableSingleton {
+		private ThingWithPrivateConstructor() { }
+	}
+
+	internal sealed class ThingWithInternalAndPublicConstructors : IImmutableSingleton {
+		internal ThingWithInternalAndPublicConstructors() { }
+		public ThingWithInternalAndPublicConstructors() { }
+	}
+
+	internal sealed class ThingWithPrivateAndPublicConstructors : IImmutableSingleton {
+		private ThingWithPrivateAndPublicConstructors() { }
+		public ThingWithPrivateAndPublicConstructors() { }
+	}
+
+	internal sealed class ThingFactoryWithInternalConstructor : IFactory<IImmutableSingleton> {
+		internal ThingFactoryWithInternalConstructor() { }
+	}
+
+	internal sealed class ThingFactoryWithPrivateConstructor : IFactory<IImmutableSingleton> {
+		private ThingFactoryWithPrivateConstructor() { }
+	}
+
+	internal sealed class ThingFactoryWithInternalAndPublicConstructors : IFactory<IImmutableSingleton> {
+		internal ThingFactoryWithInternalAndPublicConstructors() { }
+		public ThingFactoryWithInternalAndPublicConstructors() { }
+	}
+
+	internal sealed class ThingFactoryWithPrivateAndPublicConstructors : IFactory<IImmutableSingleton> {
+		internal ThingFactoryWithPrivateAndPublicConstructors() { }
+		public ThingFactoryWithPrivateAndPublicConstructors() { }
+	}
 
 }


### PR DESCRIPTION
~On top of https://github.com/Brightspace/D2L.CodeStyle/pull/443~

While working on "useless factories" codefix, I realized I may have been rewriting dependency registrations to concrete types without a public constructor. Adding this analyzer so I can better verify the changes I was making during compile time instead of waiting for activation diagnostics