### PR TITLE
Dangerous member usages analyzer rewrite

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
@@ -62,7 +62,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			}
 		}
 
-		private void AnalyzeMethod(
+		private static void AnalyzeMethod(
 				OperationAnalysisContext context,
 				DangerousMembersModel model,
 				IMethodSymbol method
@@ -75,7 +75,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			ReportDiagnostic( context, method, Diagnostics.DangerousMethodsShouldBeAvoided );
 		}
 
-		private void AnalyzeProperty(
+		private static void AnalyzeProperty(
 				OperationAnalysisContext context,
 				DangerousMembersModel model,
 				IPropertySymbol property
@@ -88,7 +88,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			ReportDiagnostic( context, property, Diagnostics.DangerousPropertiesShouldBeAvoided );
 		}
 
-		private void ReportDiagnostic(
+		private static void ReportDiagnostic(
 				OperationAnalysisContext context,
 				ISymbol memberSymbol,
 				DiagnosticDescriptor diagnosticDescriptor

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
@@ -44,9 +44,17 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			context.RegisterOperationAction(
 					ctxt => {
 						IInvocationOperation invocation = (IInvocationOperation)ctxt.Operation;
-						AnalyzeMethodInvocation( ctxt, invocation, auditedAttributeType, unauditedAttributeType, dangerousMethods );
+						AnalyzeMethod( ctxt, invocation.TargetMethod, auditedAttributeType, unauditedAttributeType, dangerousMethods );
 					},
 					OperationKind.Invocation
+				);
+
+			context.RegisterOperationAction(
+					ctxt => {
+						IMethodReferenceOperation operation = (IMethodReferenceOperation)ctxt.Operation;
+						AnalyzeMethod( ctxt, operation.Method, auditedAttributeType, unauditedAttributeType, dangerousMethods );
+					},
+					OperationKind.MethodReference
 				);
 		}
 
@@ -67,21 +75,19 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 				);
 		}
 
-		private void AnalyzeMethodInvocation(
+		private void AnalyzeMethod(
 				OperationAnalysisContext context,
-				IInvocationOperation invocation,
+				IMethodSymbol method,
 				INamedTypeSymbol auditedAttributeType,
 				INamedTypeSymbol unauditedAttributeType,
 				IImmutableSet<ISymbol> dangerousMethods
 			) {
 
-			IMethodSymbol targetMethod = invocation.TargetMethod;
-
-			if( !AnalyzePotentiallyDangerousMember( context, targetMethod, auditedAttributeType, unauditedAttributeType, dangerousMethods ) ) {
+			if( !AnalyzePotentiallyDangerousMember( context, method, auditedAttributeType, unauditedAttributeType, dangerousMethods ) ) {
 				return;
 			}
 
-			ReportDiagnostic( context, targetMethod, Diagnostics.DangerousMethodsShouldBeAvoided );
+			ReportDiagnostic( context, method, Diagnostics.DangerousMethodsShouldBeAvoided );
 		}
 
 		private void AnalyzePropertyReference(
@@ -263,6 +269,5 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 
 			return builder.ToImmutable();
 		}
-
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
@@ -34,17 +34,17 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			if( model.HasMethods ) {
 
 				context.RegisterOperationAction(
-						ctxt => {
-							IInvocationOperation invocation = (IInvocationOperation)ctxt.Operation;
-							AnalyzeMethod( ctxt, model, invocation.TargetMethod );
+						context => {
+							IInvocationOperation invocation = (IInvocationOperation)context.Operation;
+							AnalyzeMethod( context, model, invocation.TargetMethod );
 						},
 						OperationKind.Invocation
 					);
 
 				context.RegisterOperationAction(
-						ctxt => {
-							IMethodReferenceOperation operation = (IMethodReferenceOperation)ctxt.Operation;
-							AnalyzeMethod( ctxt, model, operation.Method );
+						context => {
+							IMethodReferenceOperation operation = (IMethodReferenceOperation)context.Operation;
+							AnalyzeMethod( context, model, operation.Method );
 						},
 						OperationKind.MethodReference
 					);
@@ -53,9 +53,9 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			if( model.HasProperties ) {
 
 				context.RegisterOperationAction(
-						ctxt => {
-							IPropertyReferenceOperation propertyReference = (IPropertyReferenceOperation)ctxt.Operation;
-							AnalyzeProperty( ctxt, model, propertyReference.Property );
+						context => {
+							IPropertyReferenceOperation propertyReference = (IPropertyReferenceOperation)context.Operation;
+							AnalyzeProperty( context, model, propertyReference.Property );
 						},
 						OperationKind.PropertyReference
 					);

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Immutable;
-using D2L.CodeStyle.Analyzers.Extensions;
+﻿#nullable enable
+
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -8,12 +9,6 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 
 	[DiagnosticAnalyzer( LanguageNames.CSharp )]
 	internal sealed class DangerousMemberUsagesAnalyzer : DiagnosticAnalyzer {
-
-		private const string DangerousMethodAuditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousMethodUsage+AuditedAttribute";
-		private const string DangerousMethodUnauditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousMethodUsage+UnauditedAttribute";
-
-		private const string DangerousPropertyAuditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousPropertyUsage+AuditedAttribute";
-		private const string DangerousPropertyUnauditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousPropertyUsage+UnauditedAttribute";
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
 			Diagnostics.DangerousMethodsShouldBeAvoided,
@@ -29,168 +24,68 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 
 		private void RegisterAnalysis( CompilationStartAnalysisContext context ) {
 
-			RegisterDangerousMethodAnalysis( context );
-			RegisterDangerousPropertyAnalysis( context );
-		}
-
-		private void RegisterDangerousMethodAnalysis( CompilationStartAnalysisContext context ) {
-
 			Compilation compilation = context.Compilation;
 
-			INamedTypeSymbol auditedAttributeType = compilation.GetTypeByMetadataName( DangerousMethodAuditedAttributeFullName );
-			INamedTypeSymbol unauditedAttributeType = compilation.GetTypeByMetadataName( DangerousMethodUnauditedAttributeFullName );
-			IImmutableSet<ISymbol> dangerousMethods = GetDangerousMethods( compilation );
+			DangerousMembersModel? model = DangerousMembersModel.TryCreate( compilation );
+			if( model == null ) {
+				return;
+			}
 
-			context.RegisterOperationAction(
-					ctxt => {
-						IInvocationOperation invocation = (IInvocationOperation)ctxt.Operation;
-						AnalyzeMethod( ctxt, invocation.TargetMethod, auditedAttributeType, unauditedAttributeType, dangerousMethods );
-					},
-					OperationKind.Invocation
-				);
+			if( model.HasMethods ) {
 
-			context.RegisterOperationAction(
-					ctxt => {
-						IMethodReferenceOperation operation = (IMethodReferenceOperation)ctxt.Operation;
-						AnalyzeMethod( ctxt, operation.Method, auditedAttributeType, unauditedAttributeType, dangerousMethods );
-					},
-					OperationKind.MethodReference
-				);
-		}
+				context.RegisterOperationAction(
+						ctxt => {
+							IInvocationOperation invocation = (IInvocationOperation)ctxt.Operation;
+							AnalyzeMethod( ctxt, model, invocation.TargetMethod );
+						},
+						OperationKind.Invocation
+					);
 
-		private void RegisterDangerousPropertyAnalysis( CompilationStartAnalysisContext context ) {
+				context.RegisterOperationAction(
+						ctxt => {
+							IMethodReferenceOperation operation = (IMethodReferenceOperation)ctxt.Operation;
+							AnalyzeMethod( ctxt, model, operation.Method );
+						},
+						OperationKind.MethodReference
+					);
+			}
 
-			Compilation compilation = context.Compilation;
+			if( model.HasProperties ) {
 
-			INamedTypeSymbol auditedAttributeType = compilation.GetTypeByMetadataName( DangerousPropertyAuditedAttributeFullName );
-			INamedTypeSymbol unauditedAttributeType = compilation.GetTypeByMetadataName( DangerousPropertyUnauditedAttributeFullName );
-			IImmutableSet<ISymbol> dangerousProperties = GetDangerousProperties( compilation );
-
-			context.RegisterOperationAction(
-					ctxt => {
-						IPropertyReferenceOperation propertyReference = (IPropertyReferenceOperation)ctxt.Operation;
-						AnalyzePropertyReference( ctxt, propertyReference, auditedAttributeType, unauditedAttributeType, dangerousProperties );
-					},
-					OperationKind.PropertyReference
-				);
+				context.RegisterOperationAction(
+						ctxt => {
+							IPropertyReferenceOperation propertyReference = (IPropertyReferenceOperation)ctxt.Operation;
+							AnalyzeProperty( ctxt, model, propertyReference.Property );
+						},
+						OperationKind.PropertyReference
+					);
+			}
 		}
 
 		private void AnalyzeMethod(
 				OperationAnalysisContext context,
-				IMethodSymbol method,
-				INamedTypeSymbol auditedAttributeType,
-				INamedTypeSymbol unauditedAttributeType,
-				IImmutableSet<ISymbol> dangerousMethods
+				DangerousMembersModel model,
+				IMethodSymbol method
 			) {
 
-			if( !AnalyzePotentiallyDangerousMember( context, method, auditedAttributeType, unauditedAttributeType, dangerousMethods ) ) {
+			if( !model.IsDangerousMethod( context.ContainingSymbol, method ) ) {
 				return;
 			}
 
 			ReportDiagnostic( context, method, Diagnostics.DangerousMethodsShouldBeAvoided );
 		}
 
-		private void AnalyzePropertyReference(
+		private void AnalyzeProperty(
 				OperationAnalysisContext context,
-				IPropertyReferenceOperation propertyReference,
-				INamedTypeSymbol auditedAttributeType,
-				INamedTypeSymbol unauditedAttributeType,
-				IImmutableSet<ISymbol> dangerousProperties
+				DangerousMembersModel model,
+				IPropertySymbol property
 			) {
 
-			IPropertySymbol property = propertyReference.Property;
-
-			if( !AnalyzePotentiallyDangerousMember( context, property, auditedAttributeType, unauditedAttributeType, dangerousProperties ) ) {
+			if( !model.IsDangerousProperty( context.ContainingSymbol, property ) ) {
 				return;
 			}
 
 			ReportDiagnostic( context, property, Diagnostics.DangerousPropertiesShouldBeAvoided );
-		}
-
-		private bool AnalyzePotentiallyDangerousMember(
-				OperationAnalysisContext context,
-				ISymbol memberSymbol,
-				INamedTypeSymbol auditedAttributeType,
-				INamedTypeSymbol unauditedAttributeType,
-				IImmutableSet<ISymbol> dangerousMembers
-			) {
-
-			if( memberSymbol.IsNullOrErrorType() ) {
-				return false;
-			}
-
-			if( !IsDangerousMemberSymbol( memberSymbol, dangerousMembers ) ) {
-				return false;
-			}
-
-			bool isAudited = context.ContainingSymbol
-				.GetAttributes()
-				.Any( attr => IsAuditedAttribute( auditedAttributeType, unauditedAttributeType, attr, memberSymbol ) );
-
-			if( isAudited ) {
-				return false;
-			}
-
-			return true;
-		}
-
-		private static bool IsDangerousMemberSymbol(
-				ISymbol memberSymbol,
-				IImmutableSet<ISymbol> dangerousMembers
-			) {
-
-			ISymbol originalDefinition = memberSymbol.OriginalDefinition;
-
-			if( dangerousMembers.Contains( originalDefinition ) ) {
-				return true;
-			}
-
-			if( !memberSymbol.Equals( originalDefinition, SymbolEqualityComparer.Default ) ) {
-
-				if( dangerousMembers.Contains( memberSymbol ) ) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		private static bool IsAuditedAttribute(
-				INamedTypeSymbol auditedAttributeType,
-				INamedTypeSymbol unauditedAttributeType,
-				AttributeData attr,
-				ISymbol memberSymbol
-			) {
-
-			bool isAudited = (
-					attr.AttributeClass.Equals( auditedAttributeType, SymbolEqualityComparer.Default )
-					|| attr.AttributeClass.Equals( unauditedAttributeType, SymbolEqualityComparer.Default )
-				);
-			if( !isAudited ) {
-				return false;
-			}
-
-			if( attr.ConstructorArguments.Length < 2 ) {
-				return false;
-			}
-
-			TypedConstant typeArg = attr.ConstructorArguments[ 0 ];
-			if( typeArg.Value == null ) {
-				return false;
-			}
-			if( !memberSymbol.ContainingType.Equals( typeArg.Value ) ) {
-				return false;
-			}
-
-			TypedConstant nameArg = attr.ConstructorArguments[ 1 ];
-			if( nameArg.Value == null ) {
-				return false;
-			}
-			if( !memberSymbol.Name.Equals( nameArg.Value ) ) {
-				return false;
-			}
-
-			return true;
 		}
 
 		private void ReportDiagnostic(
@@ -216,58 +111,5 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 				localOptions: SymbolDisplayLocalOptions.IncludeType,
 				typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces
 			);
-
-		private static IImmutableSet<ISymbol> GetDangerousMethods( Compilation compilation ) {
-
-			ImmutableHashSet<ISymbol>.Builder builder = ImmutableHashSet.CreateBuilder( SymbolEqualityComparer.Default );
-
-			foreach( KeyValuePair<string, ImmutableArray<string>> pairs in DangerousMethods.Definitions ) {
-
-				INamedTypeSymbol type = compilation.GetTypeByMetadataName( pairs.Key );
-				if( type != null ) {
-
-					foreach( string name in pairs.Value ) {
-
-						IEnumerable<ISymbol> methods = type
-							.GetMembers( name )
-							.Where( m => (
-								m.Kind == SymbolKind.Method
-								|| m.Kind == SymbolKind.Property
-							) );
-
-						foreach( ISymbol method in methods ) {
-							builder.Add( method );
-						}
-					}
-				}
-			}
-
-			return builder.ToImmutable();
-		}
-
-		private static IImmutableSet<ISymbol> GetDangerousProperties( Compilation compilation ) {
-
-			ImmutableHashSet<ISymbol>.Builder builder = ImmutableHashSet.CreateBuilder( SymbolEqualityComparer.Default );
-
-			foreach( KeyValuePair<string, ImmutableArray<string>> pairs in DangerousProperties.Definitions ) {
-
-				INamedTypeSymbol type = compilation.GetTypeByMetadataName( pairs.Key );
-				if( type != null ) {
-
-					foreach( string name in pairs.Value ) {
-
-						IEnumerable<ISymbol> properties = type
-							.GetMembers( name )
-							.Where( m => ( m.Kind == SymbolKind.Property ) );
-
-						foreach( ISymbol property in properties ) {
-							builder.Add( property );
-						}
-					}
-				}
-			}
-
-			return builder.ToImmutable();
-		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -95,7 +95,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 				return false;
 			}
 
-			bool isAuditAttribute = auditAttributes.IsOneOf( attributeClass );
+			bool isAuditAttribute = auditAttributes.Contains( attributeClass );
 			if( !isAuditAttribute ) {
 				return false;
 			}
@@ -215,7 +215,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 				INamedTypeSymbol? Unaudited
 			) {
 
-			public bool IsOneOf( INamedTypeSymbol attribute ) {
+			public bool Contains( INamedTypeSymbol attribute ) {
 
 				if( attribute.Equals( Audited, SymbolEqualityComparer.Default ) ) {
 					return true;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -95,8 +95,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 				return false;
 			}
 
-			bool isAuditAttribute = auditAttributes.Contains( attributeClass );
-			if( !isAuditAttribute ) {
+			if( !auditAttributes.Contains( attributeClass ) ) {
 				return false;
 			}
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -89,7 +89,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			return false;
 		}
 
-		private bool IsAuditAttribute(
+		private static bool IsAuditAttribute(
 				ISymbol member,
 				AttributeData attribute,
 				AuditAttributePair auditAttributes

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System.Collections.Immutable;
+using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
@@ -189,7 +190,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			foreach( KeyValuePair<string, ImmutableArray<string>> pairs in definitions ) {
 
 				INamedTypeSymbol? type = compilation.GetTypeByMetadataName( pairs.Key );
-				if( type == null ) {
+				if( type.IsNullOrErrorType() ) {
 					continue;
 				}
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -70,17 +70,17 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			return true;
 		}
 
-		private bool IsWellKnownDangerousMember( ISymbol memberSymbol ) {
+		private bool IsWellKnownDangerousMember( ISymbol member ) {
 
-			ISymbol originalDefinition = memberSymbol.OriginalDefinition;
+			ISymbol originalDefinition = member.OriginalDefinition;
 
 			if( m_dangerousMembers.Contains( originalDefinition ) ) {
 				return true;
 			}
 
-			if( !memberSymbol.Equals( originalDefinition, SymbolEqualityComparer.Default ) ) {
+			if( !member.Equals( originalDefinition, SymbolEqualityComparer.Default ) ) {
 
-				if( m_dangerousMembers.Contains( memberSymbol ) ) {
+				if( m_dangerousMembers.Contains( member ) ) {
 					return true;
 				}
 			}

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -8,11 +8,6 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 
 	internal sealed class DangerousMembersModel {
 
-		private readonly record struct AuditAttributePair(
-				INamedTypeSymbol? Audited,
-				INamedTypeSymbol? Unaudited
-			);
-
 		private const string DangerousMethodAuditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousMethodUsage+AuditedAttribute";
 		private const string DangerousMethodUnauditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousMethodUsage+UnauditedAttribute";
 
@@ -96,15 +91,12 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			) {
 
 			INamedTypeSymbol? attributeClass = attribute.AttributeClass;
-			if( attributeClass == null ) {
+			if( attributeClass.IsNullOrErrorType() ) {
 				return false;
 			}
 
-			bool isAudited = (
-					attributeClass.Equals( auditAttributes.Audited, SymbolEqualityComparer.Default )
-					|| attributeClass.Equals( auditAttributes.Unaudited, SymbolEqualityComparer.Default )
-				);
-			if( !isAudited ) {
+			bool isAuditAttribute = auditAttributes.IsOneOf( attributeClass );
+			if( !isAuditAttribute ) {
 				return false;
 			}
 
@@ -216,6 +208,25 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			}
 
 			return builder.ToImmutable();
+		}
+
+		private readonly record struct AuditAttributePair(
+				INamedTypeSymbol? Audited,
+				INamedTypeSymbol? Unaudited
+			) {
+
+			public bool IsOneOf( INamedTypeSymbol attribute ) {
+
+				if( attribute.Equals( Audited, SymbolEqualityComparer.Default ) ) {
+					return true;
+				}
+
+				if( attribute.Equals( Unaudited, SymbolEqualityComparer.Default ) ) {
+					return true;
+				}
+
+				return false;
+			}
 		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -168,15 +168,14 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			) {
 
 			var builder = ImmutableHashSet.CreateBuilder<ISymbol>( SymbolEqualityComparer.Default );
+			hasMethods = false;
+			hasProperties = false;
 
 			IEnumerable<KeyValuePair<string, ImmutableArray<string>>> definitions = Enumerable
 				.Concat(
 					DangerousMethods.Definitions,
 					DangerousProperties.Definitions
 				);
-
-			hasMethods = false;
-			hasProperties = false;
 
 			foreach( KeyValuePair<string, ImmutableArray<string>> pairs in definitions ) {
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -1,0 +1,221 @@
+﻿#nullable enable
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
+
+	internal sealed class DangerousMembersModel {
+
+		private readonly record struct AuditAttributePair(
+				INamedTypeSymbol? Audited,
+				INamedTypeSymbol? Unaudited
+			);
+
+		private const string DangerousMethodAuditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousMethodUsage+AuditedAttribute";
+		private const string DangerousMethodUnauditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousMethodUsage+UnauditedAttribute";
+
+		private const string DangerousPropertyAuditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousPropertyUsage+AuditedAttribute";
+		private const string DangerousPropertyUnauditedAttributeFullName = "D2L.CodeStyle.Annotations.DangerousPropertyUsage+UnauditedAttribute";
+
+		private readonly ImmutableHashSet<ISymbol> m_dangerousMembers;
+		private readonly AuditAttributePair m_dangerousMethodAttributes;
+		private readonly AuditAttributePair m_dangerousPropertyAttributes;
+
+		public bool HasMethods { get; }
+		public bool HasProperties { get; }
+
+		private DangerousMembersModel(
+				ImmutableHashSet<ISymbol> dangerousMembers,
+				AuditAttributePair dangerousMethodAttributes,
+				AuditAttributePair dangerousPropertyAttributes,
+				bool hasMethods,
+				bool hasProperties
+			) {
+
+			m_dangerousMembers = dangerousMembers;
+			m_dangerousMethodAttributes = dangerousMethodAttributes;
+			m_dangerousPropertyAttributes = dangerousPropertyAttributes;
+
+			HasMethods = hasMethods;
+			HasProperties = hasProperties;
+		}
+
+		public bool IsDangerousMethod( ISymbol containingSymbol, IMethodSymbol method ) {
+			return IsDangerousMember( containingSymbol, method, m_dangerousMethodAttributes );
+		}
+
+		public bool IsDangerousProperty( ISymbol containingSymbol, IPropertySymbol property ) {
+			return IsDangerousMember( containingSymbol, property, m_dangerousPropertyAttributes );
+		}
+
+		private bool IsDangerousMember(
+				ISymbol containingSymbol,
+				ISymbol member,
+				AuditAttributePair auditAttributes
+			) {
+
+			if( !IsWellKnownDangerousMember( member ) ) {
+				return false;
+			}
+
+			ImmutableArray<AttributeData> attributes = containingSymbol.GetAttributes();
+			foreach( AttributeData attribute in attributes ) {
+
+				if( IsAuditAttribute( member, attribute, auditAttributes ) ) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		private bool IsWellKnownDangerousMember( ISymbol memberSymbol ) {
+
+			ISymbol originalDefinition = memberSymbol.OriginalDefinition;
+
+			if( m_dangerousMembers.Contains( originalDefinition ) ) {
+				return true;
+			}
+
+			if( !memberSymbol.Equals( originalDefinition, SymbolEqualityComparer.Default ) ) {
+
+				if( m_dangerousMembers.Contains( memberSymbol ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private bool IsAuditAttribute(
+				ISymbol member,
+				AttributeData attribute,
+				AuditAttributePair auditAttributes
+			) {
+
+			INamedTypeSymbol? attributeClass = attribute.AttributeClass;
+			if( attributeClass == null ) {
+				return false;
+			}
+
+			bool isAudited = (
+					attributeClass.Equals( auditAttributes.Audited, SymbolEqualityComparer.Default )
+					|| attributeClass.Equals( auditAttributes.Unaudited, SymbolEqualityComparer.Default )
+				);
+			if( !isAudited ) {
+				return false;
+			}
+
+			if( attribute.ConstructorArguments.Length < 2 ) {
+				return false;
+			}
+
+			TypedConstant typeArg = attribute.ConstructorArguments[ 0 ];
+			if( typeArg.Value == null ) {
+				return false;
+			}
+			if( !member.ContainingType.Equals( typeArg.Value ) ) {
+				return false;
+			}
+
+			TypedConstant nameArg = attribute.ConstructorArguments[ 1 ];
+			if( nameArg.Value == null ) {
+				return false;
+			}
+			if( !member.Name.Equals( nameArg.Value ) ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		public static DangerousMembersModel? TryCreate( Compilation compilation ) {
+
+			ImmutableHashSet<ISymbol> dangerousMembers = GetDangerousMembers(
+					compilation,
+					out bool hasMethods,
+					out bool hasProperties
+				);
+
+			if( dangerousMembers.IsEmpty ) {
+				return null;
+			}
+
+			INamedTypeSymbol? dangerousMethodAuditedAttribute = compilation
+				.GetTypeByMetadataName( DangerousMethodAuditedAttributeFullName );
+
+			INamedTypeSymbol? dangerousMethodUnauditedAttribute = compilation
+				.GetTypeByMetadataName( DangerousMethodUnauditedAttributeFullName );
+
+			INamedTypeSymbol? dangerousPropertyAuditedAttribute = compilation
+				.GetTypeByMetadataName( DangerousPropertyAuditedAttributeFullName );
+
+			INamedTypeSymbol? dangerousPropertyUnauditedAttribute = compilation
+				.GetTypeByMetadataName( DangerousPropertyUnauditedAttributeFullName );
+
+			return new DangerousMembersModel(
+					dangerousMembers,
+					dangerousMethodAttributes: new(
+						Audited: dangerousMethodAuditedAttribute,
+						Unaudited: dangerousMethodUnauditedAttribute
+					),
+					dangerousPropertyAttributes: new(
+						Audited: dangerousPropertyAuditedAttribute,
+						Unaudited: dangerousPropertyUnauditedAttribute
+					),
+					hasMethods: hasMethods,
+					hasProperties: hasProperties
+				);
+		}
+
+		private static ImmutableHashSet<ISymbol> GetDangerousMembers(
+				Compilation compilation,
+				out bool hasMethods,
+				out bool hasProperties
+			) {
+
+			var builder = ImmutableHashSet.CreateBuilder<ISymbol>( SymbolEqualityComparer.Default );
+
+			IEnumerable<KeyValuePair<string, ImmutableArray<string>>> definitions = Enumerable
+				.Concat(
+					DangerousMethods.Definitions,
+					DangerousProperties.Definitions
+				);
+
+			hasMethods = false;
+			hasProperties = false;
+
+			foreach( KeyValuePair<string, ImmutableArray<string>> pairs in definitions ) {
+
+				INamedTypeSymbol? type = compilation.GetTypeByMetadataName( pairs.Key );
+				if( type == null ) {
+					continue;
+				}
+
+				foreach( string name in pairs.Value ) {
+
+					ImmutableArray<ISymbol> members = type.GetMembers( name );
+					foreach( ISymbol member in members ) {
+
+						switch( member.Kind ) {
+
+							case SymbolKind.Method:
+								builder.Add( member );
+								hasMethods = true;
+								break;
+
+							case SymbolKind.Property:
+								builder.Add( member );
+								hasProperties = true;
+								break;
+						}
+					}
+				}
+			}
+
+			return builder.ToImmutable();
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMembersModel.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -30,6 +30,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="All" />
+    <PackageReference Include="Nullable" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -43,7 +43,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 			return fullyQualifiedName;
 		}
 
-		public static bool IsNullOrErrorType( [NotNullWhen( true )] this ITypeSymbol? symbol ) {
+		public static bool IsNullOrErrorType( [NotNullWhen( false )] this ITypeSymbol? symbol ) {
 			if( symbol == null ) {
 				return true;
 			}
@@ -57,7 +57,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 			return false;
 		}
 
-		public static bool IsNullOrErrorType( [NotNullWhen( true )] this ISymbol? symbol ) {
+		public static bool IsNullOrErrorType( [NotNullWhen( false )] this ISymbol? symbol ) {
 			if( symbol == null ) {
 				return true;
 			}

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿#nullable enable
+
 using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-using D2L.CodeStyle.Analyzers.Immutability;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -45,7 +43,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 			return fullyQualifiedName;
 		}
 
-		public static bool IsNullOrErrorType( this ITypeSymbol symbol ) {
+		public static bool IsNullOrErrorType( [NotNullWhen( true )] this ITypeSymbol? symbol ) {
 			if( symbol == null ) {
 				return true;
 			}
@@ -59,7 +57,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 			return false;
 		}
 
-		public static bool IsNullOrErrorType( this ISymbol symbol ) {
+		public static bool IsNullOrErrorType( [NotNullWhen( true )] this ISymbol? symbol ) {
 			if( symbol == null ) {
 				return true;
 			}
@@ -94,7 +92,7 @@ namespace D2L.CodeStyle.Analyzers.Extensions {
 		public static bool TryGetTypeByMetadataName(
 				this Compilation compilation,
 				string fullyQualifiedMetadataName,
-				out INamedTypeSymbol typeSymbol
+				[NotNullWhen( true )] out INamedTypeSymbol? typeSymbol
 			) {
 
 			typeSymbol = compilation.GetTypeByMetadataName( fullyQualifiedMetadataName );

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/DangerousMemberUsagesAnalyzer.DangerousMethods.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/DangerousMemberUsagesAnalyzer.DangerousMethods.cs
@@ -91,6 +91,11 @@ namespace SpecTests {
 		public void/* DangerousMethodsShouldBeAvoided(System.Threading.Thread.Sleep) */ MethodWithThreadSleepTimeSpan(/**/) {
 			System.Threading.Thread.Sleep( TimeSpan.FromMilliseconds( 1 ) );
 		}
+
+		public void/* DangerousMethodsShouldBeAvoided(System.Reflection.PropertyInfo.SetValue) */ MethodReference(/**/) {
+			PropertyInfo p = typeof( string ).GetProperty( nameof( string.Length ) );
+			Action<object, object, object[]> setter = p.SetValue;
+		}
 	}
 
 	internal sealed class AuditedUsages {


### PR DESCRIPTION
* Rewriting to use RegisterOperationAction
* Pulled model out of analyzer
* Added checking for passing dangerous method as a delegate