### PR TITLE
Don't bother looking at writes to fields/properties if the member type is already totally immutable #699

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -72,15 +72,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		}
 
 		/// <summary>
-		/// Determines if a type is an "always immutable" special type.
-		/// </summary>
-		/// <param name="type">The type to check</param>
-		/// <returns>Is the type always immutable?</returns>
-		public bool IsTotallyImmutableType( ITypeSymbol type ) {
-			return m_totallyImmutableSpecialTypes.Contains( type.SpecialType );
-		}
-
-		/// <summary>
 		/// Determines if a type is known to be immutable.
 		/// </summary>
 		/// <param name="type">The type to check</param>
@@ -103,7 +94,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			diagnostic = null;
 
 			// Things like int are totally OK
-			if( IsTotallyImmutableType( type ) ) {
+			if ( m_totallyImmutableSpecialTypes.Contains( type.SpecialType ) ) {
 				return true;
 			}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -72,6 +72,15 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		}
 
 		/// <summary>
+		/// Determines if a type is an "always immutable" special type.
+		/// </summary>
+		/// <param name="type">The type to check</param>
+		/// <returns>Is the type always immutable?</returns>
+		public bool IsTotallyImmutableType( ITypeSymbol type ) {
+			return m_totallyImmutableSpecialTypes.Contains( type.SpecialType );
+		}
+
+		/// <summary>
 		/// Determines if a type is known to be immutable.
 		/// </summary>
 		/// <param name="type">The type to check</param>
@@ -94,7 +103,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			diagnostic = null;
 
 			// Things like int are totally OK
-			if ( m_totallyImmutableSpecialTypes.Contains( type.SpecialType ) ) {
+			if( IsTotallyImmutableType( type ) ) {
 				return true;
 			}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -226,7 +226,15 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				immutable = false;
 			}
 
-			if( m_context.IsTotallyImmutableType( type ) ) {
+			// Perform an initial check to see if the member is totally immutable
+			// If this fails, then we need to perform assignment checks to ensure
+			// instance immutability
+			if( m_context.IsImmutable(
+				type,
+				ImmutableTypeKind.Total,
+				typeSyntax.GetLocation,
+				out _
+			) ) {
 				return immutable;
 			}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -226,6 +226,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				immutable = false;
 			}
 
+			if( m_context.IsTotallyImmutableType( type ) ) {
+				return immutable;
+			}
+
 			// Check all assignments of the member for immutability
 			foreach( var assignment in assignments ) {
 				var stuff = GetStuffToCheckForMember(

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -103,8 +103,7 @@ namespace SpecTests {
 		public sealed class SomeClassWithConstructor5 {
 			public readonly int m_int = 5;
 
-			public SomeClassWithConstructor5()
-			{
+			public SomeClassWithConstructor5() {
 				m_int = 29;
 			}
 		}
@@ -113,16 +112,14 @@ namespace SpecTests {
 		public sealed class SomeClassWithConstructor6 {
 			public int /* MemberIsNotReadOnly(Field, m_int, SomeClassWithConstructor6) */ m_int /**/ = 5;
 
-			public SomeClassWithConstructor6()
-			{
+			public SomeClassWithConstructor6() {
 				m_int = 29;
 			}
 		}
 
 		[ConditionallyImmutable]
 		internal sealed class Foo<[ConditionallyImmutable.OnlyIf] T, U> where U : T {
-			public Foo(U you)
-			{
+			public Foo( U you ) {
 				Tee = you;
 			}
 ​

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -118,6 +118,16 @@ namespace SpecTests {
 				m_int = 29;
 			}
 		}
+
+		[ConditionallyImmutable]
+		internal sealed class Foo<[ConditionallyImmutable.OnlyIf] T, U> where U : T {
+			public Foo(U you)
+			{
+				Tee = you;
+			}
+​
+			public T Tee { get; }
+		}
 		#endregion
 
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -118,12 +118,12 @@ namespace SpecTests {
 		}
 
 		[ConditionallyImmutable]
-		internal sealed class Foo<[ConditionallyImmutable.OnlyIf] T, U> where U : T {
-			public Foo( U you ) {
+		internal sealed class SomeClassWithConstructor7<[ConditionallyImmutable.OnlyIf] T, U> where U : T {
+			public T Tee { get; }
+			
+			public SomeClassWithConstructor7( U you ) {
 				Tee = you;
 			}
-​
-			public T Tee { get; }
 		}
 		#endregion
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -98,6 +98,26 @@ namespace SpecTests {
 				}
 			}
 		}
+
+		[Immutable]
+		public sealed class SomeClassWithConstructor5 {
+			public readonly int m_int = 5;
+
+			public SomeClassWithConstructor5()
+			{
+				m_int = 29;
+			}
+		}
+
+		[Immutable]
+		public sealed class SomeClassWithConstructor6 {
+			public int /* MemberIsNotReadOnly(Field, m_int, SomeClassWithConstructor6) */ m_int /**/ = 5;
+
+			public SomeClassWithConstructor6()
+			{
+				m_int = 29;
+			}
+		}
 		#endregion
 
 


### PR DESCRIPTION
- Added method in ImmutabilityContext to check if the specified type is always immutable (such as int or bool)
- Added check to not perform full check if the type must be immutable
- Added supporting tests

Closes https://github.com/Brightspace/D2L.CodeStyle/issues/699