### PR TITLE
Jashton/serializer attribute analyzer

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
@@ -1,0 +1,122 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using D2L.CodeStyle.Analyzers.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
+
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	internal sealed class SerializerAttributeAnalyzer : DiagnosticAnalyzer {
+
+		private static readonly SymbolDisplayFormat TypeDisplayFormat = new SymbolDisplayFormat(
+				memberOptions: SymbolDisplayMemberOptions.IncludeContainingType,
+				localOptions: SymbolDisplayLocalOptions.IncludeType,
+				typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces
+			);
+
+		private const string SerializerAttributeFullName = "D2L.LP.Serialization.SerializerAttribute";
+		private const string ITrySerializerFullName = "D2L.LP.Serialization.ITrySerializer";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+			Diagnostics.InvalidSerializerType
+		);
+
+		public override void Initialize( AnalysisContext context ) {
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction( RegisterScopeBuilderAnalyzer );
+		}
+
+		private void RegisterScopeBuilderAnalyzer( CompilationStartAnalysisContext context ) {
+
+			Compilation comp = context.Compilation;
+			if( !comp.TryGetTypeByMetadataName( SerializerAttributeFullName, out INamedTypeSymbol serializerAttributeType ) ) {
+				return;
+			}
+			if( !comp.TryGetTypeByMetadataName( ITrySerializerFullName, out INamedTypeSymbol trySerializerType ) ) {
+				return;
+			}
+
+			context.RegisterSyntaxNodeAction(
+					c => AnalyzeAttributeSyntax(
+						c,
+						(AttributeSyntax)c.Node,
+						serializerAttributeType,
+						trySerializerType
+					),
+					SyntaxKind.Attribute
+				);
+		}
+
+		private void AnalyzeAttributeSyntax(
+				SyntaxNodeAnalysisContext context,
+				AttributeSyntax attributeSyntax,
+				INamedTypeSymbol serializerAttributeType,
+				INamedTypeSymbol trySerializerType
+			) {
+
+			SemanticModel model = context.SemanticModel;
+			if( !IsAttributeOfType( model, attributeSyntax, serializerAttributeType ) ) {
+				return;
+			}
+
+
+			AttributeArgumentSyntax typeArgumentSyntax = attributeSyntax.ArgumentList.Arguments[ 0 ];
+			if( !( typeArgumentSyntax.Expression is TypeOfExpressionSyntax typeofSyntax ) ) {
+
+				ReportInvalidSerializerType(
+						context,
+						typeArgumentSyntax,
+						messageArg: typeArgumentSyntax.Expression.ToString()
+					);
+				return;
+			}
+
+			ITypeSymbol serializerType = model.GetTypeInfo( typeofSyntax.Type ).Type;
+			if( serializerType.AllInterfaces.Contains( trySerializerType ) ) {
+				return;
+			}
+			
+			ReportInvalidSerializerType(
+					context,
+					typeArgumentSyntax,
+					messageArg: serializerType.ToDisplayString( TypeDisplayFormat )
+				);
+		}
+
+		private static bool IsAttributeOfType(
+				SemanticModel model,
+				AttributeSyntax attributeSyntax,
+				INamedTypeSymbol attributeType
+			) {
+
+			TypeInfo typeInfo = model.GetTypeInfo( attributeSyntax );
+			if( !( typeInfo.Type is INamedTypeSymbol namedSymbol ) ) {
+				return false;
+			}
+
+			if( !namedSymbol.Equals( attributeType ) ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		private void ReportInvalidSerializerType(
+				SyntaxNodeAnalysisContext context,
+				AttributeArgumentSyntax typeArgumentSyntax,
+				string messageArg
+			) {
+
+			Diagnostic diagnostic = Diagnostic.Create(
+					descriptor: Diagnostics.InvalidSerializerType,
+					location: typeArgumentSyntax.GetLocation(),
+					messageArgs: messageArg
+				);
+
+			context.ReportDiagnostic( diagnostic );
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
@@ -62,7 +62,12 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 				return;
 			}
 
-			AttributeArgumentSyntax typeArgumentSyntax = attributeSyntax.ArgumentList.Arguments[ 0 ];
+			SeparatedSyntaxList<AttributeArgumentSyntax> arguments = attributeSyntax.ArgumentList.Arguments;
+			if( arguments.Count == 0 ) {
+				return;
+			}
+
+			AttributeArgumentSyntax typeArgumentSyntax = arguments[ 0 ];
 			if( !( typeArgumentSyntax.Expression is TypeOfExpressionSyntax typeofSyntax ) ) {
 
 				ReportInvalidSerializerType(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
@@ -58,7 +58,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 			) {
 
 			SemanticModel model = context.SemanticModel;
-			if( !IsAttributeOfType( model, attributeSyntax, serializerAttributeType ) ) {
+			if( !model.IsAttributeOfType( attributeSyntax, serializerAttributeType ) ) {
 				return;
 			}
 
@@ -87,30 +87,12 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 			if( serializerType.AllInterfaces.Contains( trySerializerType ) ) {
 				return;
 			}
-			
+
 			ReportInvalidSerializerType(
 					context,
 					typeArgumentSyntax,
 					messageArg: serializerType.ToDisplayString( TypeDisplayFormat )
 				);
-		}
-
-		private static bool IsAttributeOfType(
-				SemanticModel model,
-				AttributeSyntax attributeSyntax,
-				INamedTypeSymbol attributeType
-			) {
-
-			TypeInfo typeInfo = model.GetTypeInfo( attributeSyntax );
-			if( !( typeInfo.Type is INamedTypeSymbol namedSymbol ) ) {
-				return false;
-			}
-
-			if( !namedSymbol.Equals( attributeType ) ) {
-				return false;
-			}
-
-			return true;
 		}
 
 		private void ReportInvalidSerializerType(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
@@ -62,7 +62,6 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 				return;
 			}
 
-
 			AttributeArgumentSyntax typeArgumentSyntax = attributeSyntax.ArgumentList.Arguments[ 0 ];
 			if( !( typeArgumentSyntax.Expression is TypeOfExpressionSyntax typeofSyntax ) ) {
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
@@ -62,7 +62,12 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 				return;
 			}
 
-			SeparatedSyntaxList<AttributeArgumentSyntax> arguments = attributeSyntax.ArgumentList.Arguments;
+			AttributeArgumentListSyntax argumentList = attributeSyntax.ArgumentList;
+			if( argumentList == null ) {
+				return;
+			}
+
+			SeparatedSyntaxList<AttributeArgumentSyntax> arguments = argumentList.Arguments;
 			if( arguments.Count == 0 ) {
 				return;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -514,5 +514,15 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true,
 			description: "This call requires arguments be named for readability."
 		);
+
+		public static readonly DiagnosticDescriptor InvalidSerializerType = new DiagnosticDescriptor(
+			id: "D2L0059",
+			title: "Serializers must implement D2L.LP.Serialization.ITrySerializer.",
+			messageFormat: "'{0}' does not implement D2L.LP.Serialization.ITrySerializer.",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "This [Serializer] attribute requires the provided type to implement D2L.LP.Serialization.ITrySerializer."
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.CSharp.Syntax.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.CSharp.Syntax.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.Extensions {
@@ -29,6 +30,26 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 						return false;
 					}
 				}
+			}
+
+			return true;
+		}
+
+		public static bool IsAttributeOfType(
+				this SemanticModel model,
+				AttributeSyntax attributeSyntax,
+				INamedTypeSymbol attributeType
+			) {
+
+			TypeInfo typeInfo = model.GetTypeInfo( attributeSyntax );
+
+			ITypeSymbol typeSymbol = typeInfo.Type;
+			if( typeSymbol == null ) {
+				return false;
+			}
+
+			if( !typeSymbol.Equals( attributeType ) ) {
+				return false;
 			}
 
 			return true;

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -270,5 +270,15 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 
 			return -1;
 		}
+
+		public static bool TryGetTypeByMetadataName(
+				this Compilation compilation,
+				string fullyQualifiedMetadataName,
+				out INamedTypeSymbol typeSymbol
+			) {
+
+			typeSymbol = compilation.GetTypeByMetadataName( fullyQualifiedMetadataName );
+			return ( typeSymbol != null );
+		}
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿// analyzer: D2L.CodeStyle.Analyzers.ApiUsage.Serialization.SerializerAttributeAnalyzer
 
 using System;
-using System.ComponentModel;
 using D2L.LP.Serialization;
 
 namespace D2L.LP.Serialization {
@@ -37,6 +36,12 @@ namespace SpecTests {
 	[Serializer()]
 	public sealed class IncompleteAttribute_WithParentheses { }
 
-	[Category( "Not related" )]
+	[System.ComponentModel.Category( "Not related" )]
 	public sealed class RandomAttribute { }
+
+	[Invalid]
+	public sealed class InvalidAttribute { }
+
+	[]
+	public sealed class JustSomeBrackets { }
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
@@ -28,6 +28,9 @@ namespace SpecTests {
 	[Serializer( /* InvalidSerializerType(null) */ null /**/ )]
 	public sealed class NullSerializerType { }
 
+	[Serializer( /* InvalidSerializerType(123) */ 123 /**/ )]
+	public sealed class InvalidSerializerTypeArgument { }
+
 	[Category( "Not related" )]
 	public sealed class RandomAttribute { }
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
@@ -31,8 +31,11 @@ namespace SpecTests {
 	[Serializer( /* InvalidSerializerType(123) */ 123 /**/ )]
 	public sealed class InvalidSerializerTypeArgument { }
 
-	[Serializer( )]
-	public sealed class IncompleteAttribute { }
+	[Serializer]
+	public sealed class IncompleteAttribute_WithoutParentheses { }
+
+	[Serializer()]
+	public sealed class IncompleteAttribute_WithParentheses { }
 
 	[Category( "Not related" )]
 	public sealed class RandomAttribute { }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
@@ -31,6 +31,9 @@ namespace SpecTests {
 	[Serializer( /* InvalidSerializerType(123) */ 123 /**/ )]
 	public sealed class InvalidSerializerTypeArgument { }
 
+	[Serializer( )]
+	public sealed class IncompleteAttribute { }
+
 	[Category( "Not related" )]
 	public sealed class RandomAttribute { }
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializerAttributeAnalyzer.cs
@@ -1,0 +1,33 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.ApiUsage.Serialization.SerializerAttributeAnalyzer
+
+using System;
+using System.ComponentModel;
+using D2L.LP.Serialization;
+
+namespace D2L.LP.Serialization {
+	public sealed class SerializerAttribute : Attribute {
+		public SerializableAttribute( Type type ) { }
+	}
+	public interface ITrySerializer { }
+}
+
+namespace SpecTests {
+
+	[Serializer( typeof( Nested.Serializer ) )]
+	public sealed class Nested {
+		private sealed class Serializer : ITrySerializer { }
+	}
+
+	[Serializer( typeof( ExternalSerializer ) )]
+	public sealed class External { }
+	public sealed class ExternalSerializer : ITrySerializer { }
+
+	[Serializer( /* InvalidSerializerType(System.String) */ typeof( string ) /**/ )]
+	public sealed class InvalidSerializerType { }
+
+	[Serializer( /* InvalidSerializerType(null) */ null /**/ )]
+	public sealed class NullSerializerType { }
+
+	[Category( "Not related" )]
+	public sealed class RandomAttribute { }
+}


### PR DESCRIPTION
Makes sure that `ExternalSerializer` : `ITrySerializer`

```
	[Serializer( typeof( ExternalSerializer ) )]
	public sealed class External { }
	public sealed class ExternalSerializer : ITrySerializer { }
```