### PR TITLE
Prevent unaudited usage of Assembly.Load()

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMethods.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMethods.cs
@@ -32,6 +32,9 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			.Add<Thread>(
 				nameof( Thread.Sleep )
 			)
+			.Add<Assembly>(
+				nameof( Assembly.Load )
+			)
 			.AddMethod(
 				"MapPath",
 				new[] {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMethods.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMethods.cs
@@ -10,6 +10,9 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 
 		internal static readonly IReadOnlyDictionary<string, ImmutableArray<string>> Definitions =
 			ImmutableDictionary.Create<string, ImmutableArray<string>>()
+			.Add<Assembly>(
+				nameof( Assembly.Load )
+			)
 			.Add<FieldInfo>(
 				nameof( FieldInfo.GetValue ),
 				nameof( FieldInfo.SetValue ),
@@ -31,9 +34,6 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			)
 			.Add<Thread>(
 				nameof( Thread.Sleep )
-			)
-			.Add<Assembly>(
-				nameof( Assembly.Load )
 			)
 			.AddMethod(
 				"MapPath",


### PR DESCRIPTION
Using `Assembly.Load()` means we can't get a proper dependency graph of projects. See https://github.com/Brightspace/lms/issues/9384 for more information

Ref: https://github.com/Brightspace/lms/issues/11891