### PR TITLE
add [ConditionallyImmutable] and [ConditionallyImmutable.OnlyIf]

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Attributes.cs
+++ b/src/D2L.CodeStyle.Analyzers/Attributes.cs
@@ -15,6 +15,8 @@ namespace D2L.CodeStyle.Analyzers {
 		internal static class Objects {
 			internal static readonly RoslynAttribute Immutable = new RoslynAttribute( "D2L.CodeStyle.Annotations.Objects.Immutable" );
 			internal static readonly RoslynAttribute ImmutableBaseClass = new RoslynAttribute( "D2L.CodeStyle.Annotations.Objects.ImmutableBaseClassAttribute" );
+			internal static readonly RoslynAttribute ConditionallyImmutable = new RoslynAttribute( "D2L.CodeStyle.Annotations.Objects.ConditionallyImmutable" );
+			internal static readonly RoslynAttribute OnlyIf = new RoslynAttribute( "D2L.CodeStyle.Annotations.Objects.ConditionallyImmutable.OnlyIf" );
 		}
 		internal static class Mutability {
 			internal static readonly RoslynAttribute Audited = new RoslynAttribute( "D2L.CodeStyle.Annotations.Mutability.AuditedAttribute" );

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -227,7 +227,7 @@ namespace D2L.CodeStyle.Analyzers {
 		public static readonly DiagnosticDescriptor MissingTransitiveImmutableAttribute = new DiagnosticDescriptor(
 			id: "D2L0040",
 			title: "Missing an explicit transitive [Immutable] attribute",
-			messageFormat: "{0} should be [Immutable] because the {1} {2} is.",
+			messageFormat: "{0} should be [Immutable]{1} because the {2} {3} is.",
 			category: "",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true,

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
@@ -107,7 +107,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					continue;
 				}
 
-				ImmutableTypeInfo info = ImmutableTypeInfo.CreateWithAllImmutableTypeParameters(
+				ImmutableTypeInfo info = ImmutableTypeInfo.CreateWithAllConditionalTypeParameters(
 					ImmutableTypeKind.Total,
 					type
 				);

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -196,7 +196,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			if( type.IsTupleType ) {
-				info = ImmutableTypeInfo.CreateWithAllImmutableTypeParameters(
+				info = ImmutableTypeInfo.CreateWithAllConditionalTypeParameters(
 					kind: ImmutableTypeKind.Total,
 					type: type.OriginalDefinition
 				);
@@ -211,6 +211,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			ITypeSymbol type
 		) {
 			if ( Attributes.Objects.Immutable.IsDefined( type ) ) {
+				return ImmutableTypeKind.Total;
+			}
+
+			if( Attributes.Objects.ConditionallyImmutable.IsDefined( type ) ) {
 				return ImmutableTypeKind.Total;
 			}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeInfo.cs
@@ -10,17 +10,17 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 	internal readonly struct ImmutableTypeInfo {
 
 		// a mapping of which type parameters considered necessarily immutable for the
-		// type to be immutable
-		private readonly ImmutableArray<bool> m_immutableTypeParameters;
+		// conditionally immutable type to be immutable
+		private readonly ImmutableArray<bool> m_conditionalTypeParameters;
 
 		private ImmutableTypeInfo(
 			ImmutableTypeKind kind,
 			INamedTypeSymbol type,
-			ImmutableArray<bool> immutableTypeParameters
+			ImmutableArray<bool> conditionalTypeParameters
 		) {
 			Kind = kind;
 			Type = type;
-			m_immutableTypeParameters = immutableTypeParameters;
+			m_conditionalTypeParameters = conditionalTypeParameters;
 		}
 
 		public ImmutableTypeKind Kind { get; }
@@ -41,7 +41,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 			var argRelevance = definition
 				.TypeArguments
-				.Zip( m_immutableTypeParameters, ( a, relevant ) => (a, relevant) );
+				.Zip( m_conditionalTypeParameters, ( a, relevant ) => (a, relevant) );
 			foreach( (ITypeSymbol argument, bool isRelevant) in argRelevance ) {
 				if( !isRelevant ) {
 					continue;
@@ -62,17 +62,17 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		) {
 			ImmutableArray<bool> immutableTypeParameters = type
 				.TypeParameters
-				.Select( p => Attributes.Objects.Immutable.IsDefined( p ) )
+				.Select( p => Attributes.Objects.OnlyIf.IsDefined( p ) )
 				.ToImmutableArray();
 
 			return new ImmutableTypeInfo(
 				kind: kind,
 				type: type,
-				immutableTypeParameters: immutableTypeParameters
+				conditionalTypeParameters: immutableTypeParameters
 			);
 		}
 
-		public static ImmutableTypeInfo CreateWithAllImmutableTypeParameters(
+		public static ImmutableTypeInfo CreateWithAllConditionalTypeParameters(
 			ImmutableTypeKind kind,
 			INamedTypeSymbol type
 		) {
@@ -84,7 +84,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			return new ImmutableTypeInfo(
 				kind: kind,
 				type: type,
-				immutableTypeParameters: immutableTypeParameters
+				conditionalTypeParameters: immutableTypeParameters
 			);
 		}
 	}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/TypeDeclarationImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/TypeDeclarationImmutabilityAnalyzer.cs
@@ -110,6 +110,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			if( !Attributes.Objects.Immutable.IsDefined( typeSymbol )
+				&& !Attributes.Objects.ConditionallyImmutable.IsDefined( typeSymbol )
 				&& !Attributes.Objects.ImmutableBaseClass.IsDefined( typeSymbol )
 			) {
 				return;

--- a/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
@@ -26,8 +26,25 @@ namespace D2L.CodeStyle.Annotations {
 		/// but other mutable classes may sub-class it.
 		/// It is always safe to add this annotation because an analyzer will check
 		/// that it is valid.
-		/// </summary>
 		[AttributeUsage( validOn: AttributeTargets.Class )]
 		public sealed class ImmutableBaseClassAttribute : ImmutableAttributeBase { }
+
+		/// <summary>
+		/// If a class, struct or interface is marked with this annotation it
+		/// means that it's type is immutable if all type arguments marked with [OnlyIf]
+		/// are themselves immutable.
+		/// </summary>
+		[AttributeUsage(
+			validOn: AttributeTargets.Class
+			       | AttributeTargets.Interface
+			       | AttributeTargets.Struct
+		)]
+		public sealed class ConditionallyImmutable : ImmutableAttributeBase {
+
+			[AttributeUsage( validOn: AttributeTargets.GenericParameter )]
+			public sealed class OnlyIf : ImmutableAttributeBase { }
+
+		}
+
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/TypeDeclarationImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/TypeDeclarationImmutabilityAnalyzer.cs
@@ -10,6 +10,9 @@ namespace D2L.CodeStyle.Annotations {
 		public abstract class ImmutableAttributeBase : Attribute {}
 		public sealed class Immutable : ImmutableAttributeBase { }
 		public sealed class ImmutableBaseClassAttribute : ImmutableAttributeBase { }
+		public sealed class ConditionallyImmutable : ImmutableAttributeBase {
+			public sealed class OnlyIf : ImmutableAttributeBase { }
+		}
 	}
 	public static class Mutability {
 		public sealed class AuditedAttribute : Attribute { }
@@ -38,8 +41,7 @@ namespace D2L.CodeStyle.Annotations {
 
 namespace SpecTests {
 
-	using static Immutable = Objects.Immutable;
-	using static ImmutableBaseClass = Objects.ImmutableBaseClassAttribute;
+	using static Objects;
 
 	public sealed class Types {
 
@@ -89,19 +91,28 @@ namespace SpecTests {
 		[Immutable]
 		public interface SomeImmutableGenericInterface<T, U> { }
 
-		[Immutable]
-		public interface SomeImmutableGenericInterfaceGivenT<[Immutable] T, U> { }
+		[ConditionallyImmutable]
+		public interface SomeImmutableGenericInterfaceGivenT<[ConditionallyImmutable.OnlyIf] T, U> { }
+
+		[ConditionallyImmutable]
+		public interface SomeImmutableGenericInterfaceGivenU<T, [ConditionallyImmutable.OnlyIf] U> { }
+
+		[ConditionallyImmutable]
+		public interface SomeImmutableGenericInterfaceGivenTU<[ConditionallyImmutable.OnlyIf] T, [ConditionallyImmutable.OnlyIf] U> { }
 
 		[Immutable]
-		public interface SomeImmutableGenericInterfaceGivenU<T, [Immutable] U> { }
+		public interface SomeImmutableGenericInterfaceRestrictingT<[Immutable] T, U> { }
 
 		[Immutable]
-		public interface SomeImmutableGenericInterfaceGivenTU<[Immutable] T, [Immutable] U> { }
+		public interface SomeImmutableGenericInterfaceRestrictingU<T, [Immutable] U> { }
+
+		[Immutable]
+		public interface SomeImmutableGenericInterfaceRestrictingTU<[Immutable] T, [Immutable] U> { }
 
 		public static void SomeGenericMethod<T, U>() { }
-		public static void SomeGenericMethodGivenT<[Immutable] T, U>() { }
-		public static void SomeGenericMethodGivenU<T, [Immutable] U>() { }
-		public static void SomeGenericMethodGivenTU<[Immutable] T, [Immutable] U>() { }
+		public static void SomeGenericMethodRestrictingT<[Immutable] T, U>() { }
+		public static void SomeGenericMethodRestrictingU<T, [Immutable] U>() { }
+		public static void SomeGenericMethodRestrictingTU<[Immutable] T, [Immutable] U>() { }
 
 }
 
@@ -432,12 +443,12 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ Property { get; }
-		Types.SomeImmutableGenericInterfaceGivenT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> Property { get { return default; } }
+		static /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ Property { get; }
+		Types.SomeImmutableGenericInterfaceGivenT<object, int> Property { get { return default; } }
 
 
 		static Types.SomeImmutableGenericInterfaceGivenU<object, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
@@ -449,12 +460,12 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ Property { get; }
-		Types.SomeImmutableGenericInterfaceGivenU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> Property { get { return default; } }
+		static /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ Property { get; }
+		Types.SomeImmutableGenericInterfaceGivenU<int, object> Property { get { return default; } }
 
 
 
@@ -467,48 +478,109 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /**/ Property { get; }
-		Types.SomeImmutableGenericInterfaceGivenTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> Property { get { return default; } }
+		static /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ Property { get; }
+		Types.SomeImmutableGenericInterfaceGivenTU<int, object> Property { get { return default; } }
 
 
-		static /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /**/ Property { get; }
-		Types.SomeImmutableGenericInterfaceGivenTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> Property { get { return default; } }
+		static /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(Class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ Property { get; }
+		Types.SomeImmutableGenericInterfaceGivenTU<object, int> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingT<int, object> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingT<int, object> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT<int, object> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingT<int, object> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT<int, object> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingT<int, object> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> Property { get { return default; } }
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingU<object, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingU<object, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<object, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingU<object, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<object, int> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingU<object, int> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingTU<int, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU<int, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingTU<int, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, int> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, int> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/> Property { get { return default; } }
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int>/* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int>m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(Class, Object, ) */ object /**/, int> Property { get { return default; } }
 	}
 
 	[Immutable]
-	public sealed class AnalyzedImmutableGenericClassGivenT<[Immutable] T, U> {
+	public sealed class AnalyzedImmutableGenericClassRestrictingT<[Immutable] T, U> {
 
 
 
-		static T /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		static T /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		static readonly T m_field;
-		T /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		T /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		readonly T m_field;
 		T Property { get; }
 		T Property { get { return default; } }
 
 
 
-		static T /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/ = new T();
+		static T /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/ = new T();
 		static readonly T m_field = new T();
-		T /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/ = new T();
+		T /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/ = new T();
 		readonly T m_field = new T();
 		T Property { get; } = new T()
 		T Property { get { return new T(); } }
 
 
 
-		static /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		static /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
 		U m_field;
 		[Mutability.Audited]
@@ -527,9 +599,9 @@ namespace SpecTests {
 
 
 
-		static U /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/ = /* TypeParameterIsNotKnownToBeImmutable(U) */ new U() /**/;
+		static U /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/ = /* TypeParameterIsNotKnownToBeImmutable(U) */ new U() /**/;
 		static readonly U m_field = /* TypeParameterIsNotKnownToBeImmutable(U) */ new U() /**/;
-		U /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/ = /* TypeParameterIsNotKnownToBeImmutable(U) */ new U() /**/;
+		U /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/ = /* TypeParameterIsNotKnownToBeImmutable(U) */ new U() /**/;
 		[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
 		U m_field = new U();
 		[Mutability.Audited]
@@ -547,64 +619,125 @@ namespace SpecTests {
 
 
 
-		static Types.SomeImmutableGenericInterfaceGivenT<T, U> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		static Types.SomeImmutableGenericInterfaceGivenT<T, U> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		static readonly Types.SomeImmutableGenericInterfaceGivenT<T, U> m_field;
-		Types.SomeImmutableGenericInterfaceGivenT<T, U> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		Types.SomeImmutableGenericInterfaceGivenT<T, U> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		readonly Types.SomeImmutableGenericInterfaceGivenT<T, U> m_field;
 		Types.SomeImmutableGenericInterfaceGivenT<T, U> Property { get; }
 		Types.SomeImmutableGenericInterfaceGivenT<T, U> Property { get { return default; } }
 
 
 
-		static /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
-		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
-		readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ Property { get; }
-		Types.SomeImmutableGenericInterfaceGivenT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get { return default; } }
+		static /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT<U, T> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT<U, T> /**/ m_field;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT<U, T> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT<U, T> /**/ m_field;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenT<U, T> /**/ Property { get; }
+		Types.SomeImmutableGenericInterfaceGivenT<U, T> Property { get { return default; } }
 
 
-		static Types.SomeImmutableGenericInterfaceGivenU<U, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		static Types.SomeImmutableGenericInterfaceGivenU<U, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		static readonly Types.SomeImmutableGenericInterfaceGivenU<U, T> m_field;
-		Types.SomeImmutableGenericInterfaceGivenU<U, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		Types.SomeImmutableGenericInterfaceGivenU<U, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		readonly Types.SomeImmutableGenericInterfaceGivenU<U, T> m_field;
 		Types.SomeImmutableGenericInterfaceGivenU<U, T> Property { get; }
 		Types.SomeImmutableGenericInterfaceGivenU<U, T> Property { get { return default; } }
 
 
 
-		static /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
-		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
-		readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ Property { get; }
-		Types.SomeImmutableGenericInterfaceGivenU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> Property { get { return default; } }
+		static /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, U> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, U> /**/ m_field;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, U> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, U> /**/ m_field;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenU<T, U> /**/ Property { get; }
+		Types.SomeImmutableGenericInterfaceGivenU<T, U> Property { get { return default; } }
 
 
 
-		static Types.SomeImmutableGenericInterfaceGivenTU<T, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		static Types.SomeImmutableGenericInterfaceGivenTU<T, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		static readonly Types.SomeImmutableGenericInterfaceGivenTU<T, T> m_field;
-		Types.SomeImmutableGenericInterfaceGivenTU<T, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
+		Types.SomeImmutableGenericInterfaceGivenTU<T, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
 		readonly Types.SomeImmutableGenericInterfaceGivenTU<T, T> m_field;
 		Types.SomeImmutableGenericInterfaceGivenTU<T, T> Property { get; }
 		Types.SomeImmutableGenericInterfaceGivenTU<T, T> Property { get { return default; } }
 
 
 
-		static /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
-		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
-		readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /**/ Property { get; }
-		Types.SomeImmutableGenericInterfaceGivenTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> Property { get { return default; } }
+		static /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, U> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, U> /**/ m_field;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, U> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, U> /**/ m_field;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<T, U> /**/ Property { get; }
+		Types.SomeImmutableGenericInterfaceGivenTU<T, U> Property { get { return default; } }
 
 
-		static /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
-		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassGivenT) */ m_field /**/;
-		readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ m_field;
-		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /**/ Property { get; }
-		Types.SomeImmutableGenericInterfaceGivenTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get { return default; } }
+		static /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<U, T> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<U, T> /**/ m_field;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<U, T> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly /* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<U, T> /**/ m_field;
+		/* TypeParameterIsNotKnownToBeImmutable(U) */ Types.SomeImmutableGenericInterfaceGivenTU<U, T> /**/ Property { get; }
+		Types.SomeImmutableGenericInterfaceGivenTU<U, T> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingT<T, U> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingT<T, U> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT<T, U> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingT<T, U> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT<T, U> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingT<T, U> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T>/* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get { return default; } }
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingU<U, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingU<U, T> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<U, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingU<U, T> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<U, T> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingU<U, T> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingTU<T, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU<T, T> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<T, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingTU<T, T> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<T, T> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingTU<T, T> Property { get { return default; } }
+
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/> Property { get { return default; } }
+
+
+		static Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> /* MemberIsNotReadOnly(Field, m_field, AnalyzedImmutableGenericClassRestrictingT) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get { return default; } }
 
 
 		void Method() {
@@ -612,18 +745,18 @@ namespace SpecTests {
 			Types.SomeGenericMethod<U, T>();
 			Types.SomeGenericMethod<T, T>();
 			Types.SomeGenericMethod<U, U>();
-			Types.SomeGenericMethodGivenT<T, U>();
-			Types.SomeGenericMethodGivenT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T>();
-			Types.SomeGenericMethodGivenT<T, T>();
-			Types.SomeGenericMethodGivenT </* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, U>();
-			Types.SomeGenericMethodGivenU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
-			Types.SomeGenericMethodGivenU<U, T>();
-			Types.SomeGenericMethodGivenU<T, T>();
-			Types.SomeGenericMethodGivenU<U, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
-			Types.SomeGenericMethodGivenTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
-			Types.SomeGenericMethodGivenTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T>();
-			Types.SomeGenericMethodGivenTU<T, T>();
-			Types.SomeGenericMethodGivenTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
+			Types.SomeGenericMethodRestrictingT<T, U>();
+			Types.SomeGenericMethodRestrictingT</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T>();
+			Types.SomeGenericMethodRestrictingT<T, T>();
+			Types.SomeGenericMethodRestrictingT </* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, U>();
+			Types.SomeGenericMethodRestrictingU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
+			Types.SomeGenericMethodRestrictingU<U, T>();
+			Types.SomeGenericMethodRestrictingU<T, T>();
+			Types.SomeGenericMethodRestrictingU<U, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
+			Types.SomeGenericMethodRestrictingTU<T, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
+			Types.SomeGenericMethodRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T>();
+			Types.SomeGenericMethodRestrictingTU<T, T>();
+			Types.SomeGenericMethodRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
 		}
 	}
 


### PR DESCRIPTION
Some follow-ups to do:
* Require [CondtionallyImmutable] types have [ConditionallyImmutable.OnlyIf] usage
* Require [ConditionallyImmutable.OnlyIf] is only used on parameters of a [ConditionallyImmutable] type
* Have codefix suggest [CondtionallyImmutable]
* Require [OnlyIf] parameters are used in base type definitions (analyzer I was working on previously when we decided we needed to split things)
* Don't allow `[ConditionallyImmutable]` and `[Immutable]` on the same type