### PR TITLE
Remove accidentally committed redundant check

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Language/DefaultValueConsistencyAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/DefaultValueConsistencyAnalyzer.cs
@@ -189,12 +189,6 @@ namespace D2L.CodeStyle.Analyzers.Language {
 				var implDefault = implParameter.ExplicitDefaultValue;
 				var baseDefault = baseParameter.ExplicitDefaultValue;
 
-				if ( implDefault == null && baseDefault == null ) {
-					return;
-				} else if ( implDefault != null && implDefault.Equals( baseDefault ) ) {
-					return;
-				}
-
 				// Use the static object.Equals because implDefault could
 				// legtimately be null and implDefault.Equals( baseDefault )
 				// would throw a NRE.


### PR DESCRIPTION
The Equals below covers this. I wrote this first and then realized
object.Equals probably had a static version for times when things could
be `null`...