### PR TITLE
Don't treat Lazy<T> as conditionally immutable

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
@@ -20,7 +20,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			("System.Collections.Generic.IReadOnlyList`1", default),
 			("System.Collections.Generic.IReadOnlyDictionary`2", default),
 			("System.Collections.Generic.IEnumerable`1", default),
-			("System.Lazy`1", default),
 			("System.Nullable`1", default),
 			("System.Tuple`1", default),
 			("System.Tuple`2", default),


### PR DESCRIPTION
Although this is arguably OK (given how we define immutability) it's working against us right now.

We are going to consolidate on `ContextFreeLazy<T>` in circumstances where this is necessary which integrates with `InstanceContextBlocker` to ensure initialization is (customer-) context-free.