### PR TITLE
Add analyzer for nameof usage in ConfigTestSetupAttribute

### DIFF
--- a/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
@@ -21,5 +21,15 @@ namespace D2L.CodeStyle.TestAnalyzers.Common {
 			isEnabledByDefault: true,
 			description: "Using strings in ValueSource attributes creates false positives during dead code analysis. nameof should be used instead."
 		);
+
+		public static readonly DiagnosticDescriptor ConfigTestSetupStrings = new DiagnosticDescriptor(
+			id: "D2LTESTS003",
+			title: "Use nameof in ConfigTestSetup attributes.",
+			messageFormat: "String arguments in ConfigTestSetup not allowed. Use nameof( {0} ) instead.",
+			category: "Cleanliness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "Using strings in ConfigTestSetup attributes creates false positives during dead code analysis. nameof should be used instead."
+		);
 	}
 }

--- a/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
@@ -25,7 +25,7 @@ namespace D2L.CodeStyle.TestAnalyzers.Common {
 		public static readonly DiagnosticDescriptor ConfigTestSetupStrings = new DiagnosticDescriptor(
 			id: "D2LTESTS003",
 			title: "Use nameof in ConfigTestSetup attributes.",
-			messageFormat: "String arguments in ConfigTestSetup not allowed. Use nameof( {0} ) instead.",
+			messageFormat: "String arguments in ConfigTestSetup are not allowed. Use nameof({0}) instead.",
 			category: "Cleanliness",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true,

--- a/src/D2L.CodeStyle.TestAnalyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace D2L.CodeStyle.TestAnalyzers.Extensions {
+	public static class RoslynExtensions {
+
+		// Copied from the non-test assembly because we do not reference it.
+
+		public static bool IsNullOrErrorType( this ITypeSymbol symbol ) {
+
+			if( symbol == null ) {
+				return true;
+			}
+
+			if( symbol.Kind == SymbolKind.ErrorType ) {
+				return true;
+			}
+
+			if( symbol.TypeKind == TypeKind.Error ) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static bool IsNullOrErrorType( this ISymbol symbol ) {
+
+			if( symbol == null ) {
+				return true;
+			}
+
+			if( symbol.Kind == SymbolKind.ErrorType ) {
+				return true;
+			}
+
+			return false;
+		}
+
+	}
+}

--- a/src/D2L.CodeStyle.TestAnalyzers/NUnit/ConfigTestSetupStringsAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/NUnit/ConfigTestSetupStringsAnalyzer.cs
@@ -1,0 +1,107 @@
+using System.Collections.Immutable;
+using System.Linq;
+using D2L.CodeStyle.TestAnalyzers.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.TestAnalyzers.NUnit {
+
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	public sealed class ConfigTestSetupStringsAnalyzer : DiagnosticAnalyzer {
+
+		private const string AttributeName = "ConfigTestSetupAttribute";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+			=> ImmutableArray.Create( Diagnostics.ConfigTestSetupStrings );
+
+		public override void Initialize( AnalysisContext context ) {
+
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction( Register );
+		}
+
+		private void Register( CompilationStartAnalysisContext compilation ) {
+
+			compilation.RegisterSyntaxNodeAction(
+					AnalyzeSyntaxNode,
+					SyntaxKind.MethodDeclaration,
+					SyntaxKind.ClassDeclaration
+				);
+		}
+
+		private void AnalyzeSyntaxNode( SyntaxNodeAnalysisContext context ) {
+
+			SyntaxList<AttributeListSyntax> attributeList;
+
+			switch( context.Node ) {
+
+				case MethodDeclarationSyntax method:
+					attributeList = method.AttributeLists;
+					break;
+
+				case ClassDeclarationSyntax @class:
+					attributeList = @class.AttributeLists;
+					break;
+
+				default:
+					return;
+			}
+
+			AttributeSyntax[] attributes = attributeList
+				.SelectMany( x => x.Attributes )
+				.ToArray();
+
+			// Method has no attributes
+			if( !attributes.Any() ) {
+				return;
+			}
+
+			foreach( AttributeSyntax attribute in attributes ) {
+
+				ISymbol symbol = context
+					.SemanticModel
+					.GetSymbolInfo( attribute )
+					.Symbol;
+
+				if( symbol == null ) {
+					continue;
+				}
+
+				// Not a [ConfigTestSetup()]
+				string displayString = symbol.ToDisplayString(
+						SymbolDisplayFormat.FullyQualifiedFormat
+					);
+				if( displayString != AttributeName ) {
+					continue;
+				}
+
+				SeparatedSyntaxList<AttributeArgumentSyntax> arguments =
+					attribute.ArgumentList.Arguments;
+
+				if( arguments.Count != 1 ) {
+					continue;
+				}
+
+				ExpressionSyntax argExpression = arguments.First().Expression;
+
+				// Not [ConfigTestSetup( "foo" )]
+				if( !argExpression.IsKind( SyntaxKind.StringLiteralExpression ) ) {
+					continue;
+				}
+
+				LiteralExpressionSyntax stringLiteral =
+					(LiteralExpressionSyntax)argExpression;
+
+				Diagnostic diagnostic = Diagnostic.Create(
+						Diagnostics.ConfigTestSetupStrings,
+						argExpression.GetLocation(),
+						stringLiteral.ToString().Trim( '"' )
+					);
+				context.ReportDiagnostic( diagnostic );
+			}
+		}
+
+	}
+}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/D2L.CodeStyle.TestAnalyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/D2L.CodeStyle.TestAnalyzers.Tests.csproj
@@ -164,6 +164,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NUnit\ConfigTestSetupStringsAnalyzerTests.cs" />
     <Compile Include="NUnit\ValueSourceStringsAnalyzerTests.cs" />
     <Compile Include="ParallelizableTests\ParallelizableTestsAnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/NUnit/ConfigTestSetupStringsAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/NUnit/ConfigTestSetupStringsAnalyzerTests.cs
@@ -1,0 +1,133 @@
+﻿using D2L.CodeStyle.TestAnalyzers.Common;
+using D2L.CodeStyle.TestAnalyzers.Test.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace D2L.CodeStyle.TestAnalyzers.NUnit {
+	[TestFixture]
+	internal sealed class ConfigTestSetupStringsAnalyzerTests : DiagnosticVerifier {
+
+		private const string PREAMBLE = @"
+using System;
+using D2L.LP.Configuration.Config;
+using NUnit.Framework;
+
+namespace D2L.LP.Configuration.Config {
+	[AttributeUsage( AttributeTargets.Method | AttributeTargets.Class )]
+	public sealed class ConfigTestSetupAttribute : Attribute {
+		public ConfigTestSetupAttribute( string sourceName ) { }
+	}
+}
+";
+
+		[Test]
+		public void NoAttribute_NoDiag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	class Test {
+		[Test]
+		public void Test() {}
+	}
+}";
+			AssertNoDiagnostic( test );
+		}
+
+		[Test]
+		public void MethodAttribute_WithNameOf_NoDiag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	class Test {
+		private static readonly object SourceName = new object();
+
+		[Test]
+		[ConfigTestSetup( nameof( SourceName ) )]
+		public void Test() {}
+	}
+}";
+			AssertNoDiagnostic( test );
+		}
+
+		[Test]
+		public void MethodAttribute_StringName_Diag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	class Test {
+		private static readonly object SourceName = new object();
+
+		[Test]
+		[ConfigTestSetup( ""SourceName"" )]
+		public void Test() {}
+	}
+}";
+			AssertSingleDiagnostic( Diagnostics.ConfigTestSetupStrings, test, 18, 21, "SourceName" );
+		}
+
+		[Test]
+		public void FixtureAttribute_WithNameOf_NoDiag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	[ConfigTestSetup( nameof( SourceName ) )]
+	class Test {
+		private static readonly object SourceName = new object();
+
+		[Test]
+		public void Test() {}
+	}
+}";
+			AssertNoDiagnostic( test );
+		}
+
+		[Test]
+		public void FixtureAttribute_StringName_Diag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	[ConfigTestSetup( ""SourceName"" )]
+	class Test {
+		private static readonly object SourceName = new object();
+
+		[Test]
+		public void Test() {}
+	}
+}";
+			AssertSingleDiagnostic( Diagnostics.ConfigTestSetupStrings, test, 14, 20, "SourceName" );
+		}
+
+		private void AssertNoDiagnostic( string file ) {
+			VerifyCSharpDiagnostic( file );
+		}
+
+		private void AssertSingleDiagnostic(
+				DiagnosticDescriptor diag,
+				string file,
+				int line,
+				int column,
+				params object[] messageArgs
+			) {
+
+			DiagnosticResult result = new DiagnosticResult {
+				Id = diag.Id,
+				Message = string.Format( diag.MessageFormat.ToString(), messageArgs ),
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] {
+					new DiagnosticResultLocation( "Test0.cs", line, column )
+				}
+			};
+
+			VerifyCSharpDiagnostic( file, result );
+		}
+
+
+		private static readonly MetadataReference NUnitReference =
+			MetadataReference.CreateFromFile( typeof(TestAttribute).Assembly.Location );
+
+		protected override MetadataReference[] GetAdditionalReferences() => new[] {
+			NUnitReference
+		};
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() {
+			return new ConfigTestSetupStringsAnalyzer();
+		}
+
+	}
+}

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/NUnit/ConfigTestSetupStringsAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/NUnit/ConfigTestSetupStringsAnalyzerTests.cs
@@ -49,7 +49,7 @@ namespace Test {
 		}
 
 		[Test]
-		public void MethodAttribute_StringName_Diag() {
+		public void MethodAttribute_WithLiteral_Diag() {
 			const string test = PREAMBLE + @"
 namespace Test {
 	class Test {
@@ -61,6 +61,22 @@ namespace Test {
 	}
 }";
 			AssertSingleDiagnostic( Diagnostics.ConfigTestSetupStrings, test, 18, 21, "SourceName" );
+		}
+
+		[Test]
+		public void MethodAttribute_WithConstant_Diag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	class Test {
+		private const string Source = ""SourceName"";
+		private static readonly object SourceName = new object();
+
+		[Test]
+		[ConfigTestSetup( Source )]
+		public void Test() {}
+	}
+}";
+			AssertSingleDiagnostic( Diagnostics.ConfigTestSetupStrings, test, 19, 21, "..." );
 		}
 
 		[Test]
@@ -79,7 +95,7 @@ namespace Test {
 		}
 
 		[Test]
-		public void FixtureAttribute_StringName_Diag() {
+		public void FixtureAttribute_WithLiteral_Diag() {
 			const string test = PREAMBLE + @"
 namespace Test {
 	[ConfigTestSetup( ""SourceName"" )]
@@ -91,6 +107,22 @@ namespace Test {
 	}
 }";
 			AssertSingleDiagnostic( Diagnostics.ConfigTestSetupStrings, test, 14, 20, "SourceName" );
+		}
+
+		[Test]
+		public void FixtureAttribute_WithConstant_Diag() {
+			const string test = PREAMBLE + @"
+namespace Test {
+	[ConfigTestSetup( Source )]
+	class Test {
+		public const string Source = ""SourceName"";
+		private static readonly object SourceName = new object();
+
+		[Test]
+		public void Test() {}
+	}
+}";
+			AssertSingleDiagnostic( Diagnostics.ConfigTestSetupStrings, test, 14, 20, "..." );
 		}
 
 		private void AssertNoDiagnostic( string file ) {


### PR DESCRIPTION
This PR adds the suggested analyzer to prevent `[ConfigTestSetup( "SymbolName" )]` usage, recommending `nameof(SymbolName)` usage instead. This was Owen's suggestion on my PR in core.