### PR TITLE
More behaviour preserving suggestion

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzerFixer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzerFixer.cs
@@ -47,7 +47,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.JsonParamBinderAttribute {
 				                  .ConfigureAwait( continueOnCapturedContext: false );
 
 			AttributeSyntax newAttribute = SyntaxFactory.Attribute(
-				SyntaxFactory.IdentifierName( "JsonConvertParameterBinder" ) );
+				SyntaxFactory.IdentifierName( "StrictJsonParamBinder" ) );
 
 			SyntaxNode newRoot = root.ReplaceNode(oldAttribute, newAttribute );
 

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -192,7 +192,7 @@ namespace D2L.CodeStyle.Analyzers {
 			category: "Correctness",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
-			description: "JsonParamBinder uses the custom D2L JSON framework, so use JsonConvertParameterBinder (which uses Newtonsoft.Json) instead."
+			description: "JsonParamBinder uses the custom D2L JSON framework, so use StrictJsonParamBinder (which uses Newtonsoft.Json) instead."
 		);
 
 		public static readonly DiagnosticDescriptor ImmutableGenericAttributeInWrongAssembly = new DiagnosticDescriptor(


### PR DESCRIPTION
The current suggestion to use JsonConvertParamBinder has caused a number of our APIs to no longer match our published API contracts. StrictJsonParamBinder was created to address this issue and should be used instead of JsonConvertParamBinder in almost all cases.