### PR TITLE
Ignore generated files when analyzing named arguments

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -36,6 +36,7 @@ namespace D2L.CodeStyle.Analyzers.Language {
 
 		public override void Initialize( AnalysisContext context ) {
 			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis( GeneratedCodeAnalysisFlags.None );
 
 			context.RegisterSyntaxNodeAction(
 				AnalyzeCallSyntax,


### PR DESCRIPTION
There were some false positives generated by `.view` files.