### PR TITLE
Add test case for assignments with missing initializer

### DIFF
--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ImmutabilityAnalyzer.cs
@@ -111,9 +111,19 @@ namespace SpecTests {
 		[Immutable]
 		public sealed class SomeClassWithConstructor5 {
 			public readonly int m_int = 5;
+			public readonly object m_alwaysOk;
+			public readonly object m_sometimesBad;
 
 			public SomeClassWithConstructor5() {
 				m_int = 29;
+
+				m_alwaysOk = null;
+				m_alwaysOk = new object();
+
+				m_sometimesBad = null;
+				m_sometimesBad = new object();
+				m_sometimesBad = /* ArraysAreMutable(Int32) */ new[] { 3 } /**/;
+				m_sometimesBad = new Good();
 			}
 		}
 


### PR DESCRIPTION
When all the assignments are good there should be no diagnostic.
This would have caught the previous bug where there was no initializer.