### PR TITLE
support value tuples in ImmutabilityContext

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -185,7 +185,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			if( type.IsTupleType ) {
 				info = ImmutableTypeInfo.CreateWithAllImmutableTypeParameters(
 					kind: ImmutableTypeKind.Total,
-					type: type
+					type: type.OriginalDefinition
 				);
 				return true;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -182,6 +182,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return true;
 			}
 
+			if( type.IsTupleType ) {
+				info = ImmutableTypeInfo.CreateWithAllImmutableTypeParameters(
+					kind: ImmutableTypeKind.Total,
+					type: type
+				);
+				return true;
+			}
+
 			// Check if we were otherwise told that this type is immutable
 			return m_extraImmutableTypes.TryGetValue( type, out info );
 		}


### PR DESCRIPTION
It's impractical and/or impossible (I forget which) to refer to value tuples by name and thus they wouldn't do well as an "extra type" style thing.

Add specific logic, filling them in as "all types must be immutable"