### PR TITLE
Immutability: analyzer assumes initializers are the only writes to readonly members #319

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -133,15 +133,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		}
 
 		private bool CheckField( DiagnosticSink diagnosticSink, IFieldSymbol field ) {
-			if( field.IsImplicitlyDeclared ) {
+			if ( field.IsImplicitlyDeclared ) {
 				// These correspond to auto-properties. That case gets handled
 				// in CheckProperty instead.
 				return true;
 			}
 
-			var decl = field.DeclaringSyntaxReferences
-			   .Single()
-			   .GetSyntax() as VariableDeclaratorSyntax;
+			var decl = field.DeclaringSyntaxReferences.Single()
+				.GetSyntax() as VariableDeclaratorSyntax;
 
 			var type = decl.FirstAncestorOrSelf<VariableDeclarationSyntax>().Type;
 
@@ -161,14 +160,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 
 		private bool CheckProperty( DiagnosticSink diagnosticSink, IPropertySymbol prop ) {
-			if( prop.IsIndexer ) {
+			if ( prop.IsIndexer ) {
 				// Indexer properties are just glorified method syntax and
 				// don't hold state.
 				// https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/indexers/
 				return true;
 			}
 
-			if( prop.IsImplicitlyDeclared ) {
+			if ( prop.IsImplicitlyDeclared ) {
 				// records have implicitly declared properties like
 				// EqualityContract which are OK but don't have a
 				// PropertyDeclarationSyntax etc.
@@ -180,7 +179,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				prop.DeclaringSyntaxReferences.Single().GetSyntax()
 			);
 
-			if( !propInfo.IsAutoImplemented ) {
+			if ( !propInfo.IsAutoImplemented ) {
 				// Properties that are auto-implemented have an implicit
 				// backing field that may be mutable. Otherwise, properties are
 				// just sugar for getter/setter methods and don't themselves
@@ -213,7 +212,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		) {
 			var immutable = true;
 
-			if( !isReadOnly ) {
+			if ( !isReadOnly ) {
 				diagnosticSink(
 					Diagnostic.Create(
 						Diagnostics.MemberIsNotReadOnly,
@@ -274,21 +273,21 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			// Retrieve a list of assignment expressions from any constructors
 			// within the class
 			var assignmentExpressions = ( memberSymbol.ContainingSymbol as INamedTypeSymbol )!
-			   .Constructors
-			   .Where( constructorSymbol => !constructorSymbol.IsImplicitlyDeclared )
-			   .Select( constructorSymbol => constructorSymbol.DeclaringSyntaxReferences
-				           .Single()
-				           .GetSyntax() )
-			   .SelectMany( constructorSyntax => constructorSyntax.DescendantNodes() )
-			   .OfType<AssignmentExpressionSyntax>();
+				.Constructors
+				.Where( constructorSymbol => !constructorSymbol.IsImplicitlyDeclared )
+				.Select( constructorSymbol => constructorSymbol.DeclaringSyntaxReferences
+					.Single()
+					.GetSyntax() )
+				.SelectMany( constructorSyntax => constructorSyntax.DescendantNodes() )
+				.OfType<AssignmentExpressionSyntax>();
 
 			// Add any assignments which act on the specific field/property
 			// to the list
 			return assignmentExpressions
-			   .Where( assignmentSyntax => IsAnAssignmentTo( assignmentSyntax, memberSymbol ) )
-			   .Select( assignmentSyntax => assignmentSyntax.Right )
-			   .Append( initializer )
-			   .ToImmutableArray();
+				.Where( assignmentSyntax => IsAnAssignmentTo( assignmentSyntax, memberSymbol ) )
+				.Select( assignmentSyntax => assignmentSyntax.Right )
+				.Append( initializer )
+				.ToImmutableArray();
 		}
 
 		private bool IsAnAssignmentTo(
@@ -300,7 +299,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			);
 
 			var leftSideSymbol = semanticModel.GetSymbolInfo( assignmentSyntax.Left )
-			   .Symbol;
+				.Symbol;
 
 			return SymbolEqualityComparer.Default.Equals(
 				memberSymbol,

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿// analyzer: D2L.CodeStyle.Analyzers.Immutability.ImmutabilityAnalyzer
 
 using System;
+using System.ComponentModel;
 using D2L.CodeStyle.Annotations;
 
 #region Relevant Types
@@ -53,6 +54,40 @@ namespace SpecTests {
 
 		[Immutable]
 		public interface SomeImmutableInterface { }
+
+		#region Constructor immutability
+		[Immutable]
+		public sealed class Good : RegularInterface { }
+
+		public class Bad : RegularInterface { }
+
+		[Immutable]
+		public sealed class SomeClassWithConstructor {
+			public readonly RegularInterface m_interface = new Good();
+
+			public SomeClassWithConstructor() {
+				m_interface = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.Bad,  (or [ImmutableBaseClass])) */ new Bad() /**/;
+			}
+		}
+
+		[Immutable]
+		public sealed class SomeOtherClassWithConstructor {
+			public readonly RegularInterface m_interface = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.Bad,  (or [ImmutableBaseClass])) */ new Bad() /**/;
+
+			public SomeClassWithConstructor() {
+				m_interface = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.Bad,  (or [ImmutableBaseClass])) */ new Bad() /**/;
+			}
+		}
+
+		[Immutable]
+		public sealed class SomeOtherOtherClassWithConstructor {
+			public readonly RegularInterface m_interface = new Good();
+
+			public SomeClassWithConstructor() {
+				m_interface = new Good();
+			}
+		}
+		#endregion
 
 
 		public class RegularClass {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -62,29 +62,40 @@ namespace SpecTests {
 		public class Bad : RegularInterface { }
 
 		[Immutable]
-		public sealed class SomeClassWithConstructor {
+		public sealed class SomeClassWithConstructor1 {
 			public readonly RegularInterface m_interface = new Good();
 
-			public SomeClassWithConstructor() {
+			public SomeClassWithConstructor1() {
 				m_interface = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.Bad,  (or [ImmutableBaseClass])) */ new Bad() /**/;
 			}
 		}
 
 		[Immutable]
-		public sealed class SomeOtherClassWithConstructor {
+		public sealed class SomeClassWithConstructor2 {
 			public readonly RegularInterface m_interface = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.Bad,  (or [ImmutableBaseClass])) */ new Bad() /**/;
 
-			public SomeClassWithConstructor() {
+			public SomeClassWithConstructor2() {
 				m_interface = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.Bad,  (or [ImmutableBaseClass])) */ new Bad() /**/;
 			}
 		}
 
 		[Immutable]
-		public sealed class SomeOtherOtherClassWithConstructor {
+		public sealed class SomeClassWithConstructor3 {
 			public readonly RegularInterface m_interface = new Good();
 
-			public SomeClassWithConstructor() {
+			public SomeClassWithConstructor3() {
 				m_interface = new Good();
+			}
+		}
+
+		[Immutable]
+		public sealed class SomeClassWithConstructor4 {
+			public readonly RegularInterface m_interface = new Good();
+
+			public SomeClassWithConstructor4() {
+				if( true == false ) {
+					m_interface = /* NonImmutableTypeHeldByImmutable(class, SpecTests.Types.Bad,  (or [ImmutableBaseClass])) */ new Bad() /**/;
+				}
 			}
 		}
 		#endregion


### PR DESCRIPTION
- Added method to get all possible initializations from within constructors
- Changed single-initializer structures to use multiple initializers
- Added supporting tests