### PR TITLE
Require named arguments when any two arguments have interchangable types #521

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -6,7 +6,7 @@
     <Title>D2L.CodeStyle.Analyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle analyzers</Description>
-    <Version>0.147.0</Version>
+    <Version>0.148.0</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Brightspace/D2L.CodeStyle</PackageProjectUrl>
     <Authors>D2L</Authors>

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -6,7 +6,7 @@
     <Title>D2L.CodeStyle.Analyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle analyzers</Description>
-    <Version>0.148.0</Version>
+    <Version>0.149.0</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Brightspace/D2L.CodeStyle</PackageProjectUrl>
     <Authors>D2L</Authors>

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -556,7 +556,7 @@ namespace D2L.CodeStyle.Analyzers {
 		public static readonly DiagnosticDescriptor SwappableArgsShouldBeNamed = new DiagnosticDescriptor(
 			id: "D2L0075",
 			title: "Swappable arguments should be named for readability.",
-			messageFormat: "The arguments for the {0} and {1} parameters may be accidentally swapped. Use named arguments for readability.",
+			messageFormat: "The arguments for the \"{0}\" and \"{1}\" parameters may be accidentally swapped. Use named arguments for readability.",
 			category: "Readability",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true,

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -554,7 +554,7 @@ namespace D2L.CodeStyle.Analyzers {
 		);
 
 		public static readonly DiagnosticDescriptor SwappableArgsShouldBeNamed = new DiagnosticDescriptor(
-			id: "D2L0075",
+			id: "D2L0074",
 			title: "Swappable arguments should be named for readability.",
 			messageFormat: "The arguments for the \"{0}\" and \"{1}\" parameters may be accidentally swapped. Use named arguments for readability.",
 			category: "Readability",

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -483,7 +483,7 @@ namespace D2L.CodeStyle.Analyzers {
 		public static readonly DiagnosticDescriptor NonImmutableTypeHeldByImmutable = new DiagnosticDescriptor(
 			id: "D2L0066",
 			title: "Type may be mutable.",
-			messageFormat: "The {0} {1} is missing the [Immutable]{2} attribute, so it isn't safe to be held by an immutable type",
+			messageFormat: "The {0} \"{1}\" is missing the [Immutable]{2} attribute, so it isn't safe to be held by an immutable type",
 			category: "Immutability",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -553,14 +553,14 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true
 		);
 
-		public static readonly DiagnosticDescriptor ImplicitUnnamedArgs = new DiagnosticDescriptor(
-			id: "D2L0074",
-			title: "Name arguments to prevent implicit swapping.",
-			messageFormat: "Multiple arguments share the {0} data type. Use named arguments to prevent mistakes.",
+		public static readonly DiagnosticDescriptor SwappableArgsShouldBeNamed = new DiagnosticDescriptor(
+			id: "D2L0075",
+			title: "Swappable arguments should be named for readability.",
+			messageFormat: "The arguments for the {0} and {1} parameters may be accidentally swapped. Use named arguments for readability.",
 			category: "Readability",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
-			description: "When multiple arguments share a data type, they should be named so that they don't get switched accidentally."
+			description: "Swappable arguments should be named for readability."
 		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -552,5 +552,15 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
+
+		public static readonly DiagnosticDescriptor ImplicitUnnamedArgs = new DiagnosticDescriptor(
+			id: "D2L0074",
+			title: "Name arguments to prevent implicit swapping.",
+			messageFormat: "Multiple arguments share the {0} data type. Use named arguments to prevent mistakes.",
+			category: "Readability",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "When multiple arguments share a data type, they should be named so that they don't get switched accidentally."
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -168,7 +168,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					diagnostic = Diagnostic.Create(
 						Diagnostics.TypeParameterIsNotKnownToBeImmutable,
 						getLocation(),
-						type.Name
+						type.ToDisplayString()
 					);
 
 					return false;
@@ -178,7 +178,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						Diagnostics.NonImmutableTypeHeldByImmutable,
 						getLocation(),
 						type.TypeKind.ToString().ToLower(),
-						type.Name,
+						type.ToDisplayString(),
 						kind == ImmutableTypeKind.Instance && !type.IsSealed ? " (or [ImmutableBaseClass])" : ""
 					);
 
@@ -190,7 +190,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						Diagnostics.NonImmutableTypeHeldByImmutable,
 						getLocation(),
 						type.TypeKind.ToString().ToLower(),
-						type.Name,
+						type.ToDisplayString(),
 						""
 					);
 

--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -170,9 +170,12 @@ namespace D2L.CodeStyle.Analyzers.Language {
 			// If more than one argument can apply to multiple parameters,
 			// then require the arguments to be named
 			if( numOfSwappableArgs > 1 ) {
+				var fixerContext = CreateFixerContext( unnamedArgs );
+
 				ctx.ReportDiagnostic( Diagnostic.Create(
 						descriptor: Diagnostics.NamedArgumentsRequired,
-						location: ctx.Node.GetLocation() ) );
+						location: ctx.Node.GetLocation(),
+						properties: fixerContext ) );
 			}
 
 			// TODO: if there are duplicate typed args then they should be named

--- a/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
+++ b/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
@@ -6,7 +6,7 @@
     <Title>D2L.CodeStyle.TestAnalyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle test analyzers</Description>
-    <Version>0.23.0</Version>
+    <Version>0.24.0</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Brightspace/D2L.CodeStyle</PackageProjectUrl>
     <Authors>D2L</Authors>

--- a/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
+++ b/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
@@ -6,7 +6,7 @@
     <Title>D2L.CodeStyle.TestAnalyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle test analyzers</Description>
-    <Version>0.24.0</Version>
+    <Version>0.25.0</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Brightspace/D2L.CodeStyle</PackageProjectUrl>
     <Authors>D2L</Authors>

--- a/tests/D2L.CodeStyle.Analyzers.Test/SpecRunner.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/SpecRunner.cs
@@ -338,7 +338,10 @@ namespace D2L.CodeStyle.Analyzers {
 
 					yield return new DiagnosticExpectation(
 						name: name,
-						arguments: arguments.Split( ',' ).Select( RemoveSingleLeadingSpace ).ToImmutableArray()
+						arguments: Regex.Split( arguments, @"(?<!\\)," )
+							.Select( arg => arg.Replace( "\\,", "," ) )
+							.Select( RemoveSingleLeadingSpace )
+							.ToImmutableArray()
 					);
 				}
 			}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -122,10 +122,10 @@ namespace SpecTests {
 }
 
 	[Immutable]
-	public sealed class AnalyzedClassMarkedImmutableExtendingMutableClass : /* NonImmutableTypeHeldByImmutable(class, RegularClass,  (or [ImmutableBaseClass])) */ Types.RegularClass /**/ { }
+	public sealed class AnalyzedClassMarkedImmutableExtendingMutableClass : /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularClass,  (or [ImmutableBaseClass])) */ Types.RegularClass /**/ { }
 
 	[ImmutableBaseClass]
-	public sealed class AnalyzedClassMarkedImmutableBaseClassExtendingMutableClass : /* NonImmutableTypeHeldByImmutable(class, RegularClass,  (or [ImmutableBaseClass])) */ Types.RegularClass /**/ { }
+	public sealed class AnalyzedClassMarkedImmutableBaseClassExtendingMutableClass : /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularClass,  (or [ImmutableBaseClass])) */ Types.RegularClass /**/ { }
 
 	[ImmutableBaseClass]
 	public sealed class AnalyzedClassMarkedImmutableBaseClassExtendingImmutableBaseClass : Types.SomeImmutableBaseClass { }
@@ -212,7 +212,7 @@ namespace SpecTests {
 
 		// This isn't safe because init-only properties can be overwritten by
 		// any caller (which we may not be able to analyze).
-		public /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ Y { get; init; } = new object();
+		public /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ Y { get; init; } = new object();
 
 		static int /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = 0;
 		static readonly int m_field = 0;
@@ -280,10 +280,10 @@ namespace SpecTests {
 
 
 
-		static readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ Property { get; }
+		static readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ Property { get; }
 
 
 		static object /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = null;
@@ -347,33 +347,33 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(class, Object, ) */ (object, int) /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ (object, int) /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ (object, int) /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ (object, int) /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ (object, int) /**/ Property { get; }
+		static /* NonImmutableTypeHeldByImmutable(class, object, ) */ (object, int) /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ (object, int) /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ (object, int) /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ (object, int) /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ (object, int) /**/ Property { get; }
 		(object, int) Property { get { return default; } }
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(class, Object, ) */ (int, object) /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ (int, object) /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ (int, object) /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly  /* NonImmutableTypeHeldByImmutable(class, Object, ) */ (int, object) /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ (int, object) /**/ Property { get; }
+		static /* NonImmutableTypeHeldByImmutable(class, object, ) */ (int, object) /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ (int, object) /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ (int, object) /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly  /* NonImmutableTypeHeldByImmutable(class, object, ) */ (int, object) /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ (int, object) /**/ Property { get; }
 		(int, object) Property { get { return default; } }
 
 
 
-		static Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
-		static readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
-		Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
-		readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
+		static Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
+		static readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
+		Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
+		readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
 		[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
 		readonly Types.RegularClass m_field = new Types.RegularClass ();
 		[Mutability.Audited]
 		readonly Types.RegularClass m_field = new Types.RegularClass();
-		Types.RegularClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
+		Types.RegularClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularClass,  (or [ImmutableBaseClass])) */ new Types.RegularClass() /**/;
 		[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
 		Types.RegularClass Property { get; } = new Types.RegularClass ();
 		[Mutability.Audited]
@@ -382,20 +382,20 @@ namespace SpecTests {
 
 
 
-		static Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
-		static readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
-		Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
-		readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
-		Types.RegularClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
+		static Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
+		static readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
+		Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
+		readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
+		Types.RegularClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularExtension,  (or [ImmutableBaseClass])) */ new Types.RegularExtension() /**/;
 		Types.RegularClass Property { get { return new Types.RegularExtension(); } }
 
 
 
-		static Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
-		static readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
-		Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
-		readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
-		Types.RegularClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
+		static Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
+		static readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
+		Types.RegularClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
+		readonly Types.RegularClass m_field = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
+		Types.RegularClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.RegularSealedExtension, ) */ new Types.RegularSealedExtension() /**/;
 		Types.RegularClass Property { get { return new Types.RegularSealedExtension(); } }
 
 
@@ -406,14 +406,14 @@ namespace SpecTests {
 
 
 
-		readonly Types.SomeImmutableBaseClass m_field = /* NonImmutableTypeHeldByImmutable(class, SomeImmutableBaseClass, ) */ Types.FuncReturningSomeImmutableBaseClass() /**/;
-		Types.SomeImmutableBaseClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, SomeImmutableBaseClass, ) */ Types.FuncReturningSomeImmutableBaseClass() /**/;
+		readonly Types.SomeImmutableBaseClass m_field = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.SomeImmutableBaseClass, ) */ Types.FuncReturningSomeImmutableBaseClass() /**/;
+		Types.SomeImmutableBaseClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.SomeImmutableBaseClass, ) */ Types.FuncReturningSomeImmutableBaseClass() /**/;
 
 
 
-		Types.SomeImmutableBaseClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, MutableExtensionOfSomeImmutableBaseClass, ) */ new Types.MutableExtensionOfSomeImmutableBaseClass() /**/;
-		readonly Types.SomeImmutableBaseClass m_field = /* NonImmutableTypeHeldByImmutable(class, MutableExtensionOfSomeImmutableBaseClass, ) */ new Types.MutableExtensionOfSomeImmutableBaseClass() /**/;
-		Types.SomeImmutableBaseClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, MutableExtensionOfSomeImmutableBaseClass, ) */ new Types.MutableExtensionOfSomeImmutableBaseClass() /**/;
+		Types.SomeImmutableBaseClass /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.MutableExtensionOfSomeImmutableBaseClass, ) */ new Types.MutableExtensionOfSomeImmutableBaseClass() /**/;
+		readonly Types.SomeImmutableBaseClass m_field = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.MutableExtensionOfSomeImmutableBaseClass, ) */ new Types.MutableExtensionOfSomeImmutableBaseClass() /**/;
+		Types.SomeImmutableBaseClass Property { get; } = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.MutableExtensionOfSomeImmutableBaseClass, ) */ new Types.MutableExtensionOfSomeImmutableBaseClass() /**/;
 
 
 
@@ -428,15 +428,15 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(interface, RegularInterface, ) */ Types.RegularInterface /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(interface, RegularInterface, ) */ Types.RegularInterface /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(interface, RegularInterface, ) */ Types.RegularInterface /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(interface, RegularInterface, ) */ Types.RegularInterface /**/ m_field;
+		static /* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.RegularInterface, ) */ Types.RegularInterface /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.RegularInterface, ) */ Types.RegularInterface /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.RegularInterface, ) */ Types.RegularInterface /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.RegularInterface, ) */ Types.RegularInterface /**/ m_field;
 		[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
 		readonly Types.RegularInterface m_field;
 		[Mutability.Audited]
 		readonly Types.RegularInterface m_field;
-		/* NonImmutableTypeHeldByImmutable(interface, RegularInterface, ) */ Types.RegularInterface /**/ Property { get; }
+		/* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.RegularInterface, ) */ Types.RegularInterface /**/ Property { get; }
 		[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
 		Types.RegularInterface Property { get; }
 		[Mutability.Audited]
@@ -460,18 +460,18 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(structure, SomeStruct, ) */ Types.SomeStruct /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(structure, SomeStruct, ) */ Types.SomeStruct /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(structure, SomeStruct, ) */ Types.SomeStruct /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		Types.SomeStruct /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(structure, SomeStruct, ) */ new Types.SomeStruct() /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(structure, SomeStruct, ) */ Types.SomeStruct /**/ m_field;
-		readonly Types.SomeStruct  m_field = /* NonImmutableTypeHeldByImmutable(structure, SomeStruct, ) */ new Types.SomeStruct() /**/;
+		static /* NonImmutableTypeHeldByImmutable(structure, SpecTests.Types.SomeStruct, ) */ Types.SomeStruct /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(structure, SpecTests.Types.SomeStruct, ) */ Types.SomeStruct /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(structure, SpecTests.Types.SomeStruct, ) */ Types.SomeStruct /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		Types.SomeStruct /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/ = /* NonImmutableTypeHeldByImmutable(structure, SpecTests.Types.SomeStruct, ) */ new Types.SomeStruct() /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(structure, SpecTests.Types.SomeStruct, ) */ Types.SomeStruct /**/ m_field;
+		readonly Types.SomeStruct  m_field = /* NonImmutableTypeHeldByImmutable(structure, SpecTests.Types.SomeStruct, ) */ new Types.SomeStruct() /**/;
 		[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
 		readonly Types.SomeStruct m_field;
 		[Mutability.Audited]
 		readonly Types.SomeStruct m_field;
-		/* NonImmutableTypeHeldByImmutable(structure, SomeStruct, ) */ Types.SomeStruct /**/ Property { get; }
-		Types.SomeStruct Property { get; } = /* NonImmutableTypeHeldByImmutable(structure, SomeStruct, ) */ new Types.SomeStruct() /**/;
+		/* NonImmutableTypeHeldByImmutable(structure, SpecTests.Types.SomeStruct, ) */ Types.SomeStruct /**/ Property { get; }
+		Types.SomeStruct Property { get; } = /* NonImmutableTypeHeldByImmutable(structure, SpecTests.Types.SomeStruct, ) */ new Types.SomeStruct() /**/;
 		[Mutability.Unaudited( Because.ItHasntBeenLookedAt )]
 		Types.SomeStruct Property { get; }
 		[Mutability.Audited]
@@ -487,11 +487,11 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(interface, SomeGenericInterface, ) */ Types.SomeGenericInterface<int, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(interface, SomeGenericInterface, ) */ Types.SomeGenericInterface<int, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(interface, SomeGenericInterface, ) */ Types.SomeGenericInterface<int, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(interface, SomeGenericInterface, ) */ Types.SomeGenericInterface<int, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(interface, SomeGenericInterface, ) */ Types.SomeGenericInterface<int, int> /**/ Property { get; }
+		static /* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.SomeGenericInterface<int\, int>, ) */ Types.SomeGenericInterface<int, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.SomeGenericInterface<int\, int>, ) */ Types.SomeGenericInterface<int, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.SomeGenericInterface<int\, int>, ) */ Types.SomeGenericInterface<int, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.SomeGenericInterface<int\, int>, ) */ Types.SomeGenericInterface<int, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(interface, SpecTests.Types.SomeGenericInterface<int\, int>, ) */ Types.SomeGenericInterface<int, int> /**/ Property { get; }
 		Types.SomeGenericInterface<int, int> Property { get { return default; } }
 
 
@@ -505,11 +505,11 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ Property { get; }
+		static /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenT<object, int> /**/ Property { get; }
 		Types.SomeImmutableGenericInterfaceGivenT<object, int> Property { get { return default; } }
 
 
@@ -522,11 +522,11 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ Property { get; }
+		static /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenU<int, object> /**/ Property { get; }
 		Types.SomeImmutableGenericInterfaceGivenU<int, object> Property { get { return default; } }
 
 
@@ -540,19 +540,19 @@ namespace SpecTests {
 
 
 
-		static /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ Property { get; }
+		static /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<int, object> /**/ Property { get; }
 		Types.SomeImmutableGenericInterfaceGivenTU<int, object> Property { get { return default; } }
 
 
-		static /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly /* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ m_field;
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ Property { get; }
+		static /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly /* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ m_field;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ Types.SomeImmutableGenericInterfaceGivenTU<object, int> /**/ Property { get; }
 		Types.SomeImmutableGenericInterfaceGivenTU<object, int> Property { get { return default; } }
 
 
@@ -566,12 +566,12 @@ namespace SpecTests {
 
 
 
-		static Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> m_field;
-		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> m_field;
-		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> Property { get; }
-		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> Property { get { return default; } }
+		static Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingT</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> Property { get { return default; } }
 
 
 		static Types.SomeImmutableGenericInterfaceRestrictingU<object, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
@@ -583,12 +583,12 @@ namespace SpecTests {
 
 
 
-		static Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> m_field;
-		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> m_field;
-		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> Property { get; }
-		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> Property { get { return default; } }
+		static Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> Property { get { return default; } }
 
 
 
@@ -601,20 +601,20 @@ namespace SpecTests {
 
 
 
-		static Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> m_field;
-		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> m_field;
-		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> Property { get; }
-		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/> Property { get { return default; } }
+		static Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingTU<int, /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/> Property { get { return default; } }
 
 
-		static Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> m_field;
-		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int>/* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
-		readonly Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int>m_field;
-		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> Property { get; }
-		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/, int> Property { get { return default; } }
+		static Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> /* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		static readonly Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int>/* MemberIsNotReadOnly(Field, m_field, AnalyzedClassMarkedImmutable) */ m_field /**/;
+		readonly Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int>m_field;
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> Property { get; }
+		Types.SomeImmutableGenericInterfaceRestrictingTU</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/, int> Property { get { return default; } }
 	}
 
 	[Immutable]
@@ -810,10 +810,10 @@ namespace SpecTests {
 		static object /* ConflictingImmutability(Statics.Audited, Statics.Unaudited, field) */ someStaticsAuditedAndUnauditedObject /**/;
 
 		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "This also shouldn't either......")]
-		static /* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ /* InvalidAuditType(static, field, Statics.*) | MemberIsNotReadOnly(Field, someStaticsMutabilityAuditedObject, AnalyzedImmutableGenericClassRestrictingT) */ someStaticsMutabilityAuditedObject /**/;
+		static /* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ /* InvalidAuditType(static, field, Statics.*) | MemberIsNotReadOnly(Field, someStaticsMutabilityAuditedObject, AnalyzedImmutableGenericClassRestrictingT) */ someStaticsMutabilityAuditedObject /**/;
 
 		[Statics.Audited("Timothy J Cowen", "2020-12-16", "Nothing works.........")]
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ /* InvalidAuditType(non-static, field, Mutability.*) | MemberIsNotReadOnly(Field, someNonstaticStaticsAuditedObject, AnalyzedImmutableGenericClassRestrictingT) */ someNonstaticStaticsAuditedObject /**/;
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ /* InvalidAuditType(non-static, field, Mutability.*) | MemberIsNotReadOnly(Field, someNonstaticStaticsAuditedObject, AnalyzedImmutableGenericClassRestrictingT) */ someNonstaticStaticsAuditedObject /**/;
 
 		[Statics.Unaudited(Because.ItsSketchy)]
 		[Mutability.Audited("Timothy J Cowen", "2020-12-16", "Seriously............?")]
@@ -843,8 +843,8 @@ namespace SpecTests {
 			Types.SomeGenericMethodRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
 			object foo = new object();
 			int bar = 529;
-			Types.SomeGenericMethodRestrictingT</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/>(foo);
-			Types./* NonImmutableTypeHeldByImmutable(class, Object, ) */ SomeGenericMethodRestrictingT /**/(foo);
+			Types.SomeGenericMethodRestrictingT</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/>(foo);
+			Types./* NonImmutableTypeHeldByImmutable(class, object, ) */ SomeGenericMethodRestrictingT /**/(foo);
 			Types.SomeGenericMethodRestrictingT<int>(bar);
 			Types.SomeGenericMethodRestrictingT(bar);
 		}
@@ -1069,8 +1069,8 @@ namespace SpecTests {
 			Types.SomeGenericMethodRestrictingTU</* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/, /* TypeParameterIsNotKnownToBeImmutable(U) */ U /**/>();
 			object foo = new object();
 			int bar = 529;
-			Types.SomeGenericMethodRestrictingT</* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/>(foo);
-			Types./* NonImmutableTypeHeldByImmutable(class, Object, ) */ SomeGenericMethodRestrictingT /**/(foo);
+			Types.SomeGenericMethodRestrictingT</* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/>(foo);
+			Types./* NonImmutableTypeHeldByImmutable(class, object, ) */ SomeGenericMethodRestrictingT /**/(foo);
 			Types.SomeGenericMethodRestrictingT<int>(bar);
 			Types.SomeGenericMethodRestrictingT(bar);
 		}
@@ -1105,7 +1105,7 @@ namespace SpecTests {
 
 		int /* MemberIsNotReadOnly(Property, Y, SomeRecord) */ Y /**/ { get; set; }
 
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ Z { get; }
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ Z { get; }
 
 		public SomeRecord( SomeRecord v, int w, Types.SomeImmutableClass x, int y, object z )
 			=> (V, W, X, Y, Z) = (v, w, x, y, z);
@@ -1115,21 +1115,21 @@ namespace SpecTests {
 
 	[Immutable]
 	record DerivedRecordWithQuestionableBase :
-		/* NonImmutableTypeHeldByImmutable(class, NonImmutableBaseRecord,  (or [ImmutableBaseClass])) */ NonImmutableBaseRecord(new object()) /**/ ;
+		/* NonImmutableTypeHeldByImmutable(class, SpecTests.NonImmutableBaseRecord,  (or [ImmutableBaseClass])) */ NonImmutableBaseRecord(new object()) /**/ ;
 
 	[ImmutableBaseClass]
 	record BaseRecordWithImmutableBaseClass { }
 
 	[Immutable]
 	record DerivedFromImmutableBaseClassRecord : BaseRecordWithImmutableBaseClass {
-		/* NonImmutableTypeHeldByImmutable(class, BaseRecordWithImmutableBaseClass, ) */ BaseRecordWithImmutableBaseClass /**/ X { get; }
+		/* NonImmutableTypeHeldByImmutable(class, SpecTests.BaseRecordWithImmutableBaseClass, ) */ BaseRecordWithImmutableBaseClass /**/ X { get; }
     }
 
 	[Immutable]
 	record ConciseRecord(
 		int xxxx,
-		/* NonImmutableTypeHeldByImmutable(class, Object, ) */ object /**/ x,
-		/* NonImmutableTypeHeldByImmutable(class, BaseRecordWithImmutableBaseClass, ) */ BaseRecordWithImmutableBaseClass /**/ y,
+		/* NonImmutableTypeHeldByImmutable(class, object, ) */ object /**/ x,
+		/* NonImmutableTypeHeldByImmutable(class, SpecTests.BaseRecordWithImmutableBaseClass, ) */ BaseRecordWithImmutableBaseClass /**/ y,
 		ConciseRecord z
 	);
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -58,6 +58,21 @@ namespace D2L {
 			public SomeCssClass(int top, int right, int bottom, int left) { }
 		}
 
+		public static sealed class ArgumentSwappingClass
+		{
+			public interface IA { }
+			public interface IB : IA { }
+			public interface IC : IA { }
+			public interface ID : IB, IC { }
+
+			public sealed class A : IA { public A() { } }
+			public sealed class B : IB { public B() { } }
+			public sealed class C : IC { public C() { } }
+			public sealed class D : ID { public D() { } }
+
+			public static void SomeMethodToTest(IA a, IB b) { }
+		}
+
 		public static void Test() {
             #region "low" number of args doesn't require naming
             _arg0();
@@ -194,32 +209,20 @@ namespace D2L {
                 () => _arg2_ret( 1, _arg2_ret(1, 2) * _arg2_ret( 1, 2 ) );
 			#endregion
 
-			#region same-named arguments should be fine
+			#region arguments may have been swapped
 			int top = 1;
 			int right = 2;
 			int bottom = 3;
 			int left = 4;
 
-			// Works because names are same as parameters
-			new SomeCssClass(
-				top,
-				right,
-				bottom,
-				left);
+			new SomeCssClass(top, right, bottom, left);
+			/* NamedArgumentsRequired */ new SomeCssClass(top, bottom, right, left) /**/;
+			new SomeCssClass(top, right: bottom, bottom: right, left);
 
-			// Does not work because bottom & right are switched
-			new SomeCssClass(
-				top,
-				/* ImplicitUnnamedArgs(System.Int32) */ bottom /**/,
-				/* ImplicitUnnamedArgs(System.Int32) */ right /**/,
-				left);
-
-			// Works because the switched arguments were explicitly named
-			new SomeCssClass(
-				top,
-				right: bottom,
-				bottom: right,
-				left);
+			ArgumentSwappingClass.SomeMethodToTest( new ArgumentSwappingClass.A(), new ArgumentSwappingClass.B() );
+			/* NamedArgumentsRequired */ ArgumentSwappingClass.SomeMethodToTest( new ArgumentSwappingClass.B(), new ArgumentSwappingClass.B() ) /**/;
+			ArgumentSwappingClass.SomeMethodToTest( new ArgumentSwappingClass.C(), new ArgumentSwappingClass.B() );
+			/* NamedArgumentsRequired */ ArgumentSwappingClass.SomeMethodToTest( new ArgumentSwappingClass.D(), new ArgumentSwappingClass.B() ) /**/;
 			#endregion
 		}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -54,6 +54,10 @@ namespace D2L {
 			public SomeClass( int a1, int a2, int a3 ) { }
 		}
 
+		public sealed class SomeCssClass {
+			public SomeCssClass(int top, int right, int bottom, int left) { }
+		}
+
 		public static void Test() {
             #region "low" number of args doesn't require naming
             _arg0();
@@ -87,12 +91,12 @@ namespace D2L {
 			#endregion
 
 			#region verbatim identifiers
-			funcWithVerbatims( @int, @class, /* LiteralArgShouldBeNamed(@params) */ 3 /**/, p, p );
+			funcWithVerbatims( @int, @class, /* LiteralArgShouldBeNamed(@params) */ 3 /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
             /* TooManyUnnamedArgs(5) */ funcWithVerbatims( p, p, p, p, p ) /**/;
 
             // These should pass:
             funcWithVerbatims( @int, @class, @params, @name, @a5 );
-            funcWithVerbatims( @int, p, p, p, p );
+            funcWithVerbatims( @int, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
             #endregion
 
             #region all named args is usually preferred if there are lots of args
@@ -107,25 +111,25 @@ namespace D2L {
 			#endregion
 
 			#region named args don't count against the unnamed args budget
-			_arg5( a1: 1, p, p, p, p );
-			_arg6( a1: 1, a2: 2, p, p, p, p );
+			_arg5( a1: 1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			_arg6( a1: 1, a2: 2, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
 			#endregion
 
 			#region arguments that are literals with the correct name don't count against the budget
 			int a1 = 11;
 			int a3 = 13;
 			int A1 = 101; // upper case doesn't matter
-			_arg5( a1, p, p, p, p );
-			_arg5( p, p, a3, p, p );
-			_arg6( A1, p, a3, p, p, p );
+			_arg5( a1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/);
+			_arg5(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, a3, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			_arg6( A1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, a3, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
 			#endregion
 
 			#region member accesses can also serve as psuedo-names
 			var thing = new Thing();
-			_arg5( p, p, p, thing.a4, p );
-			_arg5( p, p, p, thing.nested.a4, p );
-			_arg5( p, p, p, thing.m_a4, p );
-			_arg5( p, p, p, thing.nested._a4, p );
+			_arg5( /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, thing.a4, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			_arg5(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, thing.nested.a4, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			_arg5(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, thing.m_a4, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			_arg5(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, thing.nested._a4, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
 			#endregion
 
 			#region need to have enough named args, though
@@ -134,16 +138,16 @@ namespace D2L {
 			#endregion
 
 			#region params don't count against the unnamed args budget
-			funcWithParams( p, p, p );
-			funcWithParams( p, p, p, p );
-			funcWithParams( p, p, p, p, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
+			funcWithParams( /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			funcWithParams(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, p );
+			funcWithParams(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, p, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
 			#endregion
 
 			#region delegates
 			((delegate0Args)null)();
 			((delegate1Args)null)( 1 );
 			/* TooManyUnnamedArgs(5) */ ((delegate5Args)null)( p, p, p, p, p ) /**/;
-			((delegate5Args)null)( a1: 1, p, p, p, p );
+			((delegate5Args)null)( a1: 1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
 			#endregion
 
 			#region class constructors should behave the same way
@@ -151,9 +155,9 @@ namespace D2L {
 			// behave just the same.
 			new SomeClass();
 			new SomeClass( 1 );
-			new SomeClass( p, p );
+			new SomeClass( /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/);
 			/* TooManyUnnamedArgs(5) */ new SomeClass( p, p, p, p, p ) /**/;
-			new SomeClass( a1: 1, p, p, p, p );
+			new SomeClass( a1: 1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
 			new SomeClass( a1: 1, a2: 2, a3: 3 );
 			/* NamedArgumentsRequired */ new SomeClass( 1, 2, 3 ) /**/;
 			#endregion
@@ -188,8 +192,36 @@ namespace D2L {
                 () => _arg2_ret( 1, 2 + _arg2_ret( 1, 2 ) );
             System.Linq.Expressions.Expression<Func<int>> nest6 =
                 () => _arg2_ret( 1, _arg2_ret(1, 2) * _arg2_ret( 1, 2 ) );
-            #endregion
-        }
+			#endregion
+
+			#region same-named arguments should be fine
+			int top = 1;
+			int right = 2;
+			int bottom = 3;
+			int left = 4;
+
+			// Works because names are same as parameters
+			new SomeCssClass(
+				top,
+				right,
+				bottom,
+				left);
+
+			// Does not work because bottom & right are switched
+			new SomeCssClass(
+				top,
+				/* ImplicitUnnamedArgs(System.Int32) */ bottom /**/,
+				/* ImplicitUnnamedArgs(System.Int32) */ right /**/,
+				left);
+
+			// Works because the switched arguments were explicitly named
+			new SomeCssClass(
+				top,
+				right: bottom,
+				bottom: right,
+				left);
+			#endregion
+		}
 
 		public abstract class SomeBaseClass {
 
@@ -221,13 +253,13 @@ namespace D2L {
 				: this( b1 ) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, string _ )
-				: this( b1, b2 ) { }
+				: this( /* ImplicitUnnamedArgs(System.Int32) */ b1 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b2 /**/) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, string _ )
 				/* NamedArgumentsRequired */ : this( b1, b2, b3 ) /**/{ }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, int b5, string _ )
-				: this( b1, b2, b3, b4 ) { }
+				: this( /* ImplicitUnnamedArgs(System.Int32) */ b1 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b2 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b3 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b4 /**/) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, int b5, int b6, long _ )
 				: this( a1: b1, a2: b2, a3: b3, a4: b4, a5: b5 ) { }
@@ -263,13 +295,13 @@ namespace D2L {
 				: base( b1 ) { }
 
 			public SomeInheritedClass( int b1, int b2, string _ )
-				: base( b1, b2 ) { }
+				: base( /* ImplicitUnnamedArgs(System.Int32) */ b1 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b2 /**/) { }
 
 			public SomeInheritedClass( int b1, int b2, int b3, bool _ )
 				/* NamedArgumentsRequired */ : base( b1, b2, b3 ) /**/{ }
 
 			public SomeInheritedClass( int b1, int b2, int b3, int b4, string _ )
-				: base( b1, b2, b3, b4 ) { }
+				: base( /* ImplicitUnnamedArgs(System.Int32) */ b1 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b2 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b3 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b4 /**/ ) { }
 
 			public SomeInheritedClass( int b1, int b2, int b3, int b4, int b5, string _ )
 				: base( a1: b1, a2: b2, a3: b3, a4: b4, a5: b5 ) { }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -71,6 +71,7 @@ namespace D2L {
 			public sealed class D : ID { public D() { } }
 
 			public static void SomeMethodToTest(IA a, IB b) { }
+			public static void SomeOtherMethodToTest(IA a, IB b, IC c) { }
 		}
 
 		public static void Test() {
@@ -106,12 +107,12 @@ namespace D2L {
 			#endregion
 
 			#region verbatim identifiers
-			funcWithVerbatims( @int, @class, /* LiteralArgShouldBeNamed(@params) */ 3 /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			funcWithVerbatims( @int, @class, /* LiteralArgShouldBeNamed(@params) */ 3 /**/, /* SwappableArgsShouldBeNamed(name, a5) */ p /**/, /* SwappableArgsShouldBeNamed(a5, name) */ p /**/);
             /* TooManyUnnamedArgs(5) */ funcWithVerbatims( p, p, p, p, p ) /**/;
+			funcWithVerbatims( @int, /* SwappableArgsShouldBeNamed(@class, @params) */ p /**/, /* SwappableArgsShouldBeNamed(@params, @class) */ p /**/, /* SwappableArgsShouldBeNamed(name, @class) */ p /**/, /* SwappableArgsShouldBeNamed(a5, @class) */ p /**/);
 
             // These should pass:
             funcWithVerbatims( @int, @class, @params, @name, @a5 );
-            funcWithVerbatims( @int, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
             #endregion
 
             #region all named args is usually preferred if there are lots of args
@@ -126,25 +127,25 @@ namespace D2L {
 			#endregion
 
 			#region named args don't count against the unnamed args budget
-			_arg5( a1: 1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
-			_arg6( a1: 1, a2: 2, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			_arg5( a1: 1, /* SwappableArgsShouldBeNamed(a2, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/);
+			_arg6( a1: 1, a2: 2, /* SwappableArgsShouldBeNamed(a3, a4) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a6, a3) */ p /**/ );
 			#endregion
 
 			#region arguments that are literals with the correct name don't count against the budget
 			int a1 = 11;
 			int a3 = 13;
 			int A1 = 101; // upper case doesn't matter
-			_arg5( a1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/);
-			_arg5(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, a3, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
-			_arg6( A1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, a3, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			_arg5( a1, /* SwappableArgsShouldBeNamed(a2, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/);
+			_arg5(/* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, a3, /* SwappableArgsShouldBeNamed(a4, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
+			_arg6( A1, /* SwappableArgsShouldBeNamed(a2, a4) */ p /**/, a3, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a6, a2) */ p /**/ );
 			#endregion
 
 			#region member accesses can also serve as psuedo-names
 			var thing = new Thing();
-			_arg5( /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, thing.a4, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
-			_arg5(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, thing.nested.a4, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
-			_arg5(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, thing.m_a4, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
-			_arg5(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, thing.nested._a4, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			_arg5( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ p /**/, thing.a4, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
+			_arg5( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ p /**/, thing.nested.a4, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
+			_arg5( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ p /**/, thing.m_a4, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
+			_arg5( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ p /**/, thing.nested._a4, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
 			#endregion
 
 			#region need to have enough named args, though
@@ -153,16 +154,16 @@ namespace D2L {
 			#endregion
 
 			#region params don't count against the unnamed args budget
-			funcWithParams( /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
-			funcWithParams(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, p );
-			funcWithParams(/* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, p, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
+			funcWithParams( /* SwappableArgsShouldBeNamed(a, b) */ p /**/, /* SwappableArgsShouldBeNamed(b, a) */ p /**/, /* SwappableArgsShouldBeNamed(c, a) */ p /**/ );
+			funcWithParams( /* SwappableArgsShouldBeNamed(a, b) */ p /**/, /* SwappableArgsShouldBeNamed(b, a) */ p /**/, /* SwappableArgsShouldBeNamed(c, a) */ p /**/, p );
+			funcWithParams( /* SwappableArgsShouldBeNamed(a, b) */ p /**/, /* SwappableArgsShouldBeNamed(b, a) */ p /**/, /* SwappableArgsShouldBeNamed(c, a) */ p /**/, p, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
 			#endregion
 
 			#region delegates
 			((delegate0Args)null)();
 			((delegate1Args)null)( 1 );
 			/* TooManyUnnamedArgs(5) */ ((delegate5Args)null)( p, p, p, p, p ) /**/;
-			((delegate5Args)null)( a1: 1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			((delegate5Args)null)( a1: 1, /* SwappableArgsShouldBeNamed(a2, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/ );
 			#endregion
 
 			#region class constructors should behave the same way
@@ -170,9 +171,9 @@ namespace D2L {
 			// behave just the same.
 			new SomeClass();
 			new SomeClass( 1 );
-			new SomeClass( /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/);
+			new SomeClass( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/);
 			/* TooManyUnnamedArgs(5) */ new SomeClass( p, p, p, p, p ) /**/;
-			new SomeClass( a1: 1, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/, /* ImplicitUnnamedArgs(System.Int32) */ p /**/ );
+			new SomeClass( a1: 1, /* SwappableArgsShouldBeNamed(a2, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/ );
 			new SomeClass( a1: 1, a2: 2, a3: 3 );
 			/* NamedArgumentsRequired */ new SomeClass( 1, 2, 3 ) /**/;
 			#endregion
@@ -210,19 +211,25 @@ namespace D2L {
 			#endregion
 
 			#region arguments may have been swapped
+
 			int top = 1;
 			int right = 2;
 			int bottom = 3;
 			int left = 4;
 
 			new SomeCssClass(top, right, bottom, left);
-			/* NamedArgumentsRequired */ new SomeCssClass(top, bottom, right, left) /**/;
+			new SomeCssClass(top, /* SwappableArgsShouldBeNamed(right, bottom) */ bottom /**/, /* SwappableArgsShouldBeNamed(bottom, right) */ right /**/, left);
 			new SomeCssClass(top, right: bottom, bottom: right, left);
+			new SomeCssClass(/* LiteralArgShouldBeNamed(top) */ 1 /**/, /* LiteralArgShouldBeNamed(right) */ 2 /**/, /* LiteralArgShouldBeNamed(bottom) */ 3 /**/, /* LiteralArgShouldBeNamed(left) */ 4 /**/);
 
-			ArgumentSwappingClass.SomeMethodToTest( new ArgumentSwappingClass.A(), new ArgumentSwappingClass.B() );
-			/* NamedArgumentsRequired */ ArgumentSwappingClass.SomeMethodToTest( new ArgumentSwappingClass.B(), new ArgumentSwappingClass.B() ) /**/;
-			ArgumentSwappingClass.SomeMethodToTest( new ArgumentSwappingClass.C(), new ArgumentSwappingClass.B() );
-			/* NamedArgumentsRequired */ ArgumentSwappingClass.SomeMethodToTest( new ArgumentSwappingClass.D(), new ArgumentSwappingClass.B() ) /**/;
+			ArgumentSwappingClass.SomeMethodToTest(new ArgumentSwappingClass.A(), new ArgumentSwappingClass.B());
+			ArgumentSwappingClass.SomeMethodToTest(/* SwappableArgsShouldBeNamed(a, b) */ new ArgumentSwappingClass.B() /**/, /* SwappableArgsShouldBeNamed(b, a) */ new ArgumentSwappingClass.B() /**/);
+			ArgumentSwappingClass.SomeMethodToTest(new ArgumentSwappingClass.C(), new ArgumentSwappingClass.B());
+			ArgumentSwappingClass.SomeMethodToTest(/* SwappableArgsShouldBeNamed(a, b) */ new ArgumentSwappingClass.D() /**/, /* SwappableArgsShouldBeNamed(b, a) */ new ArgumentSwappingClass.B() /**/);
+
+			ArgumentSwappingClass.SomeOtherMethodToTest(new ArgumentSwappingClass.A(), new ArgumentSwappingClass.B(), new ArgumentSwappingClass.C());
+			ArgumentSwappingClass.SomeOtherMethodToTest(/* SwappableArgsShouldBeNamed(a, c) */ new ArgumentSwappingClass.C() /**/, new ArgumentSwappingClass.B(), /* SwappableArgsShouldBeNamed(c, a) */ new ArgumentSwappingClass.C() /**/);
+
 			#endregion
 		}
 
@@ -256,13 +263,13 @@ namespace D2L {
 				: this( b1 ) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, string _ )
-				: this( /* ImplicitUnnamedArgs(System.Int32) */ b1 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b2 /**/) { }
+				: this( /* SwappableArgsShouldBeNamed(a1, a2) */ b1 /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ b2 /**/) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, string _ )
-				/* NamedArgumentsRequired */ : this( b1, b2, b3 ) /**/{ }
+				/* NamedArgumentsRequired */ : this( b1, b2, b3 ) /**/ { }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, int b5, string _ )
-				: this( /* ImplicitUnnamedArgs(System.Int32) */ b1 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b2 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b3 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b4 /**/) { }
+				: this( /* SwappableArgsShouldBeNamed(a1, a2) */ b1 /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ b2 /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ b3 /**/, /* SwappableArgsShouldBeNamed(a4, a1) */ b4 /**/) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, int b5, int b6, long _ )
 				: this( a1: b1, a2: b2, a3: b3, a4: b4, a5: b5 ) { }
@@ -298,13 +305,13 @@ namespace D2L {
 				: base( b1 ) { }
 
 			public SomeInheritedClass( int b1, int b2, string _ )
-				: base( /* ImplicitUnnamedArgs(System.Int32) */ b1 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b2 /**/) { }
+				: base( /* SwappableArgsShouldBeNamed(a1, a2) */ b1 /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ b2 /**/) { }
 
 			public SomeInheritedClass( int b1, int b2, int b3, bool _ )
-				/* NamedArgumentsRequired */ : base( b1, b2, b3 ) /**/{ }
+				/* NamedArgumentsRequired */ : base( b1, b2, b3 ) /**/ { }
 
 			public SomeInheritedClass( int b1, int b2, int b3, int b4, string _ )
-				: base( /* ImplicitUnnamedArgs(System.Int32) */ b1 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b2 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b3 /**/, /* ImplicitUnnamedArgs(System.Int32) */ b4 /**/ ) { }
+				: base( /* SwappableArgsShouldBeNamed(a1, a2) */ b1 /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ b2 /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ b3 /**/, /* SwappableArgsShouldBeNamed(a4, a1) */ b4 /**/) { }
 
 			public SomeInheritedClass( int b1, int b2, int b3, int b4, int b5, string _ )
 				: base( a1: b1, a2: b2, a3: b3, a4: b4, a5: b5 ) { }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/RequireNamedArgumentsAnalyzer.cs
@@ -1,6 +1,8 @@
 ﻿// analyzer: D2L.CodeStyle.Analyzers.Language.RequireNamedArgumentsAnalyzer
 
+using System.Collections.Immutable;
 using D2L.CodeStyle.Annotations.Contract;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace D2L.CodeStyle.Annotations.Contract {
 	public sealed class RequireNamedArgumentsAttribute : System.Attribute {}
@@ -70,8 +72,11 @@ namespace D2L {
 			public sealed class C : IC { public C() { } }
 			public sealed class D : ID { public D() { } }
 
-			public static void SomeMethodToTest(IA a, IB b) { }
-			public static void SomeOtherMethodToTest(IA a, IB b, IC c) { }
+			public static void SomeMethodToTest(IA one, IB two) { }
+			public static void SomeOtherMethodToTest(IA one, IB two, IC three) { }
+
+			public static void SomeMethodWithIgnoredNames(IA item1, IB item2) { }
+			public static void SomeOtherMethodWithIgnoredNames(IA item1test, IB item2test, IC item3test) { }
 		}
 
 		public static void Test() {
@@ -127,25 +132,25 @@ namespace D2L {
 			#endregion
 
 			#region named args don't count against the unnamed args budget
-			_arg5( a1: 1, /* SwappableArgsShouldBeNamed(a2, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/);
-			_arg6( a1: 1, a2: 2, /* SwappableArgsShouldBeNamed(a3, a4) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a6, a3) */ p /**/ );
+			_arg5( a1: 1, p, p, p, p);
+			_arg6( a1: 1, a2: 2, p, p, p, p );
 			#endregion
 
 			#region arguments that are literals with the correct name don't count against the budget
 			int a1 = 11;
 			int a3 = 13;
 			int A1 = 101; // upper case doesn't matter
-			_arg5( a1, /* SwappableArgsShouldBeNamed(a2, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/);
-			_arg5(/* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, a3, /* SwappableArgsShouldBeNamed(a4, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
-			_arg6( A1, /* SwappableArgsShouldBeNamed(a2, a4) */ p /**/, a3, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a6, a2) */ p /**/ );
+			_arg5( a1, p, p, p, p );
+			_arg5( p, p, a3, p, p );
+			_arg6( A1, p, a3, p, p, p );
 			#endregion
 
 			#region member accesses can also serve as psuedo-names
 			var thing = new Thing();
-			_arg5( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ p /**/, thing.a4, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
-			_arg5( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ p /**/, thing.nested.a4, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
-			_arg5( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ p /**/, thing.m_a4, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
-			_arg5( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ p /**/, thing.nested._a4, /* SwappableArgsShouldBeNamed(a5, a1) */ p /**/ );
+			_arg5( p, p, p, thing.a4, p );
+			_arg5( p, p, p, thing.nested.a4, p );
+			_arg5( p, p, p, thing.m_a4, p );
+			_arg5( p, p, p, thing.nested._a4, p );
 			#endregion
 
 			#region need to have enough named args, though
@@ -154,16 +159,16 @@ namespace D2L {
 			#endregion
 
 			#region params don't count against the unnamed args budget
-			funcWithParams( /* SwappableArgsShouldBeNamed(a, b) */ p /**/, /* SwappableArgsShouldBeNamed(b, a) */ p /**/, /* SwappableArgsShouldBeNamed(c, a) */ p /**/ );
-			funcWithParams( /* SwappableArgsShouldBeNamed(a, b) */ p /**/, /* SwappableArgsShouldBeNamed(b, a) */ p /**/, /* SwappableArgsShouldBeNamed(c, a) */ p /**/, p );
-			funcWithParams( /* SwappableArgsShouldBeNamed(a, b) */ p /**/, /* SwappableArgsShouldBeNamed(b, a) */ p /**/, /* SwappableArgsShouldBeNamed(c, a) */ p /**/, p, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
+			funcWithParams( p, p, p );
+			funcWithParams( p, p, p, p );
+			funcWithParams( p, p, p, p, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 );
 			#endregion
 
 			#region delegates
 			((delegate0Args)null)();
 			((delegate1Args)null)( 1 );
 			/* TooManyUnnamedArgs(5) */ ((delegate5Args)null)( p, p, p, p, p ) /**/;
-			((delegate5Args)null)( a1: 1, /* SwappableArgsShouldBeNamed(a2, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/ );
+			((delegate5Args)null)( a1: 1, p, p, p, p );
 			#endregion
 
 			#region class constructors should behave the same way
@@ -171,9 +176,9 @@ namespace D2L {
 			// behave just the same.
 			new SomeClass();
 			new SomeClass( 1 );
-			new SomeClass( /* SwappableArgsShouldBeNamed(a1, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ p /**/);
+			new SomeClass( p, p );
 			/* TooManyUnnamedArgs(5) */ new SomeClass( p, p, p, p, p ) /**/;
-			new SomeClass( a1: 1, /* SwappableArgsShouldBeNamed(a2, a3) */ p /**/, /* SwappableArgsShouldBeNamed(a3, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a4, a2) */ p /**/, /* SwappableArgsShouldBeNamed(a5, a2) */ p /**/ );
+			new SomeClass( a1: 1, p, p, p, p );
 			new SomeClass( a1: 1, a2: 2, a3: 3 );
 			/* NamedArgumentsRequired */ new SomeClass( 1, 2, 3 ) /**/;
 			#endregion
@@ -222,13 +227,26 @@ namespace D2L {
 			new SomeCssClass(top, right: bottom, bottom: right, left);
 			new SomeCssClass(/* LiteralArgShouldBeNamed(top) */ 1 /**/, /* LiteralArgShouldBeNamed(right) */ 2 /**/, /* LiteralArgShouldBeNamed(bottom) */ 3 /**/, /* LiteralArgShouldBeNamed(left) */ 4 /**/);
 
-			ArgumentSwappingClass.SomeMethodToTest(new ArgumentSwappingClass.A(), new ArgumentSwappingClass.B());
-			ArgumentSwappingClass.SomeMethodToTest(/* SwappableArgsShouldBeNamed(a, b) */ new ArgumentSwappingClass.B() /**/, /* SwappableArgsShouldBeNamed(b, a) */ new ArgumentSwappingClass.B() /**/);
-			ArgumentSwappingClass.SomeMethodToTest(new ArgumentSwappingClass.C(), new ArgumentSwappingClass.B());
-			ArgumentSwappingClass.SomeMethodToTest(/* SwappableArgsShouldBeNamed(a, b) */ new ArgumentSwappingClass.D() /**/, /* SwappableArgsShouldBeNamed(b, a) */ new ArgumentSwappingClass.B() /**/);
+			ArgumentSwappingClass.A a = new ArgumentSwappingClass.A()
+			ArgumentSwappingClass.B b = new ArgumentSwappingClass.B()
+			ArgumentSwappingClass.C c = new ArgumentSwappingClass.C()
+			ArgumentSwappingClass.D d = new ArgumentSwappingClass.D()
+			
+			ArgumentSwappingClass.SomeMethodToTest(a, b);
+			ArgumentSwappingClass.SomeMethodToTest(/* SwappableArgsShouldBeNamed(one, two) */ b /**/, /* SwappableArgsShouldBeNamed(two, one) */ b /**/);
+			ArgumentSwappingClass.SomeMethodToTest(c, b);
+			ArgumentSwappingClass.SomeMethodToTest(/* SwappableArgsShouldBeNamed(one, two) */ d /**/, /* SwappableArgsShouldBeNamed(two, one) */ b /**/);
 
-			ArgumentSwappingClass.SomeOtherMethodToTest(new ArgumentSwappingClass.A(), new ArgumentSwappingClass.B(), new ArgumentSwappingClass.C());
-			ArgumentSwappingClass.SomeOtherMethodToTest(/* SwappableArgsShouldBeNamed(a, c) */ new ArgumentSwappingClass.C() /**/, new ArgumentSwappingClass.B(), /* SwappableArgsShouldBeNamed(c, a) */ new ArgumentSwappingClass.C() /**/);
+			ArgumentSwappingClass.SomeOtherMethodToTest(a, b, c);
+			ArgumentSwappingClass.SomeOtherMethodToTest(/* SwappableArgsShouldBeNamed(one, three) */ c /**/, b, /* SwappableArgsShouldBeNamed(three, one) */ c /**/);
+
+			ArgumentSwappingClass.SomeMethodWithIgnoredNames( a, b );
+			ArgumentSwappingClass.SomeMethodWithIgnoredNames( b, b );
+			ArgumentSwappingClass.SomeMethodWithIgnoredNames( c, b );
+			ArgumentSwappingClass.SomeMethodWithIgnoredNames( d, b );
+
+			ArgumentSwappingClass.SomeOtherMethodWithIgnoredNames( a, b, c );
+			ArgumentSwappingClass.SomeOtherMethodWithIgnoredNames( c, b, c );
 
 			#endregion
 		}
@@ -263,13 +281,13 @@ namespace D2L {
 				: this( b1 ) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, string _ )
-				: this( /* SwappableArgsShouldBeNamed(a1, a2) */ b1 /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ b2 /**/) { }
+				: this( b1, b2 ) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, string _ )
 				/* NamedArgumentsRequired */ : this( b1, b2, b3 ) /**/ { }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, int b5, string _ )
-				: this( /* SwappableArgsShouldBeNamed(a1, a2) */ b1 /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ b2 /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ b3 /**/, /* SwappableArgsShouldBeNamed(a4, a1) */ b4 /**/) { }
+				: this( b1, b2, b3, b4 ) { }
 
 			public SomeBaseClass( int b1, int b2, int b3, int b4, int b5, int b6, long _ )
 				: this( a1: b1, a2: b2, a3: b3, a4: b4, a5: b5 ) { }
@@ -305,13 +323,13 @@ namespace D2L {
 				: base( b1 ) { }
 
 			public SomeInheritedClass( int b1, int b2, string _ )
-				: base( /* SwappableArgsShouldBeNamed(a1, a2) */ b1 /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ b2 /**/) { }
+				: base( b1, b2 ) { }
 
 			public SomeInheritedClass( int b1, int b2, int b3, bool _ )
 				/* NamedArgumentsRequired */ : base( b1, b2, b3 ) /**/ { }
 
 			public SomeInheritedClass( int b1, int b2, int b3, int b4, string _ )
-				: base( /* SwappableArgsShouldBeNamed(a1, a2) */ b1 /**/, /* SwappableArgsShouldBeNamed(a2, a1) */ b2 /**/, /* SwappableArgsShouldBeNamed(a3, a1) */ b3 /**/, /* SwappableArgsShouldBeNamed(a4, a1) */ b4 /**/) { }
+				: base( b1, b2, b3, b4 ) { }
 
 			public SomeInheritedClass( int b1, int b2, int b3, int b4, int b5, string _ )
 				: base( a1: b1, a2: b2, a3: b3, a4: b4, a5: b5 ) { }


### PR DESCRIPTION
- Added check for how many times each data type is used in the parameters
- Added diagnostic when the current data type has been used more than once to force naming
- Updated test cases

Closes https://github.com/Brightspace/D2L.CodeStyle/issues/521