### PR TITLE
defer computing location of immutable type diagnostics

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -58,7 +58,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		public bool IsImmutable(
 			ITypeSymbol type,
 			ImmutableTypeKind kind,
-			Location location,
+			Func<Location> locationGetter,
 			out Diagnostic diagnostic
 		) {
 			if ( kind == ImmutableTypeKind.None ) {
@@ -91,7 +91,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						return info.IsImmutableDefinition(
 							context: this,
 							definition: namedType,
-							location: location,
+							locationGetter: locationGetter,
 							out diagnostic
 						);
 					}
@@ -111,7 +111,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Array:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.ArraysAreMutable,
-						location,
+						locationGetter(),
 						( type as IArrayTypeSymbol ).ElementType.Name
 					);
 
@@ -120,7 +120,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Delegate:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.DelegateTypesPossiblyMutable,
-						location
+						locationGetter()
 					);
 
 					return false;
@@ -128,7 +128,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Dynamic:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.DynamicObjectsAreMutable,
-						location
+						locationGetter()
 					);
 
 					return false;
@@ -140,7 +140,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 					diagnostic = Diagnostic.Create(
 						Diagnostics.TypeParameterIsNotKnownToBeImmutable,
-						location,
+						locationGetter(),
 						type.Name
 					);
 
@@ -149,7 +149,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Class:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.NonImmutableTypeHeldByImmutable,
-						location,
+						locationGetter(),
 						type.TypeKind,
 						type.Name,
 						kind == ImmutableTypeKind.Instance && !type.IsSealed ? " (or [ImmutableBaseClass])" : ""
@@ -161,7 +161,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Struct:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.NonImmutableTypeHeldByImmutable,
-						location,
+						locationGetter(),
 						type.TypeKind,
 						type.Name,
 						""
@@ -173,7 +173,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				default:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.UnexpectedTypeKind,
-						location: location,
+						location: locationGetter(),
 						type.Kind
 					);
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -58,7 +58,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		public bool IsImmutable(
 			ITypeSymbol type,
 			ImmutableTypeKind kind,
-			Func<Location> locationGetter,
+			Func<Location> getLocation,
 			out Diagnostic diagnostic
 		) {
 			if ( kind == ImmutableTypeKind.None ) {
@@ -91,7 +91,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						return info.IsImmutableDefinition(
 							context: this,
 							definition: namedType,
-							locationGetter: locationGetter,
+							getLocation: getLocation,
 							out diagnostic
 						);
 					}
@@ -111,7 +111,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Array:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.ArraysAreMutable,
-						locationGetter(),
+						getLocation(),
 						( type as IArrayTypeSymbol ).ElementType.Name
 					);
 
@@ -120,7 +120,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Delegate:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.DelegateTypesPossiblyMutable,
-						locationGetter()
+						getLocation()
 					);
 
 					return false;
@@ -128,7 +128,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Dynamic:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.DynamicObjectsAreMutable,
-						locationGetter()
+						getLocation()
 					);
 
 					return false;
@@ -140,7 +140,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 					diagnostic = Diagnostic.Create(
 						Diagnostics.TypeParameterIsNotKnownToBeImmutable,
-						locationGetter(),
+						getLocation(),
 						type.Name
 					);
 
@@ -149,7 +149,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Class:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.NonImmutableTypeHeldByImmutable,
-						locationGetter(),
+						getLocation(),
 						type.TypeKind,
 						type.Name,
 						kind == ImmutableTypeKind.Instance && !type.IsSealed ? " (or [ImmutableBaseClass])" : ""
@@ -161,7 +161,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				case TypeKind.Struct:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.NonImmutableTypeHeldByImmutable,
-						locationGetter(),
+						getLocation(),
 						type.TypeKind,
 						type.Name,
 						""
@@ -173,7 +173,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				default:
 					diagnostic = Diagnostic.Create(
 						Diagnostics.UnexpectedTypeKind,
-						location: locationGetter(),
+						location: getLocation(),
 						type.Kind
 					);
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -194,9 +194,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return immutable;
 			}
 
-			var (typeToCheck, checkKind, diagnosticLocationGetter) = stuff.Value;
+			var (typeToCheck, checkKind, getLocation) = stuff.Value;
 
-			if( !m_context.IsImmutable( typeToCheck, checkKind, diagnosticLocationGetter, out var diagnostic ) ) {
+			if( !m_context.IsImmutable( typeToCheck, checkKind, getLocation, out var diagnostic ) ) {
 				diagnosticSink( diagnostic );
 				immutable = false;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeInfo.cs
@@ -30,7 +30,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		public bool IsImmutableDefinition(
 			ImmutabilityContext context,
 			INamedTypeSymbol definition,
-			Func<Location> locationGetter,
+			Func<Location> getLocation,
 			out Diagnostic diagnostic
 		) {
 			if( !Type.Equals( definition ) && !Type.Equals( definition?.OriginalDefinition ) ) {
@@ -45,7 +45,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					continue;
 				}
 
-				if( !context.IsImmutable( argument, ImmutableTypeKind.Total, locationGetter, out diagnostic ) ) {
+				if( !context.IsImmutable( argument, ImmutableTypeKind.Total, getLocation, out diagnostic ) ) {
 					return false;
 				}
 			}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeInfo.cs
@@ -30,7 +30,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		public bool IsImmutableDefinition(
 			ImmutabilityContext context,
 			INamedTypeSymbol definition,
-			Location location,
+			Func<Location> locationGetter,
 			out Diagnostic diagnostic
 		) {
 			if( !Type.Equals( definition ) && !Type.Equals( definition?.OriginalDefinition ) ) {
@@ -45,7 +45,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					continue;
 				}
 
-				if( !context.IsImmutable( argument, ImmutableTypeKind.Total, location, out diagnostic ) ) {
+				if( !context.IsImmutable( argument, ImmutableTypeKind.Total, locationGetter, out diagnostic ) ) {
 					return false;
 				}
 			}


### PR DESCRIPTION
avoid paying for GetLocationOfBaseClass

| Function Name | Time, ms | Avg Time, ms | Own Time, ms | Calls |
| --- | --- | --- | --- | --- |
| D2L.CodeStyle.Analyzers.Immutability.ImmutableDefinitionChecker.GetLocationOfBaseClass(ITypeSymbol) | 226 | 21 | 8 | 11 |

(dotTrace when running current spec tests)