### PR TITLE
cleanup warning about different tuple names

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -606,9 +606,9 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					// properties. init-only properties can be overwritten by
 					// callers (rather than just constructors) which are well
 					// outside the scope of our analysis.
-					isInitOnly ? null : prop.Initializer?.Value,
+					Initializer: isInitOnly ? null : prop.Initializer?.Value,
 
-					prop.IsAutoImplemented(),
+					IsAutoImplemented: prop.IsAutoImplemented(),
 					isReadOnly
 				),
 				ParameterSyntax param => (


### PR DESCRIPTION
(name differs from the other side of the switch):

```csharp
				ParameterSyntax param => (
					param.Type,
					param.Identifier,
					// We never care about initializers for these types of
					// properties because they are always init-only and can
					// be overwritten by any caller.
					Initializer: null,
					IsAutoImplemented: true,
					isReadOnly
				),
```