### PR TITLE
Don't complain about an arg being unnamed if its a literal that matches the param name

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
@@ -131,6 +132,18 @@ namespace D2L.CodeStyle.Analyzers.Language {
 				// which case it is "unnamed", so ignore it.
 				if ( param.Name == "" ) {
 					continue;
+				}
+
+				if ( arg.Expression is IdentifierNameSyntax ident ) {
+					bool literalArgMatchesParamName = string.Equals(
+						ident.Identifier.ValueText,
+						param.Name,
+						StringComparison.OrdinalIgnoreCase
+					);
+
+					if( literalArgMatchesParamName ) {
+						continue;
+					}
 				}
 
 				yield return new ArgParamBinding(

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -71,6 +71,15 @@ namespace D2L {
 			_arg21( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, a20: 20, a21: 21 );
 			#endregion
 
+			#region arguments that are literals with the correct name don't count against the budget
+			int a16 = 16;
+			int a20 = 20;
+			int A21 = 21; // case doesn't matter
+			_arg20( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, a16, 17, 18, 19, 20 );
+			_arg20( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, a20 );
+			_arg21( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, a20, A21 );
+			#endregion
+
 			#region need to have enough named args, though
 			/* TooManyUnnamedArgs */ _arg21( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, a21: 21 ) /**/;
 			/* TooManyUnnamedArgs */ _arg21( 1, a2: 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 ) /**/;


### PR DESCRIPTION
This is a little more polite.

As a reader of code, it does mean that you need to 

1. Know that we treat this case specially
2. Trust the analyzer/know its current limits (e.g. the very high 20 arg threshold)

but I think when we make it complain about literals and inter-changeable arguments (2) will be less of a problem. (1) is only significant for people who are already careful on reviews and they are more likely to become aware of (1) anyway.