### PR TITLE
D2L0055: Require awaited tasks are configured.

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -485,5 +485,15 @@ namespace D2L.CodeStyle.Analyzers {
 			description: "[ReadOnly] paramaters must not be assigned to or passed by non-readonly reference."
 		);
 
+		public static readonly DiagnosticDescriptor AwaitedTaskNotConfigured = new DiagnosticDescriptor(
+			id: "D2L0055",
+			title: "Awaited task is not configured",
+			messageFormat: "Awaited task is not configured",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "Awaited task should have 'continueOnCapturedContext' configured (preferably with 'false')."
+		);
+
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.Codefix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.Codefix.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace D2L.CodeStyle.Analyzers.Language {
+	partial class AwaitedTasksAnalyzer {
+
+		[ExportCodeFixProvider(
+			LanguageNames.CSharp,
+			Name = nameof( ConfigureAwaitedTaskCodeFix )
+		)]
+		public sealed class ConfigureAwaitedTaskCodeFix : CodeFixProvider {
+
+			public override ImmutableArray<string> FixableDiagnosticIds
+				=> ImmutableArray.Create( Diagnostics.AwaitedTaskNotConfigured.Id );
+
+			public override FixAllProvider GetFixAllProvider()
+				=> WellKnownFixAllProviders.BatchFixer;
+
+			public override async Task RegisterCodeFixesAsync(
+				CodeFixContext ctx
+			) {
+				var root = await ctx.Document
+					.GetSyntaxRootAsync( ctx.CancellationToken )
+					.ConfigureAwait( false );
+
+				bool useSafeAsync = await CanReferenceSafeAsync( ctx )
+					.ConfigureAwait( false );
+
+				foreach( var diagnostic in ctx.Diagnostics ) {
+					var span = diagnostic.Location.SourceSpan;
+
+					SyntaxNode syntax = root.FindNode( span, getInnermostNodeForTie: true );
+					if( !( syntax is AwaitExpressionSyntax awaitExpression ) ) {
+						continue;
+					}
+
+					ctx.RegisterCodeFix(
+						CodeAction.Create(
+							title: "Configure awaited task",
+							ct => ConfigureAwaitedTask(
+								orig: ctx.Document,
+								root: root,
+								awaitExpression: awaitExpression,
+								useSafeAsync: useSafeAsync,
+								cancellationToken: ct
+							)
+						),
+						diagnostic
+					);
+				}
+			}
+
+			private static InvocationExpressionSyntax ConfigureTask( ExpressionSyntax task ) =>
+				SyntaxFactory
+					.InvocationExpression( SyntaxFactory.MemberAccessExpression(
+						SyntaxKind.SimpleMemberAccessExpression,
+						task,
+						SyntaxFactory.IdentifierName( "ConfigureAwait" )
+					) )
+					.WithArgumentList( SyntaxFactory.ArgumentList( SyntaxFactory.SingletonSeparatedList(
+						SyntaxFactory
+							.Argument( SyntaxFactory.LiteralExpression( SyntaxKind.FalseLiteralExpression ) )
+							.WithNameColon( SyntaxFactory.NameColon( "continueOnCapturedContext" ) )
+					) ) );
+
+			private static InvocationExpressionSyntax SafeAsyncify( ExpressionSyntax task ) =>
+				SyntaxFactory
+					.InvocationExpression( SyntaxFactory.MemberAccessExpression(
+						SyntaxKind.SimpleMemberAccessExpression,
+						task,
+						SyntaxFactory.IdentifierName( "SafeAsync" )
+					) );
+
+			private static Task<Document> ConfigureAwaitedTask(
+				Document orig,
+				SyntaxNode root,
+				AwaitExpressionSyntax awaitExpression,
+				bool useSafeAsync,
+				CancellationToken cancellationToken
+			) {
+				ExpressionSyntax rhs = awaitExpression.Expression;
+				InvocationExpressionSyntax replacement = useSafeAsync
+					? SafeAsyncify( rhs )
+					: ConfigureTask( rhs );
+
+				root = root.ReplaceNode( rhs, replacement );
+
+				var newDoc = orig.WithSyntaxRoot( root );
+
+				return Task.FromResult( newDoc );
+			}
+
+			private static async Task<bool> CanReferenceSafeAsync(
+				CodeFixContext ctx
+			) {
+				Compilation compilation = await ctx
+					.Document
+					.Project
+					.GetCompilationAsync( ctx.CancellationToken )
+					.ConfigureAwait( false );
+
+				foreach( AssemblyIdentity reference in compilation.ReferencedAssemblyNames ) {
+					if( reference.Name == "D2L.Core" ) {
+						return true;
+					}
+				}
+
+				return false;
+			}
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace D2L.CodeStyle.Analyzers.Language {
+
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	internal sealed class AwaitedTasksAnalyzer : DiagnosticAnalyzer {
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+			=> ImmutableArray.Create( Diagnostics.AwaitedTaskNotConfigured );
+
+		public override void Initialize( AnalysisContext context ) {
+			context.EnableConcurrentExecution();
+
+			context.ConfigureGeneratedCodeAnalysis(
+				GeneratedCodeAnalysisFlags.None
+			);
+
+			context.RegisterCompilationStartAction( RegisterAnalyzer );
+		}
+
+		private static void RegisterAnalyzer(
+			CompilationStartAnalysisContext context
+		) {
+			ImmutableHashSet<INamedTypeSymbol> configuredTaskTypes = ImmutableHashSet
+				.Create(
+					context.Compilation.GetTypeByMetadataName( "System.Runtime.CompilerServices.ConfiguredTaskAwaitable" ),
+					context.Compilation.GetTypeByMetadataName( "System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1" ),
+					context.Compilation.GetTypeByMetadataName( "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable" ),
+					context.Compilation.GetTypeByMetadataName( "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1" )
+				)
+				.Where( x => x != null && x.Kind != SymbolKind.ErrorType )
+				.ToImmutableHashSet();
+			if( !configuredTaskTypes.Any() ) {
+				return;
+			}
+
+			context.RegisterOperationAction(
+				ctx => AnalyzeAwait(
+					context: ctx,
+					configuredTaskTypes: configuredTaskTypes,
+					operation: ctx.Operation as IAwaitOperation
+				),
+				OperationKind.Await
+			);
+		}
+
+		private static void AnalyzeAwait(
+			OperationAnalysisContext context,
+			ImmutableHashSet<INamedTypeSymbol> configuredTaskTypes,
+			IAwaitOperation operation
+		) {
+			IOperation rhs = operation.Operation;
+			ITypeSymbol awaitedType = rhs.Type.OriginalDefinition;
+
+			if( configuredTaskTypes.Contains( awaitedType ) ) {
+				return;
+			}
+
+			context.ReportDiagnostic( Diagnostic.Create(
+				Diagnostics.AwaitedTaskNotConfigured,
+				operation.Syntax.GetLocation()
+			) );
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace D2L.CodeStyle.Analyzers.Language {
 
 	[DiagnosticAnalyzer( LanguageNames.CSharp )]
-	internal sealed class AwaitedTasksAnalyzer : DiagnosticAnalyzer {
+	internal sealed partial class AwaitedTasksAnalyzer : DiagnosticAnalyzer {
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create( Diagnostics.AwaitedTaskNotConfigured );
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/AwaitedTasksAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/AwaitedTasksAnalyzer.cs
@@ -1,0 +1,151 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.Language.AwaitedTasksAnalyzer
+
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+namespace System.Threading.Tasks {
+
+	public struct ValueTask {
+		public ConfiguredValueTaskAwaitable ConfigureAwait( bool continueOnCapturedContext ) { }
+	}
+	public struct ValueTask<TResult> {
+		public ConfiguredValueTaskAwaitable<TResult> ConfigureAwait( bool continueOnCapturedContext ) { }
+	}
+
+}
+
+namespace System.Runtime.CompilerServices {
+
+	public struct ConfiguredValueTaskAwaitable { }
+	public struct ConfiguredValueTaskAwaitable<TResult> { }
+
+}
+
+namespace SpecTests {
+	public sealed class SpecTests<T> {
+
+		async public Task Good() {
+
+			await TaskReturningFunction().ConfigureAwait( false );
+			await TaskTReturningFunction().ConfigureAwait( false );
+			await SomeClass.TaskReturningMemberFunction().ConfigureAwait( false );
+			await SomeClass.TaskTReturningMemberFunction().ConfigureAwait( false );
+			await ValueTaskReturningFunction().ConfigureAwait( false );
+			await ValueTaskTReturningFunction().ConfigureAwait( false );
+			await SomeClass.ValueTaskReturningMemberFunction().ConfigureAwait( false );
+			await SomeClass.ValueTaskTReturningMemberFunction().ConfigureAwait( false );
+
+			await ConfiguredTaskReturningFunction();
+			await ConfiguredTaskTReturningFunction();
+			await ConfiguredValueTaskReturningFunction();
+			await ConfiguredValueTaskTReturningFunction();
+
+			{
+				Task t = default;
+				await t.ConfigureAwait( false );
+			}
+
+			{
+				Task<T> t = default;
+				await t.ConfigureAwait( false );
+			}
+
+			{
+				ValueTask t = default;
+				await t.ConfigureAwait( false );
+			}
+
+			{
+				ValueTask<T> t = default;
+				await t.ConfigureAwait( false );
+			}
+
+		}
+
+		async public Task IdeallyBadBecauseConfiguredWrong() {
+
+			await TaskReturningFunction().ConfigureAwait( true );
+			await TaskTReturningFunction().ConfigureAwait( true );
+			await SomeClass.TaskReturningMemberFunction().ConfigureAwait( true );
+			await SomeClass.TaskTReturningMemberFunction().ConfigureAwait( true );
+			await ValueTaskReturningFunction().ConfigureAwait( true );
+			await ValueTaskTReturningFunction().ConfigureAwait( true );
+			await SomeClass.ValueTaskReturningMemberFunction().ConfigureAwait( true );
+			await SomeClass.ValueTaskTReturningMemberFunction().ConfigureAwait( true );
+
+			{
+				Task t = default;
+				await t.ConfigureAwait( true );
+			}
+
+			{
+				Task<T> t = default;
+				await t.ConfigureAwait( true );
+			}
+
+			{
+				ValueTask t = default;
+				await t.ConfigureAwait( true );
+			}
+
+			{
+				ValueTask<T> t = default;
+				await t.ConfigureAwait( true );
+			}
+
+		}
+
+		async public Task BadBecauseNotConfigured() {
+
+			/* AwaitedTaskNotConfigured() */ await TaskReturningFunction() /**/;
+			/* AwaitedTaskNotConfigured() */ await TaskTReturningFunction() /**/;
+			/* AwaitedTaskNotConfigured() */ await SomeClass.TaskReturningMemberFunction() /**/;
+			/* AwaitedTaskNotConfigured() */ await SomeClass.TaskTReturningMemberFunction() /**/;
+			/* AwaitedTaskNotConfigured() */ await ValueTaskReturningFunction() /**/;
+			/* AwaitedTaskNotConfigured() */ await ValueTaskTReturningFunction() /**/;
+			/* AwaitedTaskNotConfigured() */ await SomeClass.ValueTaskReturningMemberFunction() /**/;
+			/* AwaitedTaskNotConfigured() */ await SomeClass.ValueTaskTReturningMemberFunction() /**/;
+
+			{
+				Task t = default;
+				/* AwaitedTaskNotConfigured() */ await t /**/;
+			}
+
+			{
+				Task<T> t = default;
+				/* AwaitedTaskNotConfigured() */ await t /**/;
+			}
+
+			{
+				ValueTask t = default;
+				/* AwaitedTaskNotConfigured() */ await t /**/;
+			}
+
+			{
+				ValueTask<T> t = default;
+				/* AwaitedTaskNotConfigured() */ await t /**/;
+			}
+
+		}
+
+		async public Task TaskReturningFunction() { }
+		async public Task<T> TaskTReturningFunction() { }
+		async public ValueTask ValueTaskReturningFunction() { }
+		async public ValueTask<T> ValueTaskTReturningFunction() { }
+
+		async public ConfiguredTaskAwaitable ConfiguredTaskReturningFunction() { }
+		async public ConfiguredTaskAwaitable<T> ConfiguredTaskTReturningFunction() { }
+		async public ConfiguredValueTaskAwaitable ConfiguredValueTaskReturningFunction() { }
+		async public ConfiguredValueTaskAwaitable<T> ConfiguredValueTaskTReturningFunction() { }
+
+		public static class SomeClass {
+
+			async public static Task TaskReturningMemberFunction() { }
+			async public static Task<T> TaskTReturningMemberFunction() { }
+			async public static ValueTask ValueTaskReturningMemberFunction() { }
+			async public static ValueTask<T> ValueTaskTReturningMemberFunction() { }
+
+		}
+
+	}
+}


### PR DESCRIPTION
This is unopinionated on true vs false (modulo the CodeFix using false). Just requires something `await`ed must be configured in one direction. Handles `Task` and `ValueTask`.

Uses `SafeAsync()` if `D2L.Core` is referenced. Otherwise uses `ConfigureAwait( continueOnCapturedContext: false )`.