### PR TITLE
D2LXXXX: [ReadOnly] parameters

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -475,5 +475,15 @@ namespace D2L.CodeStyle.Analyzers {
 			description: "StatelessFunc is to be used to hold Func private members, and need to be undiff safe."
 		);
 
+		public static readonly DiagnosticDescriptor ReadOnlyParameterIsnt = new DiagnosticDescriptor(
+			id: "D2L0054",
+			title: "Parameter is not readonly",
+			messageFormat: "Parameter is not readonly: {0}",
+			category: "Safety",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "[ReadOnly] paramaters must not be assigned to or passed by non-readonly reference."
+		);
+
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ReadOnlyParameterAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ReadOnlyParameterAnalyzer.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace D2L.CodeStyle.Analyzers.Immutability {
+
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	internal sealed class ReadOnlyParameterAnalyzer : DiagnosticAnalyzer {
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+			Diagnostics.ReadOnlyParameterIsnt
+		);
+
+		public override void Initialize( AnalysisContext context ) {
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction( RegisterAnalysis );
+		}
+
+		private static void RegisterAnalysis( CompilationStartAnalysisContext context ) {
+
+			Compilation compilation = context.Compilation;
+
+			INamedTypeSymbol readOnlyAttribute = compilation.GetTypeByMetadataName( "D2L.CodeStyle.Annotations.ReadOnlyAttribute" );
+
+			if( readOnlyAttribute == null ) {
+				return;
+			}
+
+			context.RegisterSyntaxNodeAction(
+				ctx => AnalyzeParameter(
+					ctx: ctx,
+					readOnlyAttribute: readOnlyAttribute,
+					syntax: ctx.Node as ParameterSyntax
+				),
+				SyntaxKind.Parameter
+			);
+		}
+
+		private static void AnalyzeParameter(
+			SyntaxNodeAnalysisContext ctx,
+			INamedTypeSymbol readOnlyAttribute,
+			ParameterSyntax syntax
+		) {
+			SemanticModel model = ctx.SemanticModel;
+
+			IParameterSymbol parameter = model.GetDeclaredSymbol( syntax, ctx.CancellationToken );
+
+			if( !IsMarkedReadOnly( readOnlyAttribute, parameter ) ) {
+				return;
+			}
+
+			if( parameter.RefKind != RefKind.None ) {
+				/**
+				 * public void Foo( [ReadOnly] in int foo )
+				 * public void Foo( [ReadOnly] ref int foo )
+				 * public void Foo( [ReadOnly] out int foo )
+				 */
+				ctx.ReportDiagnostic( Diagnostic.Create(
+					Diagnostics.ReadOnlyParameterIsnt,
+					syntax.GetLocation(),
+					"is an in/ref/out parameter"
+				) );
+			}
+
+			IMethodSymbol method = parameter.ContainingSymbol as IMethodSymbol;
+			BlockSyntax methodBody = ( method.DeclaringSyntaxReferences[0].GetSyntax( ctx.CancellationToken ) as MethodDeclarationSyntax ).Body;
+
+			DataFlowAnalysis dataflow = model.AnalyzeDataFlow( methodBody );
+			if( dataflow.WrittenInside.Contains( parameter ) ) {
+				/**
+				 * public void Foo( [ReadOnly] int foo ) {
+				 *   foo = 1; // write
+				 *   void Inline() { foo = 1; // write }
+				 *   var lambda = () => foo = 1; // write
+				 *   SomeRefFunc( ref foo ); // pass by ref, potential for write
+				 * }
+				 */
+				ctx.ReportDiagnostic( Diagnostic.Create(
+					Diagnostics.ReadOnlyParameterIsnt,
+					syntax.GetLocation(),
+					"is assigned to and/or passed by reference"
+				) );
+			}
+		}
+
+		private static bool IsMarkedReadOnly(
+			INamedTypeSymbol readOnlyAttribute,
+			IParameterSymbol parameterSymbol
+		) {
+			foreach( AttributeData attribute in parameterSymbol.GetAttributes() ) {
+				if( IsReadOnlyAttribute( readOnlyAttribute, attribute.AttributeClass ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private static bool IsReadOnlyAttribute(
+			INamedTypeSymbol readOnlyAttribute,
+			INamedTypeSymbol type
+		) {
+			if( type == null ) {
+				return false;
+			}
+
+			if( type == readOnlyAttribute ) {
+				return true;
+			}
+
+			return IsReadOnlyAttribute( readOnlyAttribute, type.BaseType );
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Annotations/ReadOnlyAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/ReadOnlyAttribute.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+namespace D2L.CodeStyle.Annotations {
+	[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
+	public class ReadOnlyAttribute : Attribute {}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -63,6 +63,7 @@
     <EmbeddedResource Include="Specs\LoggingExecutionContextScopeBuilderAnalyzer.cs" />
     <EmbeddedResource Include="Specs\ILpContentFilePhysicalPathAnalyzer.cs" />
     <EmbeddedResource Include="Specs\StatelessFuncAnalyzerSpec.cs" />
+    <EmbeddedResource Include="Specs\ReadOnlyParameterAnalyzerSpec.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="Extensions\TypeSymbolExtensionsTests.cs" />
     <Compile Include="ApiUsage\NotNullAnalyzerTests.cs" />

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ReadOnlyParameterAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ReadOnlyParameterAnalyzerSpec.cs
@@ -1,0 +1,140 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.Immutability.ReadOnlyParameterAnalyzer
+
+using System;
+
+namespace D2L.CodeStyle.Annotations {
+	[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
+	public class ReadOnlyAttribute : Attribute {}
+
+}
+
+namespace SpecTests {
+
+	using D2L.CodeStyle.Annotations;
+
+	internal sealed class ReadOnlyAttributeUsages {
+
+		void Unused( [ReadOnly] int foo ) {}
+
+		void OnlyRead( [ReadOnly] int foo ) {
+			int bar = foo;
+		}
+
+		void PassedByValue( [ReadOnly] int foo ) {
+			WrittenToInBody( foo );
+		}
+
+		void PassedToIn( [ReadOnly] int foo ) {
+			InParameter( foo );
+		}
+
+		ref readonly int ReadonlyRefReturn( [ReadOnly] int foo ) {
+			return foo;
+		}
+
+		void WrittenToInBody( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnly] int foo /**/ ) {
+			foo = 1;
+		}
+
+		void WrittenToInInlineFunc( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnly] int foo /**/ ) {
+			void Helper() { foo = 1; }
+		}
+
+		void WrittenToInLambda( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnly] int foo /**/ ) {
+			() => { foo = 1; };
+		}
+
+		void PassedToRef( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnly] int foo /**/ ) {
+			RefParameter( ref foo );
+		}
+
+		void RefParameter( /* ReadOnlyParameterIsnt( is an in/ref/out parameter ) */ [ReadOnly] ref int foo /**/ ) { }
+		void InParameter( /* ReadOnlyParameterIsnt( is an in/ref/out parameter ) */ [ReadOnly] in int foo /**/ ) { }
+
+	}
+
+	internal sealed class SubclassAttributeUsages {
+
+		[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
+		public sealed class ReadOnlySubclassAttribute : ReadOnlyAttribute { }
+
+		void Unused( [ReadOnlySubclass] int foo ) { }
+
+		void OnlyRead( [ReadOnlySubclass] int foo ) {
+			int bar = foo;
+		}
+
+		void PassedByValue( [ReadOnlySubclass] int foo ) {
+			WrittenToInBody( foo );
+		}
+
+		void PassedToIn( [ReadOnlySubclass] int foo ) {
+			InParameter( foo );
+		}
+
+		ref readonly int ReadonlyRefReturn( [ReadOnlySubclass] int foo ) {
+			return foo;
+		}
+
+		void WrittenToInBody( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnlySubclass] int foo /**/ ) {
+			foo = 1;
+		}
+
+		void WrittenToInInlineFunc( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnlySubclass] int foo /**/ ) {
+			void Helper() { foo = 1; }
+		}
+
+		void WrittenToInLambda( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnlySubclass] int foo /**/ ) {
+			() => { foo = 1; };
+		}
+
+		void PassedToRef( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnlySubclass] int foo /**/ ) {
+			RefParameter( ref foo );
+		}
+
+		void RefParameter( /* ReadOnlyParameterIsnt( is an in/ref/out parameter ) */ [ReadOnlySubclass] ref int foo /**/ ) { }
+		void InParameter( /* ReadOnlyParameterIsnt( is an in/ref/out parameter ) */ [ReadOnlySubclass] in int foo /**/ ) { }
+
+	}
+
+	internal sealed class NonReadOnlyThings {
+
+		void Unused( int foo ) { }
+
+		void OnlyRead( int foo ) {
+			int bar = foo;
+		}
+
+		void PassedByValue( int foo ) {
+			WrittenToInBody( foo );
+		}
+
+		void PassedToIn( int foo ) {
+			InParameter( foo );
+		}
+
+		ref readonly int ReadonlyRefReturn( int foo ) {
+			return foo;
+		}
+
+		void WrittenToInBody( int foo ) {
+			foo = 1;
+		}
+
+		void WrittenToInInlineFunc( int foo ) {
+			void Helper() { foo = 1; }
+		}
+
+		void WrittenToInLambda( int foo ) {
+			() => { foo = 1; };
+		}
+
+		void PassedToRef( int foo ) {
+			RefParameter( ref foo );
+		}
+
+		void RefParameter( ref int foo ) { }
+		void InParameter( in int foo ) { }
+
+	}
+}


### PR DESCRIPTION
Provides an attribute and analyzer for marking parameters as read only (can't be assigned to or passed by non-readonly reference).

The attribute can be subclassed, so other attributes can get the same behaviour (such as `[StatelessFunc]`).