### PR TITLE
Made GetPseudoName work with any type of argument

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -227,20 +227,8 @@ namespace D2L.CodeStyle.Analyzers.Language {
 		}
 
 		private static string GetPsuedoName( ArgumentSyntax arg ) {
-			string ident = null;
 
-			switch( arg.Expression ) {
-				case IdentifierNameSyntax identArg:
-					ident = identArg.Identifier.ValueText;
-					break;
-				case MemberAccessExpressionSyntax access:
-					// Member access is left-associative, so we pick the
-					// right -most ident, i.e. "foo.bar.baz" is equivalent to
-					// (foo.bar).baz, and we will grab "baz".
-					ident = access.Name.Identifier.ValueText;
-					break;
-			}
-
+			string ident = arg.Expression.TryGetInferredMemberName();
 			if( ident == null ) {
 				return null;
 			}


### PR DESCRIPTION
Previously only `IdentifierNameSyntax` and `MemberAccessExpressionSyntax`. If any unexpected expressions are entered, new cases would need to be added.

[`ExpressionSyntax.TryGetInferredMemberName()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.csharp.syntaxfacts.trygetinferredmembername?view=roslyn-dotnet#Microsoft_CodeAnalysis_CSharp_SyntaxFacts_TryGetInferredMemberName_Microsoft_CodeAnalysis_SyntaxNode_) attempts to find the name of the variable. It still works for our current use cases, also fixes #473.