### PR TITLE
refactor ImmutabilityContext.Create

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
@@ -118,18 +118,13 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		private static ImmutableDictionary<string, IAssemblySymbol> GetCompilationAssemblies( Compilation compilation ) {
 			var builder = ImmutableDictionary.CreateBuilder<string, IAssemblySymbol>();
 
-			builder.Add( compilation.Assembly.Name, compilation.Assembly );
+			IAssemblySymbol compilationAssmebly = compilation.Assembly;
 
-			foreach( MetadataReference reference in compilation.References ) {
-				switch( compilation.GetAssemblyOrModuleSymbol( reference ) ) {
-					case IAssemblySymbol assembly:
-						builder.Add( assembly.Name, assembly );
-						break;
-					case IModuleSymbol module:
-						builder.Add( module.ContainingAssembly.Name, module.ContainingAssembly );
-						break;
-					case null:
-						break;
+			builder.Add( compilationAssmebly.Name, compilationAssmebly );
+
+			foreach( IModuleSymbol module in compilationAssmebly.Modules ) {
+				foreach( IAssemblySymbol assembly in module.ReferencedAssemblySymbols ) {
+					builder.Add( assembly.Name, assembly );
 				}
 			}
 


### PR DESCRIPTION
After doing some reading on GitHub I found there's another API `ReferencedAssemblySymbols` that "stays in symbol land" instead of going to reference information (filepaths). Seems like this is Roslyn team's preferred approach, although certainly seemed harder to discover.