### PR TITLE
Add diagnostic for audit attribute conflicts #661

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -537,17 +537,17 @@ namespace D2L.CodeStyle.Analyzers {
 
 		public static readonly DiagnosticDescriptor ConflictingImmutability = new DiagnosticDescriptor(
 			id: "D2L0072",
-			title: "The [Immutable] and [ConditionallyImmutable.OnlyIf] attributes are mutually exclusive.",
-			messageFormat: "The [Immutable] and [ConditionallyImmutable.OnlyIf] attributes cannot be used on the same parameter.",
+			title: "Conflicting immutability attributes.",
+			messageFormat: "The [{0}] and [{1}] attributes cannot be used on the same {2}.",
 			category: "Immutability",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
 
-		public static readonly DiagnosticDescriptor ConflictingAuditing = new DiagnosticDescriptor(
+		public static readonly DiagnosticDescriptor InvalidAuditType = new DiagnosticDescriptor(
 			id: "D2L0073",
-			title: "The [Audited] and [Unaudited] attributes are mutually exclusive.",
-			messageFormat: "The [Audited] and [Unaudited] attributes cannot be used on the same property.",
+			title: "Wrong type of auditing was used.",
+			messageFormat: "A {0} {1} should audit using the [{2}] attributes.",
 			category: "Immutability",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -543,5 +543,14 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
+
+		public static readonly DiagnosticDescriptor ConflictingAuditing = new DiagnosticDescriptor(
+			id: "D2L0073",
+			title: "The [Audited] and [Unaudited] attributes are mutually exclusive.",
+			messageFormat: "The [Audited] and [Unaudited] attributes cannot be used on the same property.",
+			category: "Immutability",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -547,7 +547,7 @@ namespace D2L.CodeStyle.Analyzers {
 		public static readonly DiagnosticDescriptor InvalidAuditType = new DiagnosticDescriptor(
 			id: "D2L0073",
 			title: "Wrong type of auditing was used.",
-			messageFormat: "A {0} {1} should audit using the [{2}] attributes.",
+			messageFormat: "A {0} {1} should be audited using the [{2}] attributes.",
 			category: "Immutability",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -23,7 +23,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			Diagnostics.UnnecessaryMutabilityAnnotation,
 			Diagnostics.UnexpectedConditionalImmutability,
 			Diagnostics.ConflictingImmutability,
-			Diagnostics.ConflictingAuditing
+			Diagnostics.InvalidAuditType
 		);
 
 		public override void Initialize( AnalysisContext context ) {
@@ -221,7 +221,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// Create the diagnostic on the parameter (excluding the attribute)
 			var diagnostic = Diagnostic.Create(
 				Diagnostics.ConflictingImmutability,
-				symbol.DeclaringSyntaxReferences[0].GetSyntax().GetLastToken().GetLocation() );
+				symbol.DeclaringSyntaxReferences[0].GetSyntax().GetLastToken().GetLocation(),
+				"Immutable",
+				"ConditionallyImmutable.OnlyIf",
+				symbol.Kind.ToString().ToLower() );
 			ctx.ReportDiagnostic( diagnostic );
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -52,13 +52,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				SymbolKind.Property
 			);
 
-			context.RegisterSymbolAction(
-				AnalyzeConflictingAuditingOnProperties,
-				SymbolKind.Field,
-				SymbolKind.Property,
-				SymbolKind.Event
-			);
-
 			context.RegisterSyntaxNodeAction(
 				ctx => AnalyzeTypeArguments(
 					ctx,
@@ -228,23 +221,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// Create the diagnostic on the parameter (excluding the attribute)
 			var diagnostic = Diagnostic.Create(
 				Diagnostics.ConflictingImmutability,
-				symbol.DeclaringSyntaxReferences[0].GetSyntax().GetLastToken().GetLocation() );
-			ctx.ReportDiagnostic( diagnostic );
-		}
-
-		private static void AnalyzeConflictingAuditingOnProperties( SymbolAnalysisContext ctx ) {
-			// Get the symbol for the parameter
-			var symbol = ctx.Symbol;
-
-			// Check if the parameter has both the [Audited] and the [Unaudited] attributes of either type
-			if( !( Attributes.Mutability.Audited.IsDefined( symbol ) && Attributes.Mutability.Unaudited.IsDefined( symbol ) )
-				&& !( Attributes.Statics.Audited.IsDefined( symbol ) && Attributes.Statics.Unaudited.IsDefined( symbol ) ) ) {
-				return;
-			}
-
-			// Create the diagnostic on the property
-			var diagnostic = Diagnostic.Create(
-				Diagnostics.ConflictingAuditing,
 				symbol.DeclaringSyntaxReferences[0].GetSyntax().GetLastToken().GetLocation() );
 			ctx.ReportDiagnostic( diagnostic );
 		}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -70,7 +70,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		/// values.
 		/// </remarks>
 		public bool CheckMember( ISymbol member ) {
-			if ( MutabilityAuditor.IsAudited( member, out var location ) ) {
+			if ( MutabilityAuditor.IsAudited( member, out var location, out var diagnostic ) ) {
+
+				// If they have one of the auditing attributes,
+				// error if a diagnostic occurred
+				if( diagnostic is not null ) {
+					m_diagnosticSink( diagnostic );
+				}
+
 				// If they have one of the auditing attributes, run the
 				// checks anyway and error if they are unnecessary
 				if( CheckMember( diagnosticSink: _ => { }, member ) ) {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -70,13 +70,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		/// values.
 		/// </remarks>
 		public bool CheckMember( ISymbol member ) {
-			if ( MutabilityAuditor.IsAudited( member, out var location, out var diagnostic ) ) {
-
-				// If they have one of the auditing attributes,
-				// error if a diagnostic occurred
-				if( diagnostic is not null ) {
-					m_diagnosticSink( diagnostic );
-				}
+			if( MutabilityAuditor.CheckAudited(
+				member,
+				m_diagnosticSink,
+				out var location ) ) {
 
 				// If they have one of the auditing attributes, run the
 				// checks anyway and error if they are unnecessary

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityAuditor.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityAuditor.cs
@@ -1,33 +1,94 @@
 ﻿using System.Linq;
 using Microsoft.CodeAnalysis;
+using static D2L.CodeStyle.Analyzers.Immutability.ImmutableDefinitionChecker;
 
 namespace D2L.CodeStyle.Analyzers.Immutability {
 	internal sealed class MutabilityAuditor {
-		public static bool IsAudited( ISymbol symbol, out Location location, out Diagnostic diagnostic ) {
-			AttributeData attr;
-			diagnostic = null;
+		public static bool CheckAudited(
+			ISymbol symbol,
+			DiagnosticSink diagnosticSink,
+			out Location location ) {
 
-			// Check if there is a conflicting audit AND unaudit
-			if( ( Attributes.Statics.Audited.IsDefined( symbol ) || Attributes.Mutability.Audited.IsDefined( symbol ) )
-				&& ( Attributes.Statics.Unaudited.IsDefined( symbol ) || Attributes.Mutability.Unaudited.IsDefined( symbol ) ) ) {
-				diagnostic = Diagnostic.Create(
-					Diagnostics.ConflictingAuditing,
-					symbol.DeclaringSyntaxReferences[0].GetSyntax().GetLastToken().GetLocation() );
+			// Collect audit information
+			var hasStaticAudited = Attributes.Statics.Audited.IsDefined( symbol );
+			var hasStaticUnaudited = Attributes.Statics.Unaudited.IsDefined( symbol );
+			var hasMutabilityAudited = Attributes.Mutability.Audited.IsDefined( symbol );
+			var hasMutabilityUnaudited = Attributes.Mutability.Unaudited.IsDefined( symbol );
+			var hasBothStaticsAttributes = hasStaticAudited && hasStaticUnaudited;
+			var hasBothMutabilityAttributes = hasMutabilityAudited && hasMutabilityUnaudited;
+			var hasEitherStaticsAttributes = hasStaticAudited || hasStaticUnaudited;
+			var hasEitherMutabilityAttributes = hasMutabilityAudited || hasMutabilityUnaudited;
+
+			// If there are no audits, don't do anything
+			if( !hasEitherStaticsAttributes && !hasEitherMutabilityAttributes ) {
+				location = null;
+				return false;
+			}
+
+			var syntaxLocation = symbol
+				.DeclaringSyntaxReferences[0]
+				.GetSyntax()
+				.GetLastToken()
+				.GetLocation();
+
+			// Check if both static audits are applied
+			if( hasBothStaticsAttributes ) {
+				var diagnostic = Diagnostic.Create(
+					Diagnostics.ConflictingImmutability,
+					syntaxLocation,
+					"Statics.Audited",
+					"Statics.Unaudited",
+					symbol.Kind.ToString().ToLower() );
+				diagnosticSink( diagnostic );
+			}
+
+			// Check if both mutability audits are applied
+			if( hasBothMutabilityAttributes ) {
+				var diagnostic = Diagnostic.Create(
+					Diagnostics.ConflictingImmutability,
+					syntaxLocation,
+					"Mutability.Audited",
+					"Mutability.Unaudited",
+					symbol.Kind.ToString().ToLower() );
+				diagnosticSink( diagnostic );
 			}
 
 			if( symbol.IsStatic ) {
-				attr = Attributes.Statics.Audited.GetAll( symbol ).FirstOrDefault()
-					?? Attributes.Statics.Unaudited.GetAll( symbol ).FirstOrDefault();
+				// Check if a static member is using mutability audits
+				if( hasEitherMutabilityAttributes ) {
+					var diagnostic = Diagnostic.Create(
+						Diagnostics.InvalidAuditType,
+						syntaxLocation,
+						"static",
+						symbol.Kind.ToString().ToLower(),
+						"Statics.*" );
+					diagnosticSink( diagnostic );
+				}
 			} else {
-				attr = Attributes.Mutability.Audited.GetAll( symbol ).FirstOrDefault()
-					?? Attributes.Mutability.Unaudited.GetAll( symbol ).FirstOrDefault();
+				// Check if a non-static member is using static audits
+				if( hasEitherStaticsAttributes ) {
+					var diagnostic = Diagnostic.Create(
+						Diagnostics.InvalidAuditType,
+						syntaxLocation,
+						"non-static",
+						symbol.Kind.ToString().ToLower(),
+						"Mutability.*" );
+					diagnosticSink( diagnostic );
+				}
 			}
+
+			// Everything looks good, so collect information to determine if
+			// auditing is necessary
+			AttributeData attr
+				= Attributes.Statics.Audited.GetAll( symbol ).FirstOrDefault()
+				?? Attributes.Statics.Unaudited.GetAll( symbol ).FirstOrDefault()
+				?? Attributes.Mutability.Audited.GetAll( symbol ).FirstOrDefault()
+				?? Attributes.Mutability.Unaudited.GetAll( symbol ).FirstOrDefault();
 
 			if( attr != null ) {
 				location = GetLocation( attr );
 				return true;
 			}
-
 			location = null;
 			return false;
 		}

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityAuditor.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityAuditor.cs
@@ -53,6 +53,8 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				diagnosticSink( diagnostic );
 			}
 
+			AttributeData attr = null;
+
 			if( symbol.IsStatic ) {
 				// Check if a static member is using mutability audits
 				if( hasEitherMutabilityAttributes ) {
@@ -64,6 +66,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						"Statics.*" );
 					diagnosticSink( diagnostic );
 				}
+
+				attr = Attributes.Statics.Audited.GetAll( symbol ).FirstOrDefault()
+					?? Attributes.Statics.Unaudited.GetAll( symbol ).FirstOrDefault();
 			} else {
 				// Check if a non-static member is using static audits
 				if( hasEitherStaticsAttributes ) {
@@ -75,15 +80,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						"Mutability.*" );
 					diagnosticSink( diagnostic );
 				}
-			}
 
-			// Everything looks good, so collect information to determine if
-			// auditing is necessary
-			AttributeData attr
-				= Attributes.Statics.Audited.GetAll( symbol ).FirstOrDefault()
-				?? Attributes.Statics.Unaudited.GetAll( symbol ).FirstOrDefault()
-				?? Attributes.Mutability.Audited.GetAll( symbol ).FirstOrDefault()
-				?? Attributes.Mutability.Unaudited.GetAll( symbol ).FirstOrDefault();
+				attr = Attributes.Mutability.Audited.GetAll( symbol ).FirstOrDefault()
+					?? Attributes.Mutability.Unaudited.GetAll( symbol ).FirstOrDefault();
+			}
 
 			if( attr != null ) {
 				location = GetLocation( attr );

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityAuditor.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityAuditor.cs
@@ -3,15 +3,24 @@ using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers.Immutability {
 	internal sealed class MutabilityAuditor {
-		public static bool IsAudited( ISymbol symbol, out Location location ) {
+		public static bool IsAudited( ISymbol symbol, out Location location, out Diagnostic diagnostic ) {
 			AttributeData attr;
+			diagnostic = null;
+
+			// Check if there is a conflicting audit AND unaudit
+			if( ( Attributes.Statics.Audited.IsDefined( symbol ) || Attributes.Mutability.Audited.IsDefined( symbol ) )
+				&& ( Attributes.Statics.Unaudited.IsDefined( symbol ) || Attributes.Mutability.Unaudited.IsDefined( symbol ) ) ) {
+				diagnostic = Diagnostic.Create(
+					Diagnostics.ConflictingAuditing,
+					symbol.DeclaringSyntaxReferences[0].GetSyntax().GetLastToken().GetLocation() );
+			}
 
 			if( symbol.IsStatic ) {
 				attr = Attributes.Statics.Audited.GetAll( symbol ).FirstOrDefault()
-				    ?? Attributes.Statics.Unaudited.GetAll( symbol ).FirstOrDefault();
+					?? Attributes.Statics.Unaudited.GetAll( symbol ).FirstOrDefault();
 			} else {
 				attr = Attributes.Mutability.Audited.GetAll( symbol ).FirstOrDefault()
-				    ?? Attributes.Mutability.Unaudited.GetAll( symbol ).FirstOrDefault();
+					?? Attributes.Mutability.Unaudited.GetAll( symbol ).FirstOrDefault();
 			}
 
 			if( attr != null ) {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -756,13 +756,13 @@ namespace SpecTests {
 
 		[Statics.Audited("Timothy J Cowen", "2020-12-16", "This shouldn't work either...")]
 		[Statics.Unaudited(Because.ItsSketchy)]
-		readonly int /* ConflictingAuditing */ someStaticAuditedAndUnauditedInt /**/;
+		static object /* ConflictingAuditing */ someStaticAuditedAndUnauditedObject /**/;
 
 		[Statics.Audited("Timothy J Cowen", "2020-12-16", "But this should.")]
-		readonly int someStaticAuditedInt;
+		static object someStaticAuditedObject;
 
 		[Statics.Unaudited(Because.ItsSketchy)]
-		readonly int someStaticUnauditedInt;
+		static object someStaticUnauditedObject;
 
 		void Method() {
 			Types.SomeGenericMethod<T, U>();

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -744,25 +744,28 @@ namespace SpecTests {
 		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get; }
 		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get { return default; } }
 
-		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "Actually this shouldn't work...")]
+		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "Actually this shouldn't work.")]
 		[Mutability.Unaudited(Because.ItsSketchy)]
-		object /* ConflictingAuditing */ someMutabilityAuditedAndUnauditedObject /**/;
-
-		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "But this should!")]
-		object someMutabilityAuditedObject;
-
-		[Mutability.Unaudited(Because.ItsSketchy)]
-		object someMutabilityUnauditedObject;
+		object /* ConflictingImmutability(Mutability.Audited, Mutability.Unaudited, field) */ someMutabilityAuditedAndUnauditedObject /**/;
 
 		[Statics.Audited("Timothy J Cowen", "2020-12-16", "This shouldn't work either...")]
 		[Statics.Unaudited(Because.ItsSketchy)]
-		static object /* ConflictingAuditing */ someStaticAuditedAndUnauditedObject /**/;
+		static object /* ConflictingImmutability(Statics.Audited, Statics.Unaudited, field) */ someStaticsAuditedAndUnauditedObject /**/;
 
-		[Statics.Audited("Timothy J Cowen", "2020-12-16", "But this should.")]
-		static object someStaticAuditedObject;
+		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "This also shouldn't either......")]
+		static object /* InvalidAuditType(static, field, Statics.*) */ someStaticsMutabilityAuditedObject /**/;
+
+		[Statics.Audited("Timothy J Cowen", "2020-12-16", "Nothing works.........")]
+		object /* InvalidAuditType(non-static, field, Mutability.*) */ someNonstaticStaticsAuditedObject /**/;
 
 		[Statics.Unaudited(Because.ItsSketchy)]
-		static object someStaticUnauditedObject;
+		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "Seriously............?")]
+		[Mutability.Unaudited(Because.ItsSketchy)]
+		object /* InvalidAuditType(non-static, field, Mutability.*) | ConflictingImmutability(Mutability.Audited, Mutability.Unaudited, field) */ someNonstaticDoublyAuditedObject /**/;
+
+		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "I give up.")]
+		[Statics.Unaudited(Because.ItsSketchy)]
+		static object /* InvalidAuditType(static, field, Statics.*) */ someStaticSortOfDoublyAuditedObject /**/;
 
 		void Method() {
 			Types.SomeGenericMethod<T, U>();
@@ -980,7 +983,7 @@ namespace SpecTests {
 		void SomeGenericMethodConditionallyRestrictingU<T, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] U /**/>() { }
 		void SomeGenericMethodConditionallyRestrictingTU</* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] T /**/, /* UnexpectedConditionalImmutability */ [ConditionallyImmutable.OnlyIf] U /**/>() { }
 
-		void sealed class SomeGenericClassDoublyRestrictingT<[Immutable] [ConditionallyImmutable.OnlyIf] /* ConflictingImmutability */ T /**/> { }
+		void sealed class SomeGenericClassDoublyRestrictingT<[Immutable] [ConditionallyImmutable.OnlyIf] /* ConflictingImmutability(Immutable, ConditionallyImmutable.OnlyIf, typeparameter) */ T /**/> { }
 		void sealed class SomeGenericClassRestrictingT<[Immutable] T> { }
 		void sealed class SomeGenericClassConditionallyRestrictingT<[ConditionallyImmutable.OnlyIf] T> { }
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -744,6 +744,25 @@ namespace SpecTests {
 		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get; }
 		Types.SomeImmutableGenericInterfaceRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, T> Property { get { return default; } }
 
+		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "Actually this shouldn't work...")]
+		[Mutability.Unaudited(Because.ItsSketchy)]
+		object /* ConflictingAuditing */ someMutabilityAuditedAndUnauditedObject /**/;
+
+		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "But this should!")]
+		object someMutabilityAuditedObject;
+
+		[Mutability.Unaudited(Because.ItsSketchy)]
+		object someMutabilityUnauditedObject;
+
+		[Statics.Audited("Timothy J Cowen", "2020-12-16", "This shouldn't work either...")]
+		[Statics.Unaudited(Because.ItsSketchy)]
+		readonly int /* ConflictingAuditing */ someStaticAuditedAndUnauditedInt /**/;
+
+		[Statics.Audited("Timothy J Cowen", "2020-12-16", "But this should.")]
+		readonly int someStaticAuditedInt;
+
+		[Statics.Unaudited(Because.ItsSketchy)]
+		readonly int someStaticUnauditedInt;
 
 		void Method() {
 			Types.SomeGenericMethod<T, U>();

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -753,10 +753,10 @@ namespace SpecTests {
 		static object /* ConflictingImmutability(Statics.Audited, Statics.Unaudited, field) */ someStaticsAuditedAndUnauditedObject /**/;
 
 		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "This also shouldn't either......")]
-		static object /* InvalidAuditType(static, field, Statics.*) */ someStaticsMutabilityAuditedObject /**/;
+		static /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ /* InvalidAuditType(static, field, Statics.*) | MemberIsNotReadOnly(Field, someStaticsMutabilityAuditedObject, AnalyzedImmutableGenericClassRestrictingT) */ someStaticsMutabilityAuditedObject /**/;
 
 		[Statics.Audited("Timothy J Cowen", "2020-12-16", "Nothing works.........")]
-		object /* InvalidAuditType(non-static, field, Mutability.*) */ someNonstaticStaticsAuditedObject /**/;
+		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ /* InvalidAuditType(non-static, field, Mutability.*) | MemberIsNotReadOnly(Field, someNonstaticStaticsAuditedObject, AnalyzedImmutableGenericClassRestrictingT) */ someNonstaticStaticsAuditedObject /**/;
 
 		[Statics.Unaudited(Because.ItsSketchy)]
 		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "Seriously............?")]


### PR DESCRIPTION
- Added new method to analyze if fields, properties and events have both the [Audited] and [Unaudited] attributes
  - This checks against the Mutability attributes AND the static attributes at once
- Added supporting tests

Closes https://github.com/Brightspace/D2L.CodeStyle/issues/661