### PR TITLE
Allow method returns to be marked as [Constant].

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -562,5 +562,14 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
+
+		public static readonly DiagnosticDescriptor NonConstantReturnedFromConstantMethod = new DiagnosticDescriptor(
+			id: "D2L0076",
+			title: "Constant method cannot return a non-constant value.",
+			messageFormat: "The \"{0}\" method is marked with the [Constant] attribute, and so it must return a compile-time constant value.",
+			category: "Safety",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		);
 	}
 }

--- a/src/D2L.CodeStyle.Annotations/Contract/ConstantAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/Contract/ConstantAttribute.cs
@@ -5,7 +5,7 @@ namespace D2L.CodeStyle.Annotations.Contract {
 	/// <summary>
 	/// Indicates that a parameter must be called with a constant value
 	/// </summary>
-	[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = false )]
+	[AttributeUsage( AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false )]
 	public sealed class ConstantAttribute : ReadOnlyAttribute {
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConstantAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConstantAttributeAnalyzer.cs
@@ -39,6 +39,23 @@ namespace SpecTests
 		public class SomeClassImplementingInterface : IInterface { }
 		public static void SomeMethodWithInterfaceParameter( /* InvalidConstantType(Interface) */ [Constant] IInterface @interface /**/ ) { }
 		public static void SomeMethodWithOneInterfaceParameter<T>(IInterface param1, [Constant] T param2) { }
+
+		[Constant]
+		public static string GetConstantMessage() {
+			const string CONSTANT_STR = "This is a constant message";
+			return CONSTANT_STR;
+		}
+
+		[Constant]
+		public static string TryToGetConstantMessage() {
+			string variableStr = "This is a variable message";
+			return /* NonConstantReturnedFromConstantMethod(TryToGetConstantMessage) */ randomString /**/;
+		}
+
+		public static string GetNonConstantMessage() {
+			string variableStr = "This is a variable message";
+			return randomString;
+		}
 	}
 
 	public sealed class Tests
@@ -174,6 +191,13 @@ namespace SpecTests
 			Types.SomeMethodWithTwoConstantParameters<bool>( CONSTANT_BOOL, /* NonConstantPassedToConstantParameter(param2) */ variableBool /**/ );
 			Types.SomeMethodWithTwoConstantParameters<bool>( /* NonConstantPassedToConstantParameter(param1) */ variableBool /**/, CONSTANT_BOOL );
 			Types.SomeMethodWithTwoConstantParameters<bool>( /* NonConstantPassedToConstantParameter(param1) */ variableBool /**/, /* NonConstantPassedToConstantParameter(param2) */ variableBool /**/ );
+			#endregion
+
+			#region Constant method tests
+
+			Types.SomeMethodWithConstantParameter<string>( Types.GetConstantMessage() );
+			Types.SomeMethodWithConstantParameter<string>( /* NonConstantPassedToConstantParameter(param1) */ Types.GetNonConstantMessage() /**/ );
+
 			#endregion
 		}
 	}


### PR DESCRIPTION
- Will allow methods which determine which constant value to return between multiple.
- Added analyzer to ensure return statement of [Constant] method is a compile-time constant value.
- Added supporting tests.