### PR TITLE
Add an analyzer for D2L.StatelessFunc<T>

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -465,5 +465,15 @@ namespace D2L.CodeStyle.Analyzers {
 			description: "Use the ContentPath property instead."
 		);
 
+		public static readonly DiagnosticDescriptor StatelessFuncIsnt = new DiagnosticDescriptor(
+			id: "D2L0053",
+			title: "StatelessFunc cannot hold state",
+			messageFormat: "StatelessFunc cannot hold state",
+			category: "Safety",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "StatelessFunc is to be used to hold Func private members, and need to be undiff safe."
+		);
+
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -468,7 +468,7 @@ namespace D2L.CodeStyle.Analyzers {
 		public static readonly DiagnosticDescriptor StatelessFuncIsnt = new DiagnosticDescriptor(
 			id: "D2L0053",
 			title: "StatelessFunc cannot hold state",
-			messageFormat: "StatelessFunc cannot hold state",
+			messageFormat: "StatelessFunc cannot hold state: {0}",
 			category: "Safety",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true,

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -71,7 +71,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				// lambda has parens
 				// eg () => 1, (x, y) => x + y
 				case SyntaxKind.ParenthesizedLambdaExpression:
-					if( !CheckForClosures( context, argument ) ) {
+					if( !HasCaptures( context, argument ) ) {
 						return;
 					}
 					break;
@@ -80,7 +80,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				// lambda does not have parens
 				// eg x => x + 1
 				case SyntaxKind.SimpleLambdaExpression:
-					if( !CheckForClosures( context, argument ) ) {
+					if( !HasCaptures( context, argument ) ) {
 						return;
 					}
 					break;
@@ -124,7 +124,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			return symbol.IsStatic;
 		}
 
-		private static bool CheckForClosures(
+		private static bool HasCaptures(
 			SyntaxNodeAnalysisContext context,
 			ExpressionSyntax expression
 		) {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -25,9 +25,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			context.RegisterSyntaxNodeAction(
 				ctx => {
-					if( ctx.Node is ObjectCreationExpressionSyntax expr ) {
-						AnalyzeObjectCreationExpression( ctx, expr, statelessFuncs );
-					}
+						AnalyzeObjectCreationExpression(
+							ctx,
+							statelessFuncs
+						);
 				},
 				SyntaxKind.ObjectCreationExpression
 			);
@@ -35,9 +36,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 		private static void AnalyzeObjectCreationExpression(
 			SyntaxNodeAnalysisContext context,
-			ObjectCreationExpressionSyntax syntax,
 			ImmutableHashSet<ISymbol> statelessFuncs
 		) {
+
+			ObjectCreationExpressionSyntax syntax = context.Node as ObjectCreationExpressionSyntax;
 
 			ISymbol symbol = context
 				.SemanticModel

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -21,11 +21,12 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		private void RegisterAnalysis( CompilationStartAnalysisContext context ) {
 
 			Compilation compilation = context.Compilation;
+			ImmutableHashSet<ISymbol> statelessFuncs = GetStatelessFuncTypes( compilation );
 
 			context.RegisterSyntaxNodeAction(
 				ctx => {
 					if( ctx.Node is ObjectCreationExpressionSyntax expr ) {
-						AnalyzeInvocation( ctx, expr );
+						AnalyzeInvocation( ctx, expr, statelessFuncs );
 					}
 				},
 				SyntaxKind.ObjectCreationExpression
@@ -34,7 +35,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 		private void AnalyzeInvocation(
 			SyntaxNodeAnalysisContext context,
-			ObjectCreationExpressionSyntax syntax
+			ObjectCreationExpressionSyntax syntax,
+			ImmutableHashSet<ISymbol> statelessFuncs
 		) {
 
 			ISymbol symbol = context
@@ -45,7 +47,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return;
 			}
 
-			if( !IsStatelessFunc( symbol, context ) ) {
+			if( !IsStatelessFunc( symbol, statelessFuncs ) ) {
 				return;
 			}
 
@@ -137,9 +139,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 		private static bool IsStatelessFunc(
 			ISymbol symbol,
-			SyntaxNodeAnalysisContext context
+			ImmutableHashSet<ISymbol> statelessFuncs
 		) {
-			ImmutableHashSet<ISymbol> statelessFuncs = GetStatelessFuncTypes( context.Compilation );
 
 			if( statelessFuncs.Contains( symbol ) ) {
 				// we've found a definition that matches exactly with the symbol

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -85,6 +85,15 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					}
 					break;
 
+				// this is the case where an expression is invoked,
+				// which returns a Func<T>
+				// eg ( () => { return () => 1 } )()
+				case SyntaxKind.InvocationExpression:
+					// we are rejecting this because it is tricky to
+					// analyze properly, but also a bit ugly and should
+					// never really be necessary
+					break;
+
 				default:
 					// should we do something else here because constructors
 					// of D2L.StatelessFunc<T> and friends should always take

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -26,14 +26,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			context.RegisterSyntaxNodeAction(
 				ctx => {
 					if( ctx.Node is ObjectCreationExpressionSyntax expr ) {
-						AnalyzeInvocation( ctx, expr, statelessFuncs );
+						AnalyzeObjectCreationExpression( ctx, expr, statelessFuncs );
 					}
 				},
 				SyntaxKind.ObjectCreationExpression
 			);
 		}
 
-		private static void AnalyzeInvocation(
+		private static void AnalyzeObjectCreationExpression(
 			SyntaxNodeAnalysisContext context,
 			ObjectCreationExpressionSyntax syntax,
 			ImmutableHashSet<ISymbol> statelessFuncs

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -1,0 +1,153 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using System.Collections.Immutable;
+
+namespace D2L.CodeStyle.Analyzers.Immutability {
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	public sealed class StatelessFuncAnalyzer : DiagnosticAnalyzer {
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+			Diagnostics.StatelessFuncIsnt
+		);
+
+		public override void Initialize( AnalysisContext context ) {
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction( RegisterAnalysis );
+		}
+
+		private void RegisterAnalysis( CompilationStartAnalysisContext context ) {
+
+			Compilation compilation = context.Compilation;
+
+			context.RegisterSyntaxNodeAction(
+				ctx => {
+					if( ctx.Node is ObjectCreationExpressionSyntax expr ) {
+						AnalyzeInvocation( ctx, expr );
+					}
+				},
+				SyntaxKind.ObjectCreationExpression
+			);
+		}
+
+		private void AnalyzeInvocation(
+			SyntaxNodeAnalysisContext context,
+			ObjectCreationExpressionSyntax syntax
+		) {
+
+			TypeSyntax type = syntax.Type;
+			ISymbol symbol = context
+				.SemanticModel
+				.GetSymbolInfo( type ).Symbol;
+
+			if( symbol == null ) {
+				return;
+			}
+
+			if( !IsStatelessFunc( symbol ) ) {
+				return;
+			}
+
+			ExpressionSyntax argument = syntax.ArgumentList.Arguments[ 0 ].Expression;
+			SyntaxKind kind = argument.Kind();
+			switch( kind ) {
+
+				// this is the case when a method reference is used
+				// eg Func<string, int> func = int.Parse
+				case SyntaxKind.SimpleMemberAccessExpression:
+					if( IsStaticMemberAccess( context, argument ) ) {
+						return;
+					}
+
+					// non-static member access means that state could
+					// be used / held.
+					// TODO: Look for [Immutable] on the member's type
+					// to determine if the non-static member is safe
+					break;
+
+				// this is the case when the left hand side of the
+				// lambda has parens
+				// eg () => 1, (x, y) => x + y
+				case SyntaxKind.ParenthesizedLambdaExpression:
+					if( !CheckForClosures( context, argument ) ) {
+						return;
+					}
+					break;
+
+				// this is the case when the left hand side of the
+				// lambda does not have parens
+				// eg x => x + 1
+				case SyntaxKind.SimpleLambdaExpression:
+					if( !CheckForClosures( context, argument ) ) {
+						return;
+					}
+					break;
+
+				default:
+					// should we do something else here because constructors
+					// of D2L.StatelessFunc<T> and friends should always take
+					// a func?
+					return;
+			}
+
+			var diag = Diagnostic.Create(
+				Diagnostics.StatelessFuncIsnt,
+				argument.GetLocation()
+			);
+
+			context.ReportDiagnostic( diag );
+		}
+
+		private static bool IsStaticMemberAccess(
+			SyntaxNodeAnalysisContext context,
+			ExpressionSyntax expression
+		) {
+			ISymbol symbol = context
+				.SemanticModel
+				.GetSymbolInfo( expression ).Symbol;
+
+			if( symbol == null ) {
+				return false;
+			}
+
+			return symbol.IsStatic;
+		}
+
+		private static bool CheckForClosures(
+			SyntaxNodeAnalysisContext context,
+			ExpressionSyntax expression
+		) {
+
+			DataFlowAnalysis dataFlow = context
+				.SemanticModel
+				.AnalyzeDataFlow( expression );
+
+			ImmutableArray<ISymbol> captures = dataFlow.Captured;
+			return captures.Length > 0;
+		}
+
+		private static bool IsStatelessFunc( ISymbol symbol ) {
+			ImmutableHashSet<string> statelessFuncs = GetStatelessFuncTypes();
+
+			string fullName = $"{ symbol.ContainingNamespace.Name }.{ symbol.MetadataName }";
+
+			return statelessFuncs.Contains( fullName );
+		}
+
+		private static ImmutableHashSet<string> GetStatelessFuncTypes() {
+
+			var builder = ImmutableArray.CreateBuilder<string>();
+			builder.Add( "D2L.StatelessFunc`1" );
+			builder.Add( "D2L.StatelessFunc`2" );
+			builder.Add( "D2L.StatelessFunc`3" );
+			builder.Add( "D2L.StatelessFunc`4" );
+			builder.Add( "D2L.StatelessFunc`5" );
+			builder.Add( "D2L.StatelessFunc`6" );
+			ImmutableHashSet<string> typeNames = builder.ToImmutableHashSet();
+
+			return typeNames;
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -18,7 +18,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			context.RegisterCompilationStartAction( RegisterAnalysis );
 		}
 
-		private void RegisterAnalysis( CompilationStartAnalysisContext context ) {
+		private static void RegisterAnalysis( CompilationStartAnalysisContext context ) {
 
 			Compilation compilation = context.Compilation;
 			ImmutableHashSet<ISymbol> statelessFuncs = GetStatelessFuncTypes( compilation );
@@ -33,7 +33,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 		}
 
-		private void AnalyzeInvocation(
+		private static void AnalyzeInvocation(
 			SyntaxNodeAnalysisContext context,
 			ObjectCreationExpressionSyntax syntax,
 			ImmutableHashSet<ISymbol> statelessFuncs

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -94,10 +94,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					break;
 
 				default:
-					// should we do something else here because constructors
-					// of D2L.StatelessFunc<T> and friends should always take
-					// a func?
-					return;
+					// we need StatelessFunc<T> to be ultra safe, so we'll
+					// reject usages we do not understand yet
+					break;
 			}
 
 			var diag = Diagnostic.Create(

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -62,6 +62,7 @@
     <EmbeddedResource Include="Specs\ConfigViewerAnalyzer.cs" />
     <EmbeddedResource Include="Specs\LoggingExecutionContextScopeBuilderAnalyzer.cs" />
     <EmbeddedResource Include="Specs\ILpContentFilePhysicalPathAnalyzer.cs" />
+    <EmbeddedResource Include="Specs\StatelessFuncAnalyzerSpec.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="Extensions\TypeSymbolExtensionsTests.cs" />
     <Compile Include="ApiUsage\NotNullAnalyzerTests.cs" />

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -33,7 +33,7 @@ namespace SpecTests {
 
 		public void ParenWithClosures() {
 			int zero = 0;
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt */ () => zero /**/ );
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
 		}
 
 		public void SimpleNoClosures() {
@@ -42,11 +42,11 @@ namespace SpecTests {
 
 		public void SimpleWithClosures() {
 			string trailing = "\n";
-			var func = new StatelessFunc<string, string>( /* StatelessFuncIsnt */ x => x + trailing /**/ );
+			var func = new StatelessFunc<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
 		}
 
 		public void NonStaticMember() {
-			var func = new StatelessFunc<string>( /* StatelessFuncIsnt */ this.ToString /**/ );
+			var func = new StatelessFunc<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
 		}
 
 		public void StaticMember() {
@@ -64,7 +64,7 @@ namespace SpecTests {
 
 		public void MultiLineWithThisCapture() {
 			var func = new StatelessFunc<string>(
-				/* StatelessFuncIsnt */ () => {
+				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
 					string trailing = "\n";
 					return this.ToString() + trailing;
 				} /**/
@@ -84,7 +84,7 @@ namespace SpecTests {
 				};
 			};
 
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt */ evil() /**/ );
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
 		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -70,5 +70,21 @@ namespace SpecTests {
 				} /**/
 			);
 		}
+
+		public void InvalidCtor() {
+			var func = new StatelessFunc();
+		}
+
+		public void EvilFactory() {
+			Func<int> evil() {
+				int x = 0;
+				return () => {
+					x += 1;
+					return x;
+				};
+			};
+
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt */ evil() /**/ );
+		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -1,0 +1,74 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.Immutability.StatelessFuncAnalyzer
+
+using System;
+
+namespace D2L {
+	public class StatelessFunc<TResult> {
+
+		private readonly Func<TResult> m_func;
+
+		public StatelessFunc( Func<TResult> func ) {
+			m_func = func;
+		}
+	}
+
+	public class StatelessFunc<T, TResult> {
+
+		private readonly Func<T, TResult> m_func;
+
+		public StatelessFunc( Func<T, TResult> func ) {
+			m_func = func;
+		}
+	}
+}
+
+namespace SpecTests {
+
+	using D2L;
+	internal sealed class Usages {
+
+		public void ParenNoClosures() {
+			var func = new StatelessFunc<int>( () => 0 );
+		}
+
+		public void ParenWithClosures() {
+			int zero = 0;
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt */ () => zero /**/ );
+		}
+
+		public void SimpleNoClosures() {
+			var func = new StatelessFunc<string, string>( x => x + "\n" );
+		}
+
+		public void SimpleWithClosures() {
+			string trailing = "\n";
+			var func = new StatelessFunc<string, string>( /* StatelessFuncIsnt */ x => x + trailing /**/ );
+		}
+
+		public void NonStaticMember() {
+			var func = new StatelessFunc<string>( /* StatelessFuncIsnt */ this.ToString /**/ );
+		}
+
+		public void StaticMember() {
+			var func = new StatelessFunc<string, int>( Int32.Parse );
+		}
+
+		public void MultiLine() {
+			var func = new StatelessFunc<int>(
+				() => {
+					int x = 0;
+					return x + 1;
+				}
+			);
+		}
+
+		public void MultiLineWithThisCapture() {
+			var func = new StatelessFunc<string>(
+				/* StatelessFuncIsnt */ () => {
+					string trailing = "\n";
+					return this.ToString() + trailing;
+				} /**/
+			);
+		}
+	}
+}


### PR DESCRIPTION
By ensuring that every instantiation of StatelessFunc<T> and friends is
safe, we can convert other classes from Func<T> members to
StatelessFunc<T> and then mark that class [Immutable] safely. This will
allow us to remove a large number of [Mutability.Audited] attributes.