### PR TITLE
Make TestAttributeMissed an Error

### DIFF
--- a/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
@@ -57,7 +57,7 @@ namespace D2L.CodeStyle.TestAnalyzers.Common {
             title: "Method not labelled as [Test], [Theory], [TestCase], or [TestCaseSource]",
             messageFormat: "Method {0} is public, but does not have [Test], [Theory], [TestCase], or [TestCaseSource] attribute, add attribute or change the method visibility.",
             category: "Correctness",
-            defaultSeverity: DiagnosticSeverity.Warning,
+            defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "If a [Test], [Theory], [TestCase], or [TestCaseSource] attribute is missed the test will not be run, leading to false confidence in the code."
         );

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/NUnit/TestAttributeAnalyzerTests.cs
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/NUnit/TestAttributeAnalyzerTests.cs
@@ -230,7 +230,7 @@ namespace TestNamespace {
             DiagnosticResult result = new DiagnosticResult {
                 Id = diag.Id,
                 Message = string.Format( diag.MessageFormat.ToString(), messageArgs ),
-                Severity = DiagnosticSeverity.Warning,
+                Severity = DiagnosticSeverity.Error,
                 Locations = new[] {
                     new DiagnosticResultLocation( "Test1.cs", line, column )
                 }


### PR DESCRIPTION
We run our build with `werr`, so make Visual Studio reflect that