### PR TITLE
Require [Immutable] for records that extend [Immutable] records

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -47,7 +47,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				ctx => AnalyzeTypeDeclaration( ctx, hasTheImmutableAttribute ),
 				SyntaxKind.ClassDeclaration,
 				SyntaxKind.StructDeclaration,
-				SyntaxKind.InterfaceDeclaration
+				SyntaxKind.InterfaceDeclaration,
+				SyntaxKind.RecordDeclaration
 			);
 
 			// helper methods:

--- a/tests/D2L.CodeStyle.Analyzers.Test/SpecRunner.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/SpecRunner.cs
@@ -416,7 +416,7 @@ namespace D2L.CodeStyle.Analyzers {
 				.ParseOptions as CSharpParseOptions;
 
 			parseOptions = parseOptions
-				.WithLanguageVersion( LanguageVersion.CSharp7_3 );
+				.WithLanguageVersion( LanguageVersion.CSharp9 );
 
 			solution = solution
 				.WithProjectCompilationOptions( projectId, compilationOptions )

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -84,4 +84,20 @@ namespace Tests {
 
 	// This shouldn't crash the analyzer
 	public sealed class Foo : IThingThatDoesntExist { }
+
+	[Immutable]
+	public record UnsealedImmutableRecord { }
+
+	public sealed record
+		/* MissingTransitiveImmutableAttribute(Tests.DerivedRecordMissingAttribute, base class, Tests.UnsealedImmutableRecord) */ DerivedRecordMissingAttribute /**/
+		: UnsealedImmutableRecord { }
+
+	[Immutable]
+	public sealed record SealedDerivedWithAttribute : UnsealedImmutableRecord { }
+
+	[Immutable]
+	public record UnsealedDerivedWithAttribute : UnsealedImmutableRecord { }
+
+	public record RegularRecord { }
+	public sealed RegularDerivedRecord : RegularRecord { }
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ExplicitImmutableAttributeTransitivityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ExplicitImmutableAttributeTransitivityAnalyzer.cs
@@ -100,4 +100,20 @@ namespace Tests {
 
 	public record RegularRecord { }
 	public sealed RegularDerivedRecord : RegularRecord { }
+
+	public record ConciseRecord : UnsealedImmutableRecord;
+
+	[Immutable]
+	public record BaseRecordWithArgs(int x ) {}
+
+	[Immutable]
+	public record ImmutableDerivedWithArgs(int y) : BaseRecordWithArgs(y);
+
+	public sealed record
+		/* MissingTransitiveImmutableAttribute(DerivedRecordNoAttrConstArg, base class, BaseRecordWithArgs) */ DerivedRecordNoAttrConstArg /**/
+		: BaseRecordWithArgs(0);
+
+	public sealed record
+		/* MissingTransitiveImmutableAttribute(DerivedRecordNoAttrWithArg, base class, BaseRecordWithArgs) */ DerivedRecordNoAttrWithArg /**/
+		(int z) : BaseRecordWithArgs(z);
 }


### PR DESCRIPTION
Easy case; checking [Immutable] is currently broken though.

Part of #644