### PR TITLE
US127307 Add telemetry event logger code style

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/BannedConfigs.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/BannedConfigs.cs
@@ -12,7 +12,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Configs {
 			.Add( "GetOrg", ImmutableDictionary.Create<string, string>( StringComparer.OrdinalIgnoreCase )
 				.Add( "d2l.Settings.WebServerName", "WebServerName is being moved to Hiera data. Use IUrlFormatter or IWebServerNameProvider instead." )
 				.Add( "d2l.System.Aws.Region", "Use IOrgAwsRegionProvider instead." )
-				.Add( "d2l.System.Services.ProductTelemetryEndpoint", " Use ITelemetryEventLogger.Endpoint( orgId ) instead." )
+				.Add( "d2l.System.Services.ProductTelemetryEndpoint", "Use ITelemetryEventLogger.Endpoint( orgId ) instead." )
 
 				.Add( "Directories.Org.Content", "Use IFileSystemRootProvider.GetContentPath( orgId ) instead." )
 				.Add( "Directories.Org.Shared", "Use IFileSystemRootProvider.GetSharedPath( orgId ) instead." )

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/BannedConfigs.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/BannedConfigs.cs
@@ -12,6 +12,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Configs {
 			.Add( "GetOrg", ImmutableDictionary.Create<string, string>( StringComparer.OrdinalIgnoreCase )
 				.Add( "d2l.Settings.WebServerName", "WebServerName is being moved to Hiera data. Use IUrlFormatter or IWebServerNameProvider instead." )
 				.Add( "d2l.System.Aws.Region", "Use IOrgAwsRegionProvider instead." )
+				.Add( "d2l.System.Services.ProductTelemetryEndpoint", " Use ITelemetryEventLogger.Endpoint( orgId ) instead." )
 
 				.Add( "Directories.Org.Content", "Use IFileSystemRootProvider.GetContentPath( orgId ) instead." )
 				.Add( "Directories.Org.Shared", "Use IFileSystemRootProvider.GetSharedPath( orgId ) instead." )

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConfigViewerAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConfigViewerAnalyzer.cs
@@ -53,6 +53,11 @@ namespace D2L.CodeStyle.Analyzers.Specs {
 				orgId: 123
 			);
 
+			m_configViewer.GetOrg<string>(
+				configName: /* BannedConfig(d2l.System.Services.ProductTelemetryEndpoint, ProductTelemetryEndpoint is encapsulated in LP framework core. Use ITelemetryEventLogger.Endpoint( orgId ) instead.) */ "d2l.System.Services.ProductTelemetryEndpoint" /**/,
+				orgId: 123,
+			);
+
 			// <T> isn't considered
 			m_configViewer.GetOrg<int>(
 				123,

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConfigViewerAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConfigViewerAnalyzer.cs
@@ -53,11 +53,6 @@ namespace D2L.CodeStyle.Analyzers.Specs {
 				orgId: 123
 			);
 
-			m_configViewer.GetOrg<string>(
-				configName: /* BannedConfig(d2l.System.Services.ProductTelemetryEndpoint, ProductTelemetryEndpoint is encapsulated in LP framework core. Use ITelemetryEventLogger.Endpoint( orgId ) instead.) */ "d2l.System.Services.ProductTelemetryEndpoint" /**/,
-				orgId: 123,
-			);
-
 			// <T> isn't considered
 			m_configViewer.GetOrg<int>(
 				123,


### PR DESCRIPTION
### Motivation/Context
* As part of the PBMM work we need to ensure we do not log telemetry events for Protected B clients so we added `ITelemetryEventLogger` to encapsulate all the telemetry endpoint usages for better control of what we are returning (we return the telemetry endpoint for non-PBMM clients and `null` for PBMM clients)

This PR has a dependency on another PR to be merged first: https://github.com/Brightspace/lms/pull/10201

### Summary of Changes
* Listed data telemetry endpoint as a banned config and added message to direct developers to use `ITelemetryEventLogger` instead

### Rally Story
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F600523947568&fdp=true?fdp=true