### PR TITLE
Enabling nullable by default

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/AnnotationsContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/AnnotationsContext.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/BannedConfigs.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/BannedConfigs.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/ConfigViewerAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/ConfigViewerAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/ILegacyLpContentDirectoryFullNameAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/ILegacyLpContentDirectoryFullNameAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/ILegacyLpContentFilePhysicalPathAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/ILegacyLpContentFilePhysicalPathAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/ILpContentFilePhysicalPathAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/ILpContentFilePhysicalPathAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/PhysicalPathPropertyAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/PhysicalPathPropertyAnalysis.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMethods.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMethods.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+#nullable disable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Threading;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousProperties.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousProperties.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+#nullable disable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DataRecordConverters/InterfaceBinderAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DataRecordConverters/InterfaceBinderAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/DependencyRegistrationsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/DependencyRegistrationsAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain;
 using D2L.CodeStyle.Analyzers.Extensions;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/ConfigureInstancePluginsExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/ConfigureInstancePluginsExpression.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/ConfigurePluginsExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/ConfigurePluginsExpression.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/ConfigurePluginsExtensionPointExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/ConfigurePluginsExtensionPointExpression.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistration.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistration.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {
 	internal sealed class DependencyRegistration {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistrationExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistrationExpression.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+#nullable disable
+
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistry.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/DependencyRegistry.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/FullyGenericRegisterExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/FullyGenericRegisterExpression.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/NonGenericRegisterExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/NonGenericRegisterExpression.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/RegisterPluginForExtensionPointExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/RegisterPluginForExtensionPointExpression.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/RegisterSubInterfaceExpression.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DependencyInjection/Domain/RegisterSubInterfaceExpression.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.DependencyInjection.Domain {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventHandlersDisallowedList.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventHandlersDisallowedList.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+#nullable disable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace D2L.CodeStyle.Analyzers.ApiUsage.Events {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventHandlersDisallowedListAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventHandlersDisallowedListAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+#nullable disable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Extensions;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventTypesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventTypesAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Helpers;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzerFixer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzerFixer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/LaunchDarkly/FeatureDefinitionAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/LaunchDarkly/FeatureDefinitionAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Logging/LoggingExecutionContextScopeBuilderAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Logging/LoggingExecutionContextScopeBuilderAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+#nullable disable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/NotNullAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/NotNullAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/RpcAnalyzer.IsValidParameterType.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/RpcAnalyzer.IsValidParameterType.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/RpcAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/RpcAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerModel.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerModel.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+#nullable disable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Extensions;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ServiceLocator/OldAndBrokenServiceLocatorAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ServiceLocator/OldAndBrokenServiceLocatorAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using D2L.CodeStyle.Analyzers.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ServiceLocator/SingletonLocatorAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ServiceLocator/SingletonLocatorAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/System.Collections.Immutable/ImmutableCollectionsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/System.Collections.Immutable/ImmutableCollectionsAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/D2L.CodeStyle.Analyzers/Async/BlockingAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/BlockingAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+#nullable disable
+
+using System.Linq;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/D2L.CodeStyle.Analyzers/Attributes.cs
+++ b/src/D2L.CodeStyle.Analyzers/Attributes.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 

--- a/src/D2L.CodeStyle.Analyzers/Build/MandatoryReferencesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Build/MandatoryReferencesAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/RemoveAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/RemoveAttributeCodeFix.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -17,6 +17,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <IncludeSymbols>True</IncludeSymbols>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers {
 	public static class Diagnostics {

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers {

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.CSharp.Syntax.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.CSharp.Syntax.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+#nullable disable
+
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.CSharp.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/Microsoft.CodeAnalysis.CSharp.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/D2L.CodeStyle.Analyzers/GlobalSuppressions.cs
+++ b/src/D2L.CodeStyle.Analyzers/GlobalSuppressions.cs
@@ -1,4 +1,6 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+#nullable disable
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/D2L.CodeStyle.Analyzers/GlobalSuppressions.cs
+++ b/src/D2L.CodeStyle.Analyzers/GlobalSuppressions.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/src/D2L.CodeStyle.Analyzers/Helpers/AllowedTypeList.cs
+++ b/src/D2L.CodeStyle.Analyzers/Helpers/AllowedTypeList.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.Factory.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityContext.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityQuery.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityQuery.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 
 namespace D2L.CodeStyle.Analyzers.Immutability {
 	internal readonly struct ImmutabilityQuery {

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableAttributeConsistencyChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableAttributeConsistencyChecker.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using D2L.CodeStyle.Analyzers.CommonFixes;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableDefinitionChecker.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeInfo.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeKind.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutableTypeKind.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 
 namespace D2L.CodeStyle.Analyzers.Immutability {
 	/// <summary>

--- a/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityAuditor.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/MutabilityAuditor.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+#nullable disable
+
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using static D2L.CodeStyle.Analyzers.Immutability.ImmutableDefinitionChecker;
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ReadOnlyParameterAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ReadOnlyParameterAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using D2L.CodeStyle.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/D2L.CodeStyle.Analyzers/IsExternalInit.cs
+++ b/src/D2L.CodeStyle.Analyzers/IsExternalInit.cs
@@ -1,4 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+#nullable disable
+
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // From: https://github.com/dotnet/runtime/commit/6072e4d3a7a2a1493f514cdf4be75a3d56580e84#diff-afc57cc6e9c659ebf491bc78d06cdb5b13d5a049122d8a41f744a515f493663b

--- a/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.Codefix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.Codefix.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/D2L.CodeStyle.Analyzers/Language/ClassShouldBeSealedAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/ClassShouldBeSealedAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Concurrent;
+#nullable disable
+
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/Language/DefaultValueConsistencyAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/DefaultValueConsistencyAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+#nullable disable
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/RequireNamedArgumentsAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/D2L.CodeStyle.Analyzers/Language/StructShouldBeReadonlyAnalyzer.Codefix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/StructShouldBeReadonlyAnalyzer.Codefix.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/D2L.CodeStyle.Analyzers/Language/StructShouldBeReadonlyAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/StructShouldBeReadonlyAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/D2L.CodeStyle.Analyzers/Language/UseNamedArgumentsCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/UseNamedArgumentsCodeFix.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+#nullable disable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;

--- a/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/D2L.CodeStyle.Analyzers/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+#nullable disable
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo( "D2L.CodeStyle.Analyzers.Tests" )]


### PR DESCRIPTION
Will remove existing `#nullable enable` statements in follow up PR

```
using System.Text.RegularExpressions;

Regex nullableRegex = new Regex(
		@"^\s*#nullable\s+",
		RegexOptions.Compiled | RegexOptions.Multiline
	);

IEnumerable<string> files = Directory.EnumerateFiles(
		path: @"C:\D2L\libraries\D2L.CodeStyle\src\D2L.CodeStyle.Analyzers",
		searchPattern: "*.cs",
		searchOption: SearchOption.AllDirectories
	);

foreach( string file in files ) {

	string contents = File.ReadAllText( file );

	Match m = nullableRegex.Match( contents );
	if( m.Success ) {
		continue;
	}

	string newContents = "#nullable disable\r\n\r\n" + contents;
	File.WriteAllText( file, newContents );
}
```