### PR TITLE
remove GetSemanticModel usage from JsonParamBinderAnalyzer

### DIFF
--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/JsonParamBinderAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/JsonParamBinderAnalyzer.cs
@@ -39,4 +39,10 @@ namespace SpecTests {
 
 	}
 
+	public class /* UnnecessaryAllowedListEntry(SpecTests.AllowedClass2\, JsonParamBinderAnalyzer, LegacyJsonParamBinderAllowedList.txt) */ AllowedClass2 /**/ {
+
+		public void Test( int x ) { }
+
+	}
+
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/TestAllowedLists/LegacyJsonParamBinderAllowedList.txt
+++ b/tests/D2L.CodeStyle.Analyzers.Test/TestAllowedLists/LegacyJsonParamBinderAllowedList.txt
@@ -1,1 +1,2 @@
 ﻿SpecTests.AllowedClass, JsonParamBinderAnalyzer
+SpecTests.AllowedClass2, JsonParamBinderAnalyzer


### PR DESCRIPTION
`Warning	RS1030	Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer`