### PR TITLE
Consider lambda initializers for fields safe

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -283,24 +283,22 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			ExpressionSyntax expr,
 			HashSet<ITypeSymbol> typeStack
 		) {
-			if( expr.Kind() == SyntaxKind.NullLiteralExpression ) {
+
+			switch( expr.Kind() ) {
 				// This is perhaps a bit suspicious, because fields and
 				// properties have to be readonly, but it is safe...
-				return MutabilityInspectionResult.NotMutable();
-			}
-
-			SemanticModel model = m_compilation.GetSemanticModel( expr.SyntaxTree );
-
-			if( expr.Kind() == SyntaxKind.SimpleLambdaExpression ||
-				expr.Kind() == SyntaxKind.ParenthesizedLambdaExpression
-			) {
+				case SyntaxKind.NullLiteralExpression:
 
 				// Lambda initializers for readonly members are safe
 				// because they can only close over other members, which
 				// will be checked independently, or static members of
 				// another class, which are also analyzed
-				return MutabilityInspectionResult.NotMutable();
+				case SyntaxKind.SimpleLambdaExpression:
+				case SyntaxKind.ParenthesizedLambdaExpression:
+					return MutabilityInspectionResult.NotMutable();
 			}
+
+			SemanticModel model = m_compilation.GetSemanticModel( expr.SyntaxTree );
 
 			TypeInfo typeInfo = model.GetTypeInfo( expr );
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityInspector.cs
@@ -291,6 +291,17 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			SemanticModel model = m_compilation.GetSemanticModel( expr.SyntaxTree );
 
+			if( expr.Kind() == SyntaxKind.SimpleLambdaExpression ||
+				expr.Kind() == SyntaxKind.ParenthesizedLambdaExpression
+			) {
+
+				// Lambda initializers for readonly members are safe
+				// because they can only close over other members, which
+				// will be checked independently, or static members of
+				// another class, which are also analyzed
+				return MutabilityInspectionResult.NotMutable();
+			}
+
 			TypeInfo typeInfo = model.GetTypeInfo( expr );
 
 			// Type can be null in the case of an implicit conversion where

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using NUnit.Framework;
@@ -549,6 +550,67 @@ sealed class Baz { }
 			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
 
 			AssertUnauditedReasonsResult( ty, "ItsUgly", "ItHasntBeenLookedAt" );
+		}
+
+		[Test]
+		public void InspectType_SimpleLambdaMember_NotMutable() {
+
+			var field = Field( "private readonly Func<int> m_func = () => 1;" );
+
+			var inspector = new MutabilityInspector( field.Compilation );
+
+			var expected = MutabilityInspectionResult.NotMutable();
+
+			var actual = inspector.InspectType( field.Symbol.ContainingType );
+
+			AssertResultsAreEqual( expected, actual );
+		}
+
+		[Test]
+		public void InspectType_LambdaInitializedFromStaticMethod_NotMutable() {
+
+			var field = Field( "private readonly Func<int> m_func = () => int.Parse( \"1\" );" );
+
+			var inspector = new MutabilityInspector( field.Compilation );
+
+			var expected = MutabilityInspectionResult.NotMutable();
+
+			var actual = inspector.InspectType( field.Symbol.ContainingType );
+
+			AssertResultsAreEqual( expected, actual );
+		}
+
+		[Test]
+		public void InspectType_ParameterizedLambda_NotMutable() {
+
+			var field = Field( "private readonly Func<int,int> m_addTwo = ( a ) => a + 2;" );
+
+			var inspector = new MutabilityInspector( field.Compilation );
+
+			var expected = MutabilityInspectionResult.NotMutable();
+
+			var actual = inspector.InspectType( field.Symbol.ContainingType );
+
+			AssertResultsAreEqual( expected, actual );
+		}
+
+		[Test]
+		public void InspectType_LambdaInitializerReferencingField_NotMutable() {
+			const string source = AnnotationsPreamble + @"
+sealed class Foo {
+
+	private readonly int m_int = 3;
+	private readonly Func<int> m_func = () => { return m_int; };
+}
+";
+
+			TestSymbol<ITypeSymbol> ty = CompileAndGetFooType( source );
+
+			var inspector = new MutabilityInspector( ty.Compilation );
+
+			var result = inspector.InspectType( ty.Symbol );
+
+			Assert.IsFalse( result.IsMutable );
 		}
 
 		private TestSymbol<ITypeSymbol> CompileAndGetFooType( string source ) {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Immutability/MutabilityInspectorTests.cs
@@ -581,7 +581,7 @@ sealed class Baz { }
 		}
 
 		[Test]
-		public void InspectType_ParameterizedLambda_NotMutable() {
+		public void InspectType_ParenthesizedLambda_NotMutable() {
 
 			var field = Field( "private readonly Func<int,int> m_addTwo = ( a ) => a + 2;" );
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -363,4 +363,27 @@ namespace SpecTests {
 			private readonly T m_field;
 		}
 	}
+
+	class ImmutableFieldTests {
+
+		[Objects.Immutable]
+		public class FieldIsNullLiteral {
+			private readonly string m_str = null;
+		}
+
+		[Objects.Immutable]
+		public class FieldIsSimpleFunc {
+			private readonly Func<int> m_str = () => 1;
+		}
+
+		[Objects.Immutable]
+		public class FieldIsStaticAction {
+			private readonly Action m_str = () => Console.WriteLine( "Hello World" );
+		}
+
+		[Objects.Immutable]
+		public class FieldIsParenthesizedFunc {
+			private readonly Func<int, int> m_add = ( x ) => { return x + 1; };
+		}
+	}
 }


### PR DESCRIPTION
Member fields initalized with lambdas (for Func<T>, Action<T>, etc) can
be considered safe, because they will either not contain state, or the
state contained will be analyzed by other analyzers. Initializers that
do no include state include those which reference static members of
other classes, which are also checked with another analyzer