### PR TITLE
Add diagnostic for [Immutable]+[ConditionallyImmutable] conflicts #660

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -553,10 +553,10 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true
 		);
 
-		public static readonly DiagnosticDescriptor ConflictingAuditing = new DiagnosticDescriptor(
+		public static readonly DiagnosticDescriptor InvalidAuditType = new DiagnosticDescriptor(
 			id: "D2L0073",
-			title: "The [Audited] and [Unaudited] attributes are mutually exclusive.",
-			messageFormat: "The [Audited] and [Unaudited] attributes cannot be used on the same property.",
+			title: "Wrong type of auditing was used.",
+			messageFormat: "A {0} {1} should audit using the [{2}] attributes.",
 			category: "Immutability",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -552,5 +552,14 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
+
+		public static readonly DiagnosticDescriptor ConflictingAuditing = new DiagnosticDescriptor(
+			id: "D2L0073",
+			title: "The [Audited] and [Unaudited] attributes are mutually exclusive.",
+			messageFormat: "The [Audited] and [Unaudited] attributes cannot be used on the same property.",
+			category: "Immutability",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -552,14 +552,5 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
-
-		public static readonly DiagnosticDescriptor InvalidAuditType = new DiagnosticDescriptor(
-			id: "D2L0073",
-			title: "Wrong type of auditing was used.",
-			messageFormat: "A {0} {1} should audit using the [{2}] attributes.",
-			category: "Immutability",
-			defaultSeverity: DiagnosticSeverity.Error,
-			isEnabledByDefault: true
-		);
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -137,6 +137,63 @@ namespace SpecTests {
 	public sealed class AnalyzedClassMarkedImmutableExtendingImmutableClass : Types.SomeImmutableClass { }
 
 	[Immutable]
+	[ConditionallyImmutable]
+	public sealed class /* ConflictingImmutability(Immutable, ConditionallyImmutable, class) */ AnalyzedClassMarkedWithMultipleImmutabilities1 /**/ { }
+
+	[Immutable]
+	[ImmutableBaseClassAttribute]
+	public sealed class /* ConflictingImmutability(Immutable, ImmutableBaseClassAttribute, class) */ AnalyzedClassMarkedWithMultipleImmutabilities2 /**/ { }
+
+	[ConditionallyImmutable]
+	[ImmutableBaseClassAttribute]
+	public sealed class /* ConflictingImmutability(ConditionallyImmutable, ImmutableBaseClassAttribute, class) */ AnalyzedClassMarkedWithMultipleImmutabilities3 /**/ { }
+
+	[Immutable]
+	[ConditionallyImmutable]
+	[ImmutableBaseClassAttribute]
+	public sealed class /* ConflictingImmutability(Immutable, ConditionallyImmutable, class)
+	                     | ConflictingImmutability(Immutable, ImmutableBaseClassAttribute, class)
+	                     | ConflictingImmutability(ConditionallyImmutable, ImmutableBaseClassAttribute, class) */ AnalyzedClassMarkedWithMultipleImmutabilities4 /**/ { }
+
+	[Immutable]
+	[ConditionallyImmutable]
+	public sealed interface /* ConflictingImmutability(Immutable, ConditionallyImmutable, interface) */ AnalyzedInterfaceMarkedWithMultipleImmutabilities1 /**/ { }
+
+	[Immutable]
+	[ImmutableBaseClassAttribute]
+	public sealed interface /* ConflictingImmutability(Immutable, ImmutableBaseClassAttribute, interface) */ AnalyzedInterfaceMarkedWithMultipleImmutabilities2 /**/ { }
+
+	[ConditionallyImmutable]
+	[ImmutableBaseClassAttribute]
+	public sealed interface /* ConflictingImmutability(ConditionallyImmutable, ImmutableBaseClassAttribute, interface) */ AnalyzedInterfaceMarkedWithMultipleImmutabilities3 /**/ { }
+
+	[Immutable]
+	[ConditionallyImmutable]
+	[ImmutableBaseClassAttribute]
+	public sealed interface /* ConflictingImmutability(Immutable, ConditionallyImmutable, interface)
+					         | ConflictingImmutability(Immutable, ImmutableBaseClassAttribute, interface)
+	                         | ConflictingImmutability(ConditionallyImmutable, ImmutableBaseClassAttribute, interface) */ AnalyzedInterfaceMarkedWithMultipleImmutabilities4 /**/ { }
+
+	[Immutable]
+	[ConditionallyImmutable]
+	public sealed struct /* ConflictingImmutability(Immutable, ConditionallyImmutable, struct) */ AnalyzedStructMarkedWithMultipleImmutabilities1 /**/ { }
+
+	[Immutable]
+	[ImmutableBaseClassAttribute]
+	public sealed struct /* ConflictingImmutability(Immutable, ImmutableBaseClassAttribute, struct) */ AnalyzedStructMarkedWithMultipleImmutabilities2 /**/ { }
+
+	[ConditionallyImmutable]
+	[ImmutableBaseClassAttribute]
+	public sealed struct /* ConflictingImmutability(ConditionallyImmutable, ImmutableBaseClassAttribute, struct) */ AnalyzedStructMarkedWithMultipleImmutabilities3 /**/ { }
+
+	[Immutable]
+	[ConditionallyImmutable]
+	[ImmutableBaseClassAttribute]
+	public sealed struct /* ConflictingImmutability(Immutable, ConditionallyImmutable, struct)
+	                      | ConflictingImmutability(Immutable, ImmutableBaseClassAttribute, struct)
+	                      | ConflictingImmutability(ConditionallyImmutable, ImmutableBaseClassAttribute, struct) */ AnalyzedStructMarkedWithMultipleImmutabilities4 /**/	{ }
+
+	[Immutable]
 	public sealed class AnalyzedClassMarkedImmutable {
 
 


### PR DESCRIPTION
- Added new analyzer method to check if there are two of [Immutable], [ConditionallyImmutable], and [ImmutableBaseClassAttribute]
- Added supporting tests

Closes https://github.com/Brightspace/D2L.CodeStyle/issues/660