### PR TITLE
Handling getter/setter style classes with multiple constructors

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerAnalyzer.cs
@@ -87,11 +87,8 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 				INamedTypeSymbol type
 			) {
 
-			ImmutableArray<IMethodSymbol> constructors = type.InstanceConstructors;
-
-			ImmutableArray<IMethodSymbol> publicConstructors = constructors
-				.Where( c => c.DeclaredAccessibility == Accessibility.Public )
-				.ToImmutableArray();
+			ImmutableArray<IMethodSymbol> publicConstructors = model
+				.GetOrderedPublicInstanceConstructors( type );
 
 			if( publicConstructors.IsEmpty ) {
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerModel.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 
-		internal sealed class ReflectionSerializerModel {
+	internal sealed class ReflectionSerializerModel {
 
 		private readonly INamedTypeSymbol m_ignoreAttributeType;
 		private readonly INamedTypeSymbol m_reflectionSerializerAttributeType;
@@ -18,6 +18,28 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 
 			m_ignoreAttributeType = ignoreAttributeType;
 			m_reflectionSerializerAttributeType = reflectionSerializerAttributeType;
+		}
+
+		public ImmutableArray<IMethodSymbol> GetOrderedPublicInstanceConstructors( INamedTypeSymbol type ) {
+
+			var builder = ImmutableArray.CreateBuilder<IMethodSymbol>();
+
+			foreach( IMethodSymbol constructor in type.InstanceConstructors ) {
+
+				if( constructor.DeclaredAccessibility == Accessibility.Public ) {
+
+					if( constructor.Parameters.IsEmpty ) {
+
+						// empty constructor takes priority over all others
+						builder.Insert( 0, constructor );
+
+					} else {
+						builder.Add( constructor );
+					}
+				}
+			}
+
+			return builder.ToImmutable();
 		}
 
 		public ImmutableHashSet<string> GetPublicReadablePropertyNames( INamedTypeSymbol type ) {

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -6,7 +6,7 @@
     <Title>D2L.CodeStyle.Analyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle analyzers</Description>
-    <Version>0.176.0</Version>
+    <Version>0.176.1</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Brightspace/D2L.CodeStyle</PackageProjectUrl>
     <Authors>D2L</Authors>

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -6,7 +6,7 @@
     <Title>D2L.CodeStyle.Analyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle analyzers</Description>
-    <Version>0.176.1</Version>
+    <Version>0.177.0</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Brightspace/D2L.CodeStyle</PackageProjectUrl>
     <Authors>D2L</Authors>

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ReflectionSerializerAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ReflectionSerializerAnalyzer.cs
@@ -80,7 +80,7 @@ namespace SpecTests {
 				X = value;
 			}
 			public int X { get; }
-        }
+		}
 
 		[ReflectionSerializer]
 		public sealed class ParameterCannotBeDeserialized_And_MultipleConstructors {
@@ -109,7 +109,7 @@ namespace SpecTests {
 
 		[ReflectionSerializer]
 		public static class /* ReflectionSerializer_StaticClass() */ Static /**/ { }
-		
+
 		[ReflectionSerializer]
 		public sealed class OutputParameterNotSupported {
 			public OutputParameterNotSupported(
@@ -117,17 +117,37 @@ namespace SpecTests {
 			) {
 				value = 1;
 			}
-        }
-		
+		}
+
 		[ReflectionSerializer]
 		public sealed class RefParameterNotSupported {
 			public RefParameterNotSupported(
 				ref int /* ReflectionSerializer_ConstructorParameter_InvalidRefKind(value,ref) */ value /**/
 			) { }
-        }
+		}
+
+		[ReflectionSerializer]
+		public sealed class GetterSetter_WithMultipleConstructors {
+
+			public /* ReflectionSerializer_MultiplePublicConstructors() */ GetterSetter_WithMultipleConstructors /**/ ( int x )
+				: this( x: x, y: 0 ) {
+			}
+
+			public GetterSetter_WithMultipleConstructors()
+				: this( x: 0, y: 0 ) {
+			}
+
+			public /* ReflectionSerializer_MultiplePublicConstructors() */ GetterSetter_WithMultipleConstructors /**/ ( int x, int y ) {
+				X = x;
+				Y = y;
+			}
+
+			public int X { get; set; }
+			public int Y { get; set; }
+		}
 	}
 
-    namespace Records {
+	namespace Records {
 
 		[ReflectionSerializer]
 		public sealed record Empty();
@@ -181,15 +201,15 @@ namespace SpecTests {
 		}
 
 		[ReflectionSerializer]
-		public sealed partial record PartialPrimaryAndPublicConstructorWithPrimaryAttributed ( int X, int Y );
+		public sealed partial record PartialPrimaryAndPublicConstructorWithPrimaryAttributed( int X, int Y );
 		public sealed partial record PartialPrimaryAndPublicConstructorWithPrimaryAttributed {
-			public /* ReflectionSerializer_MultiplePublicConstructors() */ PartialPrimaryAndPublicConstructorWithPrimaryAttributed /**/ (int x ) : this( X: x, Y: 0 ) { }
+			public /* ReflectionSerializer_MultiplePublicConstructors() */ PartialPrimaryAndPublicConstructorWithPrimaryAttributed /**/ ( int x ) : this( X: x, Y: 0 ) { }
 		}
 
 		public sealed partial record PartialPrimaryAndPublicConstructorWithPublicAttributed( int X, int Y );
 		[ReflectionSerializer]
 		public sealed partial record PartialPrimaryAndPublicConstructorWithPublicAttributed {
-			public /* ReflectionSerializer_MultiplePublicConstructors() */ PartialPrimaryAndPublicConstructorWithPublicAttributed /**/(int x ) : this( X: x, Y: 0 ) { }
+			public /* ReflectionSerializer_MultiplePublicConstructors() */ PartialPrimaryAndPublicConstructorWithPublicAttributed /**/( int x ) : this( X: x, Y: 0 ) { }
 		}
 
 		[ReflectionSerializer]


### PR DESCRIPTION
`ReflectionSerializer` always uses public empty constructor if it exists:

![image](https://user-images.githubusercontent.com/12101120/149269654-6f4c5521-4d14-4b77-8975-4ce0fb81df96.png)

* https://github.com/Brightspace/lms/blob/a69ed5a503707fbc149ded87e39656e3ec93edeb/lp/framework/core/D2L.LP/LP/Serialization/Reflection/Default/ReflectionSerializer.cs#L128
* https://github.com/Brightspace/lms/blob/a69ed5a503707fbc149ded87e39656e3ec93edeb/lp/framework/core/D2L.LP/LP/Serialization/Default/Json/JsonSerializationReader.cs#L66
* https://github.com/Brightspace/lms/blob/a69ed5a503707fbc149ded87e39656e3ec93edeb/lp/framework/core/D2L.LP/LP/Serialization/Activation/Default/Activator.cs#L36
* https://github.com/Brightspace/lms/blob/a69ed5a503707fbc149ded87e39656e3ec93edeb/lp/framework/core/D2L.LP/LP/Serialization/Activation/Default/Activator.cs#L49