### PR TITLE
Extend DangerousMemberUsagesAnalyzer to support custom DangerousMethod and DangerousProperty

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
@@ -147,7 +147,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 		}
 
 		private bool IsDangerousMemberAttribute( ISymbol memberSymbol, INamedTypeSymbol dangerousMemberType ) {
-			return memberSymbol.GetAttributes().Where( attr => attr.AttributeClass.Equals( dangerousMemberType, SymbolEqualityComparer.Default ) ).Any();
+			return memberSymbol.GetAttributes().Any( attr => attr.AttributeClass.Equals( dangerousMemberType, SymbolEqualityComparer.Default ) );
 		}
 
 		private static bool IsDangerousMemberSymbol(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
@@ -19,7 +19,8 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 		private const string DangerousPropertyAuditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousPropertyUsage+AuditedAttribute";
 		private const string DangerousPropertyUnauditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousPropertyUsage+UnauditedAttribute";
 
-		private const string DangerousMemberFullName = "D2L.CodeStyle.Annotations.Objects+DangerousMember";
+		private const string DangerousMethodFullName = "D2L.CodeStyle.Annotations.Objects+DangerousMethod";
+		private const string DangerousPropertyFullName = "D2L.CodeStyle.Annotations.Objects+DangerousProperty";
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
 			Diagnostics.DangerousMethodsShouldBeAvoided,
@@ -45,7 +46,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 
 			INamedTypeSymbol auditedAttributeType = compilation.GetTypeByMetadataName( DangerousMethodAuditedAttributeFullName );
 			INamedTypeSymbol unauditedAttributeType = compilation.GetTypeByMetadataName( DangerousMethodUnauditedAttributeFullName );
-			INamedTypeSymbol dangerousMemberType = compilation.GetTypeByMetadataName( DangerousMemberFullName );
+			INamedTypeSymbol dangerousMemberType = compilation.GetTypeByMetadataName( DangerousMethodFullName );
 			IImmutableSet<ISymbol> dangerousMethods = GetDangerousMethods( compilation );
 
 			context.RegisterSyntaxNodeAction(
@@ -64,7 +65,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 
 			INamedTypeSymbol auditedAttributeType = compilation.GetTypeByMetadataName( DangerousPropertyAuditedAttributeFullName );
 			INamedTypeSymbol unauditedAttributeType = compilation.GetTypeByMetadataName( DangerousPropertyUnauditedAttributeFullName );
-			INamedTypeSymbol dangerousMemberType = compilation.GetTypeByMetadataName( DangerousMemberFullName );
+			INamedTypeSymbol dangerousMemberType = compilation.GetTypeByMetadataName( DangerousPropertyFullName );
 			IImmutableSet<ISymbol> dangerousProperties = GetDangerousProperties( compilation );
 
 			context.RegisterSyntaxNodeAction(

--- a/src/D2L.CodeStyle.Annotations/Objects/DangerousMember.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/DangerousMember.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace D2L.CodeStyle.Annotations {
+	public static partial class Objects {
+
+		[AttributeUsage( validOn: AttributeTargets.Method )]
+		public sealed class DangerousMember : Attribute { }
+	}
+}

--- a/src/D2L.CodeStyle.Annotations/Objects/DangerousMethod.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/DangerousMethod.cs
@@ -4,6 +4,7 @@ namespace D2L.CodeStyle.Annotations {
 	public static partial class Objects {
 
 		[AttributeUsage( validOn: AttributeTargets.Method )]
-		public sealed class DangerousMember : Attribute { }
+		public sealed class DangerousMethod : Attribute { }
+
 	}
 }

--- a/src/D2L.CodeStyle.Annotations/Objects/DangerousProperty.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/DangerousProperty.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace D2L.CodeStyle.Annotations {
+	public static partial class Objects {
+
+		[AttributeUsage( validOn: AttributeTargets.Property )]
+		public sealed class DangerousProperty : Attribute { }
+	}
+}

--- a/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
+++ b/src/D2L.CodeStyle.Annotations/Objects/Immutable.cs
@@ -2,7 +2,7 @@
 
 // ReSharper disable once CheckNamespace
 namespace D2L.CodeStyle.Annotations {
-	public static class Objects {
+	public static partial class Objects {
 
 		public abstract class ImmutableAttributeBase : Attribute {}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/DangerousMemberUsagesAnalyzer.DangerousMember.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/DangerousMemberUsagesAnalyzer.DangerousMember.cs
@@ -1,0 +1,58 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages.DangerousMemberUsagesAnalyzer
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpecTests{
+	public class SketchyClass {
+		[D2L.CodeStyle.Annotations.Objects.DangerousProperty]
+		public int DangerousProperty { get; }
+
+		[D2L.CodeStyle.Annotations.Objects.DangerousProperty]
+		public int PropertyDefinedButNotUsed { get; }
+
+		public int OkayProperty { get; }
+
+		[D2L.CodeStyle.Annotations.Objects.DangerousMethod]
+		public void DangerousMethod();
+
+		public void OkayMethod();
+	}
+
+	public class 🦝 {
+		public void/* DangerousMethodsShouldBeAvoided(SpecTests.SketchyClass.DangerousMethod) */ MethodCallingDangerousMethod(/**/SketchyClass w) {
+			w.DangerousMethod();
+		}
+
+		public void MethodCallingOkayMethod( SketchyClass w ) {
+			w.OkayMethod();
+        }
+
+		public int/* DangerousPropertiesShouldBeAvoided(SpecTests.SketchyClass.DangerousProperty) */ MethodCallingDangerousProperty(/**/ SketchyClass w ) {
+			return w.DangerousProperty;
+        }
+
+		[D2L.CodeStyle.Annotations.DangerousMethodUsage.Audited( declaringType:typeof(SketchyClass), methodName:"DangerousMethod", owner:"me", auditedDate:"today", rationale: "wow" )]
+		public void AuditedMethodCallingDangerousMethod( SketchyClass w ) {
+			w.DangerousMethod();
+		}
+
+		[D2L.CodeStyle.Annotations.DangerousMethodUsage.Unaudited( declaringType: typeof(SketchyClass), methodName: "DangerousMethod" )]
+		public void UnauditedMethodCallingDangerousMethod( SketchyClass w ) {
+			w.DangerousMethod();
+		}
+
+		[D2L.CodeStyle.Annotations.DangerousPropertyUsage.Audited( declaringType:typeof(SketchyClass), propertyName: "DangerousProperty", owner:"me", auditedDate:"today", rationale: "wow" )]
+		public int AuditedMethodCallingDangerousProperty( SketchyClass w ) {
+			return w.DangerousProperty;
+		}
+
+		[D2L.CodeStyle.Annotations.DangerousPropertyUsage.Unaudited( declaringType:typeof(SketchyClass), propertyName: "DangerousProperty" )]
+		public int UnauditedMethodCallingDangerousProperty( SketchyClass w ) {
+			return w.DangerousProperty;
+		}
+	}
+}


### PR DESCRIPTION
Right now, if we want discourage usage of a particular method such as [ITypeResolver.TryResolveType()](https://code.d2l.dev/#D2L.LP/LP/Extensibility/TypeResolution/ITypeResolver.cs,11) we either have to use the inaccurate [Obsolete](https://docs.microsoft.com/en-us/dotnet/api/system.obsoleteattribute?view=net-5.0) or make a code change to this repo. This is an attempt to resolve that by using the existing `DangerousMethodUsage` and `DangerousPropertyUsage` classes to audit usages of them

This PR allows us to attach `[DangerousMethod]` attribute to a method (and `[DangerousProperty]` to properties) that would fail builds unless accompanied by `[DangerousMethodUsage.Audited()]` (or unaudited)

Ref: https://github.com/Brightspace/lms/issues/11891