### PR TITLE
Add diagnostic to block use of [OnlyIf] in method declarations #663

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -528,7 +528,7 @@ namespace D2L.CodeStyle.Analyzers {
 
 		public static readonly DiagnosticDescriptor UnexpectedConditionalImmutability = new DiagnosticDescriptor(
 			id: "D2L0071",
-			title: "The [ConditionallyImmutable.OnlyIf] attribute cannot be applied to this member.",
+			title: "The [ConditionallyImmutable.OnlyIf] attribute cannot be used with methods.",
 			messageFormat: "The [ConditionallyImmutable.OnlyIf] attribute is only valid on parameters of named types.",
 			category: "Immutability",
 			defaultSeverity: DiagnosticSeverity.Error,

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -525,5 +525,14 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
+
+		public static readonly DiagnosticDescriptor UnexpectedConditionalImmutability = new DiagnosticDescriptor(
+			id: "D2L0071",
+			title: "The [ConditionallyImmutable.OnlyIf] attribute cannot be applied to this member.",
+			messageFormat: "The [ConditionallyImmutable.OnlyIf] attribute is only valid on parameters of named types.",
+			category: "Immutability",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -181,8 +181,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		}
 
 		private static void AnalyzeConditionalImmutability( SyntaxNodeAnalysisContext ctx ) {
-			var syntax = ctx.Node;
-
 			// Get the symbol for the method
 			if( ctx.SemanticModel.GetDeclaredSymbol( ctx.Node ) is not IMethodSymbol symbol ) {
 				return;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -61,10 +61,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			context.RegisterSyntaxNodeAction(
-				ctx => AnalyzeConditionalImmutability(
-					ctx,
-					ctx.Node
-				),
+				AnalyzeConditionalImmutability,
 				SyntaxKind.MethodDeclaration,
 				SyntaxKind.LocalFunctionStatement
 			);
@@ -183,32 +180,22 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 		}
 
-		private static void AnalyzeConditionalImmutability(
-			SyntaxNodeAnalysisContext ctx,
-			SyntaxNode syntax
-		) {
-			// Ignore references in DocComments such as crefs
-			if( syntax.IsFromDocComment() ) {
-				return;
-			}
+		private static void AnalyzeConditionalImmutability( SyntaxNodeAnalysisContext ctx ) {
+			var syntax = ctx.Node;
 
-			// Methods can be either of the following depending on where they are declared
-			MethodDeclarationSyntax methodSyntax = null;
-			LocalFunctionStatementSyntax functionSyntax = null;
-
+			// Retrieve the relevant parameter list
+			TypeParameterListSyntax paramListSyntax;
 			switch( syntax ) {
 				case MethodDeclarationSyntax:
-					methodSyntax = (MethodDeclarationSyntax)syntax;
+					paramListSyntax = ( (MethodDeclarationSyntax)syntax ).TypeParameterList;
 					break;
 				case LocalFunctionStatementSyntax:
-					functionSyntax = (LocalFunctionStatementSyntax)syntax;
+					paramListSyntax = ( (LocalFunctionStatementSyntax)syntax ).TypeParameterList;
 					break;
 				default:
 					return;
 			}
 
-			// Get the parameter list syntax and make sure it is not null
-			TypeParameterListSyntax paramListSyntax = methodSyntax?.TypeParameterList ?? functionSyntax?.TypeParameterList;
 			if( paramListSyntax == null ) {
 				return;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -188,29 +188,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return;
 			}
 
-			// Exit if this somehow is not possible
 			// We don't care about arguments so throw them out
-			if( !GetTypeParamsAndArgs( symbol, out var typeParameters, out _ ) ) {
-				return;
-			}
+			GetTypeParamsAndArgs( symbol, out var typeParameters, out _ );
 
-			// Retrieve the relevant parameter list
-			TypeParameterListSyntax paramListSyntax;
-			switch( syntax ) {
-				case MethodDeclarationSyntax:
-					paramListSyntax = ( (MethodDeclarationSyntax)syntax ).TypeParameterList;
-					break;
-				case LocalFunctionStatementSyntax:
-					paramListSyntax = ( (LocalFunctionStatementSyntax)syntax ).TypeParameterList;
-					break;
-				default:
-					return;
-			}
-
-			// Iterate through the parameter symbols
-			for( int i = 0; i < typeParameters.Length; i++ ) {
-				var parameter = typeParameters[i];
-
+			foreach( var parameter in typeParameters ) {
 				// Check if the parameter has the [OnlyIf] attribute
 				if( !Attributes.Objects.OnlyIf.IsDefined( parameter ) ) {
 					continue;
@@ -219,7 +200,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				// Create the diagnostic on the parameter (including the attribute)
 				var diagnostic = Diagnostic.Create(
 					Diagnostics.UnexpectedConditionalImmutability,
-					paramListSyntax.Parameters[i].GetLocation() );
+					parameter.DeclaringSyntaxReferences[0].GetSyntax().GetLocation() );
 				ctx.ReportDiagnostic( diagnostic );
 			}
 		}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -61,7 +61,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			context.RegisterSyntaxNodeAction(
-				AnalyzeConditionalImmutability,
+				AnalyzeConditionalImmutabilityOnMethodDeclarations,
 				SyntaxKind.MethodDeclaration,
 				SyntaxKind.LocalFunctionStatement
 			);
@@ -180,7 +180,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 		}
 
-		private static void AnalyzeConditionalImmutability( SyntaxNodeAnalysisContext ctx ) {
+		private static void AnalyzeConditionalImmutabilityOnMethodDeclarations( SyntaxNodeAnalysisContext ctx ) {
 			// Get the symbol for the method
 			if( ctx.SemanticModel.GetDeclaredSymbol( ctx.Node ) is not IMethodSymbol symbol ) {
 				return;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -188,10 +188,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return;
 			}
 
-			// We don't care about arguments so throw them out
-			GetTypeParamsAndArgs( symbol, out var typeParameters, out _ );
-
-			foreach( var parameter in typeParameters ) {
+			foreach( var parameter in symbol.TypeParameters ) {
 				// Check if the parameter has the [OnlyIf] attribute
 				if( !Attributes.Objects.OnlyIf.IsDefined( parameter ) ) {
 					continue;

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -956,18 +956,18 @@ namespace SpecTests {
 		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, /* TypeParameterIsNotKnownToBeImmutable(T) */ T /**/> Property { get { return default; } }
 
 		// These are MethodDeclarationSyntax
-		void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T>() { }
-		void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T, U>() { }
-		void SomeGenericMethodConditionallyRestrictingU<T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ U>() { }
-		void SomeGenericMethodConditionallyRestrictingTU</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ U>() { }
+		void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] T /**/>() { }
+		void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] T /**/, U>() { }
+		void SomeGenericMethodConditionallyRestrictingU<T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] U /**/>() { }
+		void SomeGenericMethodConditionallyRestrictingTU</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] T /**/, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] U /**/>() { }
 
 		void Method()
 		{
 			// These are LocalFunctionStatementSyntax
-			void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T>() { }
-			void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T, U>() { }
-			void SomeGenericMethodConditionallyRestrictingU<T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ U>() { }
-			void SomeGenericMethodConditionallyRestrictingTU</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ U>() { }
+			void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] T /**/>() { }
+			void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] T /**/, U>() { }
+			void SomeGenericMethodConditionallyRestrictingU<T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] U /**/>() { }
+			void SomeGenericMethodConditionallyRestrictingTU</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] T /**/, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] U /**/>() { }
 			Types.SomeGenericMethod<T, U>();
 			Types.SomeGenericMethod<U, T>();
 			Types.SomeGenericMethod<T, T>();

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -955,8 +955,19 @@ namespace SpecTests {
 		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, /* TypeParameterIsNotKnownToBeImmutable(T) */ T /**/> Property { get; }
 		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, /* TypeParameterIsNotKnownToBeImmutable(T) */ T /**/> Property { get { return default; } }
 
+		// These are MethodDeclarationSyntax
+		void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T>() { }
+		void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T, U>() { }
+		void SomeGenericMethodConditionallyRestrictingU<T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ U>() { }
+		void SomeGenericMethodConditionallyRestrictingTU</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ U>() { }
 
-		void Method() {
+		void Method()
+		{
+			// These are LocalFunctionStatementSyntax
+			void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T>() { }
+			void SomeGenericMethodConditionallyRestrictingT</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T, U>() { }
+			void SomeGenericMethodConditionallyRestrictingU<T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ U>() { }
+			void SomeGenericMethodConditionallyRestrictingTU</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] /**/ U>() { }
 			Types.SomeGenericMethod<T, U>();
 			Types.SomeGenericMethod<U, T>();
 			Types.SomeGenericMethod<T, T>();


### PR DESCRIPTION
- Added syntax checking for MethodDeclaration and LocalFunctionStatement
  - Checks if any type parameters have the [ConditionallyImmutable.OnlyIf] attribute
- Added supporting tests

Closes https://github.com/Brightspace/D2L.CodeStyle/issues/663