### PR TITLE
Add System.IO.Abstractions.FileSystem as an [Immutable] type

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
@@ -80,7 +80,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			("log4net.ILog", default),
 			("Newtonsoft.Json.JsonSerializer", "Newtonsoft.Json"),
 			("Newtonsoft.Json.JsonConverter", "Newtonsoft.Json"),
-			("System.IO.Abstractions.IFileSystem", default)
+			("System.IO.Abstractions.IFileSystem", default),
+			("System.IO.Abstractions.FileSystem", default)
 		);
 
 		internal static ImmutabilityContext Create( Compilation compilation ) {


### PR DESCRIPTION
`System.IO.Abstractions.IFileSystem` is already in the list, and `FileSystem : IFileSystem` in that same DLL.

Previously we'd look at `FileSystem` and look at each of its interfaces, but now we don't "recurse" like that, so we need to explicitly add this.

The LMS is relying on this in DI.

Not my favourite entries in this list :o