### PR TITLE
Fix symbol equality comparisons

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
@@ -147,7 +147,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 				return true;
 			}
 
-			if( memberSymbol != originalDefinition ) {
+			if( !memberSymbol.Equals( originalDefinition ) ) {
 
 				if( dangerousMembers.Contains( memberSymbol ) ) {
 					return true;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistrationExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistrationExpression.cs
@@ -72,12 +72,12 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {
 			var iFactoryType = compilation.GetTypeByMetadataName( IFactoryTypeMetadataName );
 
 			var factoryInterfacesImplemented = factoryType.AllInterfaces
-				.Where( i => i.ConstructedFrom == iFactoryType );
+				.Where( i => i.ConstructedFrom.Equals( iFactoryType ) );
 
 			foreach( var iface in factoryInterfacesImplemented ) {
 				var t = iface.TypeArguments[0];
 
-				if( t == baseType ) {
+				if( t.Equals( baseType ) ) {
 					return iface;
 				}
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistry.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistry.cs
@@ -66,7 +66,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {
 		}
 
 		public bool IsRegistationMethod( IMethodSymbol method ) {
-			if( method.ContainingType != m_dependencyRegistryType && method.ReceiverType != m_dependencyRegistryType ) {
+			if( !method.ContainingType.Equals( m_dependencyRegistryType ) && !method.ReceiverType.Equals( m_dependencyRegistryType ) ) {
 				return false;
 			}
 
@@ -79,7 +79,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {
 			}
 
 			// otherwise, if it's a method on IDependencyRegistry, then yes
-			return method.ContainingType == m_dependencyRegistryType;
+			return method.ContainingType.Equals( m_dependencyRegistryType );
 		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Logging/LoggingExecutionContextScopeBuilderAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Logging/LoggingExecutionContextScopeBuilderAnalyzer.cs
@@ -195,7 +195,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Logging {
 
 			IEnumerable<AttributeData> typeAttributes = type.GetAttributes();
 			bool typeIsCustomAwaitable = typeAttributes.Any(
-				a => a.AttributeClass.OriginalDefinition == AsyncMethodBuilderAttribute
+				a => a.AttributeClass.OriginalDefinition.Equals( AsyncMethodBuilderAttribute )
 			);
 
 			if( typeIsCustomAwaitable ) {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -57,7 +57,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			bool isTheImmutableAttribute( AttributeData attr ) {
-				return attr.AttributeClass == immutableAttribute;
+				return attr.AttributeClass.Equals( immutableAttribute );
 			}
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableGenericAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableGenericAttributeAnalyzer.cs
@@ -67,13 +67,13 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			// check if the type is defined in the current assembly
-			if( typeBeingMarkedImmutable.ContainingAssembly == currentAssembly ) {
+			if( typeBeingMarkedImmutable.ContainingAssembly.Equals( currentAssembly ) ) {
 				return;
 			}
 
 			// otherwise, check if any of the type arguments are in the current assembly
 			foreach( var typeArgument in typeBeingMarkedImmutable.TypeArguments ) {
-				if( typeArgument.ContainingAssembly == currentAssembly ) {
+				if( typeArgument.ContainingAssembly.Equals( currentAssembly ) ) {
 					return;
 				}
 			}

--- a/src/D2L.CodeStyle.TestAnalyzers/NUnit/TestAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/NUnit/TestAttributeAnalyzer.cs
@@ -65,7 +65,7 @@ namespace D2L.CodeStyle.TestAnalyzers.NUnit {
 
             // We need the declaring class to be a [TestFixture] to continue
             INamedTypeSymbol declaringClass = method.ContainingType;
-            if ( !declaringClass.GetAttributes().Any( attr => attr.AttributeClass == types.TestFixtureAttribute ) ) {
+            if ( !declaringClass.GetAttributes().Any( attr => attr.AttributeClass.Equals( types.TestFixtureAttribute ) ) ) {
                 return;
             }
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/D2L.CodeStyle.TestAnalyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/D2L.CodeStyle.TestAnalyzers.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Prior to MSBuild 16.5, these symbol reference equality comparisons worked. This has been confirmed by analyzing known-broken code on Visual Studio 2019 16.4. With the update to MSBuild 16.5+, these started silently failing instead.

The 3.6.0 release of the CodeAnalysis packages includes an analyzer that catches these invalid equality checks, which was used to identify all of the broken cases.

This also updates the test projects to use the 3.6.0 release of the CodeAnalysis packages. These packages align with the Roslyn version provided with [Visual Studio 2019 and .NET Core 3.1][0].

[0]: https://github.com/dotnet/roslyn/blob/master/docs/wiki/NuGet-packages.md#versioning