### PR TITLE
add an analyzer for a [StatelessFunc] attribute

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using D2L.CodeStyle.Analyzers.Extensions;
+using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -64,8 +64,19 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return;
 			}
 
-			Diagnostic diag;
 			ExpressionSyntax argument = syntax.Expression;
+
+			/**
+			* Even though we haven't specifically accounted for its
+			* source if it's a StatelessFunc<T> we're reasonably
+			* certain its been analyzed.
+			*/
+			ISymbol type = model.GetTypeInfo( argument ).Type;
+			if( type != null && IsStatelessFunc( type, statelessFuncs ) ) {
+				return;
+			}
+
+			Diagnostic diag;
 			SyntaxKind kind = argument.Kind();
 			switch( kind ) {
 
@@ -141,16 +152,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				 *   void S() { Foo( m_f ); }
 				 * }
 				 */
-				case SyntaxKind.IdentifierName: {
-
-					/**
-					 * Doesn't matter where it came from, if it's a StatelessFunc<T> we're
-					 * reasonably certain its been analyzed.
-					 */
-					ISymbol type = model.GetTypeInfo( argument ).Type;
-					if( type != null && IsStatelessFunc( type, statelessFuncs ) ) {
-						return;
-					}
+				case SyntaxKind.IdentifierName:
 
 					/**
 					 * If it's a local parameter marked with [StatelessFunc] we're reasonably
@@ -175,19 +177,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					);
 
 					break;
-				}
 
-				default: {
-
-					/**
-					 * Even though we haven't specifically accounted for its
-					 * source if it's a StatelessFunc<T> we're reasonably
-					 * certain its been analyzed.
-					 */
-					ISymbol type = model.GetTypeInfo( argument ).Type;
-					if( type != null && IsStatelessFunc( type, statelessFuncs ) ) {
-						return;
-					}
+				default:
 
 					// we need StatelessFunc<T> to be ultra safe, so we'll
 					// reject usages we do not understand yet
@@ -198,7 +189,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					);
 
 					break;
-				}
 			}
 
 			context.ReportDiagnostic( diag );

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -137,15 +137,15 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					);
 
 					break;
-				
+
 				/**
 				 * This is the case where a variable is passed in
 				 * eg Foo( f )
 				 * Where f might be a local variable, a parameter, or field
-				 * 
+				 *
 				 * class C<T> {
 				 *   StatelessFunc<T> m_f;
-				 *   
+				 *
 				 *   void P( StatelessFunc<T></T> f ) { Foo( f ); }
 				 *   void Q( [StatelessFunc] Func<T> f ) { Foo( f ); }
 				 *   void R() { StatelessFunc<T> f; Foo( f ); }
@@ -153,7 +153,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				 * }
 				 */
 				case SyntaxKind.IdentifierName:
-
 					/**
 					 * If it's a local parameter marked with [StatelessFunc] we're reasonably
 					 * certain it was analyzed on the caller side.
@@ -179,7 +178,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					break;
 
 				default:
-
 					// we need StatelessFunc<T> to be ultra safe, so we'll
 					// reject usages we do not understand yet
 					diag = Diagnostic.Create(

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -276,7 +276,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				"D2L.StatelessFunc`3",
 				"D2L.StatelessFunc`4",
 				"D2L.StatelessFunc`5",
-				"D2L.StatelessFunc`6"
+				"D2L.StatelessFunc`6",
 			};
 
 			foreach( string typeName in types ) {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -24,6 +24,11 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			Compilation compilation = context.Compilation;
 			ISymbol statelessFuncAttr = compilation.GetTypeByMetadataName( "D2L.CodeStyle.Annotations.Contract.StatelessFuncAttribute" );
+
+			if( statelessFuncAttr == null ) {
+				return;
+			}
+
 			ImmutableHashSet<ISymbol> statelessFuncs = GetStatelessFuncTypes( compilation );
 
 			context.RegisterSyntaxNodeAction(

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -63,9 +63,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return;
 			}
 
-			ExpressionSyntax argument = syntax.Expression;
-
 			Diagnostic diag;
+			ExpressionSyntax argument = syntax.Expression;
 			SyntaxKind kind = argument.Kind();
 			switch( kind ) {
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -23,7 +23,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		private static void RegisterAnalysis( CompilationStartAnalysisContext context ) {
 
 			Compilation compilation = context.Compilation;
-			ISymbol statelessFuncAttr = compilation.GetTypeByMetadataName( "D2L.StatelessFuncAttribute" );
+			ISymbol statelessFuncAttr = compilation.GetTypeByMetadataName( "D2L.CodeStyle.Annotations.Contract.StatelessFuncAttribute" );
 			ImmutableHashSet<ISymbol> statelessFuncs = GetStatelessFuncTypes( compilation );
 
 			context.RegisterSyntaxNodeAction(

--- a/src/D2L.CodeStyle.Annotations/Contract/StatelessFuncAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/Contract/StatelessFuncAttribute.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+namespace D2L.CodeStyle.Annotations.Contract {
+	[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
+	public sealed class StatelessFuncAttribute : ReadOnlyAttribute {}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -30,13 +30,118 @@ namespace SpecTests {
 	}
 
 	internal sealed class Usages {
-		public void StatelessFunc() {
 
+		public void ParenNoClosures() {
+			var func = new StatelessFunc<int>( () => 0 );
+			AttributeFuncReceiver.Accept<int>( () => 0 );
+		}
+
+		public void ParenWithClosures() {
+			int zero = 0;
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
+			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
+		}
+
+		public void SimpleNoClosures() {
+			var func = new StatelessFunc<string, string>( x => x + "\n" );
+			AttributeFuncReceiver.Accept<string, string>( x => x + "\n" );
+		}
+
+		public void SimpleWithClosures() {
+			string trailing = "\n";
+			var func = new StatelessFunc<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
+			AttributeFuncReceiver.Accept<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
+		}
+
+		public void NonStaticMember() {
+			var func = new StatelessFunc<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
+			AttributeFuncReceiver.Accept<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
+		}
+
+		public void StaticMember() {
+			var func = new StatelessFunc<string, int>( Int32.Parse );
+			AttributeFuncReceiver.Accept<string, int>( Int32.Parse );
+		}
+
+		public void MultiLine() {
+			var func = new StatelessFunc<int>(
+				() => {
+					int x = 0;
+					return x + 1;
+				}
+			);
+			AttributeFuncReceiver.Accept<int>(
+				 () => {
+					 int x = 0;
+					 return x + 1;
+				 }
+			 );
+		}
+
+		public void MultiLineWithThisCapture() {
+			var func = new StatelessFunc<string>(
+				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
+					string trailing = "\n";
+					return this.ToString() + trailing;
+				} /**/
+			);
+			AttributeFuncReceiver.Accept<string>(
+				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
+					string trailing = "\n";
+					return this.ToString() + trailing;
+				} /**/
+			);
+		}
+
+		public void InvalidCtor() {
+			var func = new StatelessFunc();
+		}
+
+		public void EvilFactory() {
+			Func<int> evil() {
+				int x = 0;
+				return () => {
+					x += 1;
+					return x;
+				};
+			};
+
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
+			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
+		}
+
+		public void StatelessFunc() {
+			var func = new StatelessFunc<int>( new StatelessFunc<int>( () => 0 ) );
+			AttributeFuncReceiver.Accept( new StatelessFunc<int>( () => 0 ) );
+		}
+
+		public void StatelessFuncFromVar() {
 			var f = new StatelessFunc<int>( () => 0 );
 
 			var func = new StatelessFunc<int>( f );
 			AttributeFuncReceiver.Accept( f );
+		}
 
+		public void StatelessFuncFromParam( StatelessFunc<int> f) {
+			var func = new StatelessFunc<int>( f );
+			AttributeFuncReceiver.Accept( f );
+		}
+
+		public void StatelessFuncAttrParam( [StatelessFunc] Func<int> f ) {
+			var func = new StatelessFunc<int>( f );
+			AttributeFuncReceiver.Accept( f );
+		}
+
+		public void FuncFromVar() {
+			Func<int> f = () => 0;
+
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Unable to determine if variable reference f is a stateless func. ) */ f /**/ );
+			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt( Unable to determine if variable reference f is a stateless func. ) */ f /**/ );
+		}
+
+		public void FuncFromParam( Func<int> f ) {
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Unable to determine if variable reference f is a stateless func. ) */ f /**/ );
+			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt( Unable to determine if variable reference f is a stateless func. ) */ f /**/ );
 		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -7,21 +7,11 @@ namespace D2L {
 	public class StatelessFuncAttribute : Attribute { }
 
 	public class StatelessFunc<TResult> {
-
-		private readonly Func<TResult> m_func;
-
-		public StatelessFunc( Func<TResult> func ) {
-			m_func = func;
-		}
+		public StatelessFunc( [StatelessFunc] Func<TResult> func ) { }
 	}
 
 	public class StatelessFunc<T, TResult> {
-
-		private readonly Func<T, TResult> m_func;
-
-		public StatelessFunc( Func<T, TResult> func ) {
-			m_func = func;
-		}
+		public StatelessFunc( [StatelessFunc] Func<T, TResult> func ) { }
 	}
 
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -3,6 +3,9 @@
 using System;
 
 namespace D2L {
+
+	public class StatelessFuncAttribute : Attribute { }
+
 	public class StatelessFunc<TResult> {
 
 		private readonly Func<TResult> m_func;
@@ -20,37 +23,52 @@ namespace D2L {
 			m_func = func;
 		}
 	}
+
 }
 
 namespace SpecTests {
 
 	using D2L;
+
+	internal static class AttributeFuncReceiver {
+
+		internal static void Accept<TResult>( [StatelessFunc] Func<TResult> f ) { }
+		internal static void Accept<T1, TResult>( [StatelessFunc] Func<T1, TResult> f ) { }
+
+	}
+
 	internal sealed class Usages {
 
 		public void ParenNoClosures() {
 			var func = new StatelessFunc<int>( () => 0 );
+			AttributeFuncReceiver.Accept<int>( () => 0 );
 		}
 
 		public void ParenWithClosures() {
 			int zero = 0;
 			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
+			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
 		}
 
 		public void SimpleNoClosures() {
 			var func = new StatelessFunc<string, string>( x => x + "\n" );
+			AttributeFuncReceiver.Accept<string, string>( x => x + "\n" );
 		}
 
 		public void SimpleWithClosures() {
 			string trailing = "\n";
 			var func = new StatelessFunc<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
+			AttributeFuncReceiver.Accept<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
 		}
 
 		public void NonStaticMember() {
 			var func = new StatelessFunc<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
+			AttributeFuncReceiver.Accept<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
 		}
 
 		public void StaticMember() {
 			var func = new StatelessFunc<string, int>( Int32.Parse );
+			AttributeFuncReceiver.Accept<string, int>( Int32.Parse );
 		}
 
 		public void MultiLine() {
@@ -60,10 +78,22 @@ namespace SpecTests {
 					return x + 1;
 				}
 			);
+			AttributeFuncReceiver.Accept<int>(
+				 () => {
+					 int x = 0;
+					 return x + 1;
+				 }
+			 );
 		}
 
 		public void MultiLineWithThisCapture() {
 			var func = new StatelessFunc<string>(
+				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
+					string trailing = "\n";
+					return this.ToString() + trailing;
+				} /**/
+			);
+			AttributeFuncReceiver.Accept<string>(
 				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
 					string trailing = "\n";
 					return this.ToString() + trailing;
@@ -85,6 +115,7 @@ namespace SpecTests {
 			};
 
 			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
+			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
 		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -2,9 +2,19 @@
 
 using System;
 
+namespace D2L.CodeStyle.Annotations {
+	[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
+	public class ReadOnlyAttribute : Attribute { }
+
+	namespace Contract {
+		[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
+		public sealed class StatelessFuncAttribute : ReadOnlyAttribute { }
+	}
+}
+
 namespace D2L {
 
-	public class StatelessFuncAttribute : Attribute { }
+	using D2L.CodeStyle.Annotations.Contract;
 
 	public class StatelessFunc<TResult> {
 		public StatelessFunc( [StatelessFunc] Func<TResult> func ) { }
@@ -21,6 +31,7 @@ namespace D2L {
 namespace SpecTests {
 
 	using D2L;
+	using D2L.CodeStyle.Annotations.Contract;
 
 	internal static class AttributeFuncReceiver {
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -146,13 +146,13 @@ namespace SpecTests {
 		public void FuncFromVar() {
 			Func<int> f = () => 0;
 
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Unable to determine if variable reference f is a stateless func. ) */ f /**/ );
-			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt( Unable to determine if variable reference f is a stateless func. ) */ f /**/ );
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Unable to determine if f is stateless. ) */ f /**/ );
+			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt( Unable to determine if f is stateless. ) */ f /**/ );
 		}
 
 		public void FuncFromParam( Func<int> f ) {
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Unable to determine if variable reference f is a stateless func. ) */ f /**/ );
-			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt( Unable to determine if variable reference f is a stateless func. ) */ f /**/ );
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Unable to determine if f is stateless. ) */ f /**/ );
+			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt( Unable to determine if f is stateless. ) */ f /**/ );
 		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -8,10 +8,12 @@ namespace D2L {
 
 	public class StatelessFunc<TResult> {
 		public StatelessFunc( [StatelessFunc] Func<TResult> func ) { }
+		public static implicit operator Func<TResult>( StatelessFunc<TResult> @this ) { }
 	}
 
 	public class StatelessFunc<T, TResult> {
 		public StatelessFunc( [StatelessFunc] Func<T, TResult> func ) { }
+		public static implicit operator Func<T, TResult>( StatelessFunc<T, TResult> @this ) { }
 	}
 
 }
@@ -28,84 +30,13 @@ namespace SpecTests {
 	}
 
 	internal sealed class Usages {
+		public void StatelessFunc() {
 
-		public void ParenNoClosures() {
-			var func = new StatelessFunc<int>( () => 0 );
-			AttributeFuncReceiver.Accept<int>( () => 0 );
-		}
+			var f = new StatelessFunc<int>( () => 0 );
 
-		public void ParenWithClosures() {
-			int zero = 0;
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
-			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
-		}
+			var func = new StatelessFunc<int>( f );
+			AttributeFuncReceiver.Accept( f );
 
-		public void SimpleNoClosures() {
-			var func = new StatelessFunc<string, string>( x => x + "\n" );
-			AttributeFuncReceiver.Accept<string, string>( x => x + "\n" );
-		}
-
-		public void SimpleWithClosures() {
-			string trailing = "\n";
-			var func = new StatelessFunc<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
-			AttributeFuncReceiver.Accept<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
-		}
-
-		public void NonStaticMember() {
-			var func = new StatelessFunc<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
-			AttributeFuncReceiver.Accept<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
-		}
-
-		public void StaticMember() {
-			var func = new StatelessFunc<string, int>( Int32.Parse );
-			AttributeFuncReceiver.Accept<string, int>( Int32.Parse );
-		}
-
-		public void MultiLine() {
-			var func = new StatelessFunc<int>(
-				() => {
-					int x = 0;
-					return x + 1;
-				}
-			);
-			AttributeFuncReceiver.Accept<int>(
-				 () => {
-					 int x = 0;
-					 return x + 1;
-				 }
-			 );
-		}
-
-		public void MultiLineWithThisCapture() {
-			var func = new StatelessFunc<string>(
-				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
-					string trailing = "\n";
-					return this.ToString() + trailing;
-				} /**/
-			);
-			AttributeFuncReceiver.Accept<string>(
-				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
-					string trailing = "\n";
-					return this.ToString() + trailing;
-				} /**/
-			);
-		}
-
-		public void InvalidCtor() {
-			var func = new StatelessFunc();
-		}
-
-		public void EvilFactory() {
-			Func<int> evil() {
-				int x = 0;
-				return () => {
-					x += 1;
-					return x;
-				};
-			};
-
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
-			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
 		}
 	}
 }


### PR DESCRIPTION
(Future?) TODOs:
- Remove the ObjectCreation analysis, and just do `public StatelessFunc( [StatelessFunc] Func<> func )`
- Expand to trust `StatelessFunc<>` as an argument
- Expand to trust references to a local argument that's marked `[StatelessFunc]`

Why I think this could be beneficial:

- Introduce analysis into an API without requiring `new StatelessFunc`age
- `StatelessFunc<>` is only needed for storage
- Reasons?