### PR TITLE
allow leading spaces in spec expectations

### DIFF
--- a/tests/D2L.CodeStyle.Analyzers.Test/SpecRunner.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/SpecRunner.cs
@@ -313,9 +313,21 @@ namespace D2L.CodeStyle.Analyzers {
 					str.Length - 2 - indexOfOpenParen
 				);
 
+				string RemoveSingleLeadingSpace( string s ) {
+					if (string.IsNullOrEmpty(s)) {
+						return s;
+					}
+
+					if (s[0] == ' ') {
+						return s.Substring( 1 );
+					}
+
+					return s;
+				}
+
 				return new DiagnosticExpectation(
 					name: name,
-					arguments: arguments.Split( ',' ).Select( arg => arg.Trim() ).ToImmutableArray()
+					arguments: arguments.Split( ',' ).Select( RemoveSingleLeadingSpace ).ToImmutableArray()
 				);
 			}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ReadOnlyParameterAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ReadOnlyParameterAnalyzerSpec.cs
@@ -32,24 +32,24 @@ namespace SpecTests {
 			return foo;
 		}
 
-		void WrittenToInBody( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnly] int foo /**/ ) {
+		void WrittenToInBody( /* ReadOnlyParameterIsnt(is assigned to and/or passed by reference) */ [ReadOnly] int foo /**/ ) {
 			foo = 1;
 		}
 
-		void WrittenToInInlineFunc( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnly] int foo /**/ ) {
+		void WrittenToInInlineFunc( /* ReadOnlyParameterIsnt(is assigned to and/or passed by reference) */ [ReadOnly] int foo /**/ ) {
 			void Helper() { foo = 1; }
 		}
 
-		void WrittenToInLambda( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnly] int foo /**/ ) {
+		void WrittenToInLambda( /* ReadOnlyParameterIsnt(is assigned to and/or passed by reference) */ [ReadOnly] int foo /**/ ) {
 			() => { foo = 1; };
 		}
 
-		void PassedToRef( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnly] int foo /**/ ) {
+		void PassedToRef( /* ReadOnlyParameterIsnt(is assigned to and/or passed by reference) */ [ReadOnly] int foo /**/ ) {
 			RefParameter( ref foo );
 		}
 
-		void RefParameter( /* ReadOnlyParameterIsnt( is an in/ref/out parameter ) */ [ReadOnly] ref int foo /**/ ) { }
-		void InParameter( /* ReadOnlyParameterIsnt( is an in/ref/out parameter ) */ [ReadOnly] in int foo /**/ ) { }
+		void RefParameter( /* ReadOnlyParameterIsnt(is an in/ref/out parameter) */ [ReadOnly] ref int foo /**/ ) { }
+		void InParameter( /* ReadOnlyParameterIsnt(is an in/ref/out parameter) */ [ReadOnly] in int foo /**/ ) { }
 
 		internal class C {
 			C( [ReadOnly] int foo ) { }
@@ -84,24 +84,24 @@ namespace SpecTests {
 			return foo;
 		}
 
-		void WrittenToInBody( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnlySubclass] int foo /**/ ) {
+		void WrittenToInBody( /* ReadOnlyParameterIsnt(is assigned to and/or passed by reference) */ [ReadOnlySubclass] int foo /**/ ) {
 			foo = 1;
 		}
 
-		void WrittenToInInlineFunc( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnlySubclass] int foo /**/ ) {
+		void WrittenToInInlineFunc( /* ReadOnlyParameterIsnt(is assigned to and/or passed by reference) */ [ReadOnlySubclass] int foo /**/ ) {
 			void Helper() { foo = 1; }
 		}
 
-		void WrittenToInLambda( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnlySubclass] int foo /**/ ) {
+		void WrittenToInLambda( /* ReadOnlyParameterIsnt(is assigned to and/or passed by reference) */ [ReadOnlySubclass] int foo /**/ ) {
 			() => { foo = 1; };
 		}
 
-		void PassedToRef( /* ReadOnlyParameterIsnt( is assigned to and/or passed by reference ) */ [ReadOnlySubclass] int foo /**/ ) {
+		void PassedToRef( /* ReadOnlyParameterIsnt(is assigned to and/or passed by reference) */ [ReadOnlySubclass] int foo /**/ ) {
 			RefParameter( ref foo );
 		}
 
-		void RefParameter( /* ReadOnlyParameterIsnt( is an in/ref/out parameter ) */ [ReadOnlySubclass] ref int foo /**/ ) { }
-		void InParameter( /* ReadOnlyParameterIsnt( is an in/ref/out parameter ) */ [ReadOnlySubclass] in int foo /**/ ) { }
+		void RefParameter( /* ReadOnlyParameterIsnt(is an in/ref/out parameter) */ [ReadOnlySubclass] ref int foo /**/ ) { }
+		void InParameter( /* ReadOnlyParameterIsnt(is an in/ref/out parameter) */ [ReadOnlySubclass] in int foo /**/ ) { }
 
 		internal class C {
 			C( [ReadOnlySubclass] int foo ) { }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/StatelessFuncAnalyzerSpec.cs
@@ -49,8 +49,8 @@ namespace SpecTests {
 
 		public void ParenWithClosures() {
 			int zero = 0;
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
-			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt( Captured variable(s): zero ) */ () => zero /**/ );
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt(Captured variable(s): zero) */ () => zero /**/ );
+			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt(Captured variable(s): zero) */ () => zero /**/ );
 		}
 
 		public void SimpleNoClosures() {
@@ -60,8 +60,8 @@ namespace SpecTests {
 
 		public void SimpleWithClosures() {
 			string trailing = "\n";
-			var func = new StatelessFunc<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
-			AttributeFuncReceiver.Accept<string, string>( /* StatelessFuncIsnt( Captured variable(s): trailing ) */ x => x + trailing /**/ );
+			var func = new StatelessFunc<string, string>( /* StatelessFuncIsnt(Captured variable(s): trailing) */ x => x + trailing /**/ );
+			AttributeFuncReceiver.Accept<string, string>( /* StatelessFuncIsnt(Captured variable(s): trailing) */ x => x + trailing /**/ );
 		}
 
 		public void DelegateNoClosures() {
@@ -71,13 +71,13 @@ namespace SpecTests {
 
 		public void DelegateWithClosures() {
 			string trailing = "\n";
-			var func = new StatelessFunc<string, string>(  /* StatelessFuncIsnt( Captured variable(s): trailing ) */ delegate ( string x ) { return x + trailing; } /**/ );
-			AttributeFuncReceiver.Accept<string, string>(  /* StatelessFuncIsnt( Captured variable(s): trailing ) */ delegate ( string x ) { return x + trailing; } /**/ );
+			var func = new StatelessFunc<string, string>(  /* StatelessFuncIsnt(Captured variable(s): trailing) */ delegate ( string x ) { return x + trailing; } /**/ );
+			AttributeFuncReceiver.Accept<string, string>(  /* StatelessFuncIsnt(Captured variable(s): trailing) */ delegate ( string x ) { return x + trailing; } /**/ );
 		}
 
 		public void NonStaticMember() {
-			var func = new StatelessFunc<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
-			AttributeFuncReceiver.Accept<string>( /* StatelessFuncIsnt( this.ToString is not static ) */ this.ToString /**/ );
+			var func = new StatelessFunc<string>( /* StatelessFuncIsnt(this.ToString is not static) */ this.ToString /**/ );
+			AttributeFuncReceiver.Accept<string>( /* StatelessFuncIsnt(this.ToString is not static) */ this.ToString /**/ );
 		}
 
 		public void StaticMember() {
@@ -102,13 +102,13 @@ namespace SpecTests {
 
 		public void MultiLineWithThisCapture() {
 			var func = new StatelessFunc<string>(
-				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
+				/* StatelessFuncIsnt(Captured variable(s): this) */ () => {
 					string trailing = "\n";
 					return this.ToString() + trailing;
 				} /**/
 			);
 			AttributeFuncReceiver.Accept<string>(
-				/* StatelessFuncIsnt( Captured variable(s): this ) */ () => {
+				/* StatelessFuncIsnt(Captured variable(s): this) */ () => {
 					string trailing = "\n";
 					return this.ToString() + trailing;
 				} /**/
@@ -128,8 +128,8 @@ namespace SpecTests {
 				};
 			};
 
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
-			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt( Invocations are not allowed: evil() ) */ evil() /**/ );
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt(Invocations are not allowed: evil()) */ evil() /**/ );
+			AttributeFuncReceiver.Accept<int>( /* StatelessFuncIsnt(Invocations are not allowed: evil()) */ evil() /**/ );
 		}
 
 		public void StatelessFunc() {
@@ -157,19 +157,19 @@ namespace SpecTests {
 		public void FuncFromVar() {
 			Func<int> f = () => 0;
 
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Unable to determine if f is stateless. ) */ f /**/ );
-			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt( Unable to determine if f is stateless. ) */ f /**/ );
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt(Unable to determine if f is stateless.) */ f /**/ );
+			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt(Unable to determine if f is stateless.) */ f /**/ );
 		}
 
 		public void FuncFromParam( Func<int> f ) {
-			var func = new StatelessFunc<int>( /* StatelessFuncIsnt( Unable to determine if f is stateless. ) */ f /**/ );
-			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt( Unable to determine if f is stateless. ) */ f /**/ );
+			var func = new StatelessFunc<int>( /* StatelessFuncIsnt(Unable to determine if f is stateless.) */ f /**/ );
+			AttributeFuncReceiver.Accept( /* StatelessFuncIsnt(Unable to determine if f is stateless.) */ f /**/ );
 		}
 
 		internal sealed class AnotherConstructor {
 
 			public AnotherConstructor( int i )
-				: this( /* StatelessFuncIsnt( Captured variable(s): i ) */ () => ++i /**/ ) { }
+				: this( /* StatelessFuncIsnt(Captured variable(s): i) */ () => ++i /**/ ) { }
 
 			public AnotherConstructor()
 				: this( DoStuff ) { }
@@ -187,7 +187,7 @@ namespace SpecTests {
 			internal sealed class SubClass : BaseClass {
 
 				public SubClass( int i )
-					: base( /* StatelessFuncIsnt( Captured variable(s): i ) */ () => ++i /**/ ) { }
+					: base( /* StatelessFuncIsnt(Captured variable(s): i) */ () => ++i /**/ ) { }
 
 			}
 		}


### PR DESCRIPTION
Allows expecting a message arg like ` foo` (foo with a leading space), by an expectation of `Diagnostic(  foo)`.