### PR TITLE
place the diagnostic on the member type if both member and initialize…

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -209,7 +209,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				if( !m_context.IsImmutable( typeToCheck, checkKind, diagnosticLocation, out var diagnostic ) ) {
 					immutable = false;
 
-					// depending on the situation, it may be preferable to place a diagnostic on the held member type instead
+					// if the initializer _and_ the member type aren't immutable, prefer the diagnostic on the member type
 					if( !m_context.IsImmutable( type, ImmutableTypeKind.Instance, typeSyntax.GetLocation(), out _ ) ) {
 						// This returning false is implied by not being Instance immutable
 						// Running this is mostly just a hack to get a diagnostic without the " (or [ImmutableBaseClass])" though


### PR DESCRIPTION
…r arent immutable

This is pretty roundabout... 😞 

```csharp
sealed class SomeClass {}

[Immutable]
sealed class AnalyzedClass {
  readonly SomeClass m_foo = new SomeClass();
}
```

Current behaviour:
```
readonly SomeClass m_foo = new SomeClass();
                               ~~~~~~~~~
// The Class SomeClass is missing the [Immutable] (or [ImmutableBaseClass]) attribute, so it isn't safe to be held by an immutable type
```

New behaviour:
```
readonly SomeClass m_foo = new SomeClass();
         ~~~~~~~~~
// The Class SomeClass is missing the [Immutable] attribute, so it isn't safe to be held by an immutable type
```

This is maybe pretty preferential though, so I could ignore it for the sake of the less complicated code.