### PR TITLE
Jashton/report diagnostic extensions

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/ConfigViewerAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Configs/ConfigViewerAnalyzer.cs
@@ -127,12 +127,14 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Configs {
 			string configName,
 			string deprecationMessage
 		) {
-			context.ReportDiagnostic( Diagnostic.Create(
+			context.ReportDiagnostic(
 				Diagnostics.BannedConfig,
 				configNameArg.Syntax.GetLocation(),
-				configName,
-				deprecationMessage
-			) );
+				messageArgs: new[] {
+					configName,
+					deprecationMessage
+				}
+			);
 		}
 
 		private IReadOnlyDictionary<IMethodSymbol, IReadOnlyDictionary<string, string>> GetBannedConfigs(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
@@ -82,11 +82,9 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 
 			// The current parameter type cannot be marked as [Constant]
 			context.ReportDiagnostic(
-				Diagnostic.Create(
-					descriptor: Diagnostics.InvalidConstantType,
-					location: parameter.Locations.First(),
-					messageArgs: type.TypeKind
-				)
+				descriptor: Diagnostics.InvalidConstantType,
+				location: parameter.Locations.First(),
+				messageArgs: new object[] { type.TypeKind }
 			);
 		}
 
@@ -115,11 +113,9 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 
 			// Argument is not constant, so report it
 			context.ReportDiagnostic(
-				Diagnostic.Create(
-					descriptor: Diagnostics.NonConstantPassedToConstantParameter,
-					location: argument.Syntax.GetLocation(),
-					messageArgs: parameter.Name
-				)
+				descriptor: Diagnostics.NonConstantPassedToConstantParameter,
+				location: argument.Syntax.GetLocation(),
+				messageArgs: new[] { parameter.Name }
 			);
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/PhysicalPathPropertyAnalysis.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ContentPhysicalPaths/PhysicalPathPropertyAnalysis.cs
@@ -124,13 +124,12 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.ContentPhysicalPaths {
 
 			Location location = context.Node.GetLocation();
 			string memberName = memberSymbol.ToDisplayString( MemberDisplayFormat );
-			Diagnostic diagnostic = Diagnostic.Create(
+
+			context.ReportDiagnostic(
 					diagnosticDescriptor,
 					location,
-					memberName
+					messageArgs: new[] { memberName }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static readonly SymbolDisplayFormat MemberDisplayFormat = new SymbolDisplayFormat(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DangerousMemberUsages/DangerousMemberUsagesAnalyzer.cs
@@ -95,13 +95,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DangerousMemberUsages {
 			Location location = context.ContainingSymbol.Locations[ 0 ];
 			string methodName = memberSymbol.ToDisplayString( MemberDisplayFormat );
 
-			var diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					diagnosticDescriptor,
 					location,
-					methodName
+					messageArgs: new[] { methodName }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static readonly SymbolDisplayFormat MemberDisplayFormat = new SymbolDisplayFormat(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/DataRecordConverters/InterfaceBinderAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/DataRecordConverters/InterfaceBinderAnalyzer.cs
@@ -73,13 +73,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.DataRecordConverters {
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					InterfaceBinder_InterfacesOnly,
 					interfaceArgument.GetLocation(),
-					messageArgs: interfaceType.Name
+					messageArgs: new[] { interfaceType.Name }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventHandlerLoaderTypesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventHandlerLoaderTypesAnalyzer.cs
@@ -106,13 +106,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Events {
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					Diagnostics.EventTypeMissingEventAttribute,
 					invocation.Syntax.GetLocation(),
-					eventTypeSymbol.ToDisplayString()
+					messageArgs: new[] { eventTypeSymbol.ToDisplayString() }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static void InspectEventHandlerType(
@@ -130,13 +128,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Events {
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					Diagnostics.EventHandlerTypeMissingEventAttribute,
 					invocation.Syntax.GetLocation(),
-					eventHandlerSymbol.ToDisplayString()
+					messageArgs: new[] { eventHandlerSymbol.ToDisplayString() }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static IEnumerable<ISymbol> GetGenericRegisterMethods( Compilation compilation ) {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventHandlersDisallowedListAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventHandlersDisallowedListAnalyzer.cs
@@ -60,7 +60,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Events {
 				INamedTypeSymbol eventHandlerInterface
 			) {
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					descriptor: Diagnostics.EventHandlerDisallowed,
 					location: type.Locations[ 0 ],
 					additionalLocations: type.Locations.Skip( 1 ),
@@ -68,8 +68,6 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Events {
 						eventHandlerInterface.ToDisplayString()
 					}
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static ImmutableHashSet<INamedTypeSymbol> GetDisallowedEventHandlerInterfaces( Compilation compilation ) {

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventPublisherEVentTypesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventPublisherEVentTypesAnalyzer.cs
@@ -85,13 +85,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Events {
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					Diagnostics.EventTypeMissingEventAttribute,
 					invocation.Syntax.GetLocation(),
-					eventTypeSymbol.ToDisplayString()
+					messageArgs: new[] { eventTypeSymbol.ToDisplayString() }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static IEnumerable<ISymbol> GetGenericPublishMethods(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventTypesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Events/EventTypesAnalyzer.cs
@@ -67,24 +67,20 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Events {
 			bool hasImmutableAttirbute = HasAttribute( declarationType, immutableAttributeType );
 			if( !hasImmutableAttirbute ) {
 
-				Diagnostic diagnostic = Diagnostic.Create(
+				context.ReportDiagnostic(
 					Diagnostics.EventTypeMissingImmutableAttribute,
 					declaration.Identifier.GetLocation(),
-					declarationType.ToDisplayString()
+					messageArgs: new[] { declarationType.ToDisplayString() }
 				);
-
-				context.ReportDiagnostic( diagnostic );
 			}
 
 			if( declaration.Modifiers.IndexOf( SyntaxKind.SealedKeyword ) < 0 ) {
 
-				Diagnostic diagnostic = Diagnostic.Create(
+				context.ReportDiagnostic(
 					Diagnostics.EventTypeNotSealed,
 					declaration.Identifier.GetLocation(),
-					declarationType.ToDisplayString()
+					messageArgs: new[] { declarationType.ToDisplayString() }
 				);
-
-				context.ReportDiagnostic( diagnostic );
 			}
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzer.cs
@@ -81,12 +81,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.JsonParamBinderAttribute {
 			}
 
 			Location location = attribute.GetLocation();
-			Diagnostic diagnostic = Diagnostic.Create(
+
+			context.ReportDiagnostic(
 				Diagnostics.ObsoleteJsonParamBinder,
 				location
 			);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static bool AttributeIsOfDisallowedType(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/LaunchDarkly/FeatureDefinitionAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/LaunchDarkly/FeatureDefinitionAnalyzer.cs
@@ -76,13 +76,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.LaunchDarkly {
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					Diagnostics.InvalidLaunchDarklyFeatureDefinition,
 					baseTypeSyntax.GetLocation(),
-					valueType
+					messageArgs: new[] { valueType }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Logging/LoggingExecutionContextScopeBuilderAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Logging/LoggingExecutionContextScopeBuilderAnalyzer.cs
@@ -216,10 +216,10 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Logging {
 				syntaxToLocate = memberAccessSyntax.Name;
 			}
 
-			context.ReportDiagnostic( Diagnostic.Create(
+			context.ReportDiagnostic(
 				Diagnostics.LoggingContextRunAwaitable,
 				syntaxToLocate.GetLocation()
-			) );
+			);
 		}
 
 	}

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/RpcAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/RpcAnalyzer.cs
@@ -130,21 +130,21 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 		) {
 			if( rpcContext == default) {
 				context.ReportDiagnostic(
-					Diagnostic.Create( Diagnostics.RpcContextFirstArgument, method.ParameterList.GetLocation() )
+					Diagnostics.RpcContextFirstArgument, method.ParameterList.GetLocation()
 				);
 				return;
 			}
 
 			if( !rpcTypes.RpcContexts.Contains( rpcContext.Symbol.Type ) ) {
 				context.ReportDiagnostic(
-					Diagnostic.Create( Diagnostics.RpcContextFirstArgument, rpcContext.Syntax.GetLocation() )
+					Diagnostics.RpcContextFirstArgument, rpcContext.Syntax.GetLocation()
 				);
 				return;
 			}
 
 			if( IsMarkedAsDependency( rpcContext.Symbol, rpcTypes ) ) {
 				context.ReportDiagnostic(
-					Diagnostic.Create( Diagnostics.RpcContextMarkedDependency, rpcContext.Syntax.GetLocation() )
+					Diagnostics.RpcContextMarkedDependency, rpcContext.Syntax.GetLocation()
 				);
 			}
 		}
@@ -158,7 +158,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 				bool isValidParameterType = IsValidParameterType( context, parameter.Symbol.Type, rpcTypes );
 				if( !isValidParameterType ) {
 					context.ReportDiagnostic(
-						Diagnostic.Create( Diagnostics.RpcInvalidParameterType, parameter.Syntax.Type.GetLocation() )
+						Diagnostics.RpcInvalidParameterType, parameter.Syntax.Type.GetLocation()
 					);
 				}
 			}
@@ -189,7 +189,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 
 				if( IsMarkedAsDependency( parameter, rpcTypes ) ) {
 					if( parametersBuilder.Count > 0 ) {
-						context.ReportDiagnostic( Diagnostic.Create( Diagnostics.RpcArgumentSortOrder, syntax.GetLocation() ) );
+						context.ReportDiagnostic( Diagnostics.RpcArgumentSortOrder, syntax.GetLocation() );
 					}
 
 					continue;

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/ReflectionSerializerAnalyzer.cs
@@ -147,12 +147,10 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 
 			TypeDeclarationSyntax typeDeclaration = GetTypeDeclaration( context, reflectionSerializerAttribute );
 
-			Diagnostic d = Diagnostic.Create(
+			context.ReportDiagnostic(
 					ReflectionSerializer_NoPublicConstructor,
 					typeDeclaration.Identifier.GetLocation()
 				);
-
-			context.ReportDiagnostic( d );
 		}
 
 		private static void ReportMultiplePublicConstructors(
@@ -162,12 +160,10 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 
 			ConstructorDeclarationSyntax declaration = GetFirstDeclaringSyntax<ConstructorDeclarationSyntax>( context, constructor );
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 				descriptor: ReflectionSerializer_MultiplePublicConstructors,
 				location: declaration.Identifier.GetLocation()
 			);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static void ReportConstructorParameterCannotBeDeserialized(
@@ -177,13 +173,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 
 			ParameterSyntax declaration = GetFirstDeclaringSyntax<ParameterSyntax>( context, parameter );
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					descriptor: ReflectionSerializer_ConstructorParameter_CannotBeDeserialized,
 					location: declaration.Identifier.GetLocation(),
 					messageArgs: new[] { parameter.Name }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static void ReportConstructorParameterInvalidRefKind(
@@ -194,7 +188,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 
 			ParameterSyntax declaration = GetFirstDeclaringSyntax<ParameterSyntax>( context, parameter );
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					descriptor: ReflectionSerializer_ConstructorParameter_InvalidRefKind,
 					location: declaration.Identifier.GetLocation(),
 					messageArgs: new[] {
@@ -202,8 +196,6 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 						refKind.ToString().ToLowerInvariant()
 					}
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static void AnalyzeProperties(
@@ -248,12 +240,10 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 				AccessorDeclarationSyntax accessor = accessors.Accessors[i];
 				if( accessor.Kind() == SyntaxKind.InitAccessorDeclaration ) {
 
-					Diagnostic d = Diagnostic.Create(
+					context.ReportDiagnostic(
 							ReflectionSerializer_InitOnlySetter,
 							accessor.Keyword.GetLocation()
 						);
-
-					context.ReportDiagnostic( d );
 					return;
 				}
 			}
@@ -266,12 +256,10 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 
 			TypeDeclarationSyntax typeDeclaration = GetTypeDeclaration( context, reflectionSerializerAttribute );
 
-			Diagnostic d = Diagnostic.Create(
+			context.ReportDiagnostic(
 					ReflectionSerializer_StaticClass,
 					typeDeclaration.Identifier.GetLocation()
 				);
-
-			context.ReportDiagnostic( d );
 		}
 
 		private static TypeDeclarationSyntax GetTypeDeclaration(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializerAttributeAnalyzer.cs
@@ -117,13 +117,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
 				string messageArg
 			) {
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 					descriptor: Diagnostics.InvalidSerializerType,
 					location: typeArgumentSyntax.GetLocation(),
-					messageArgs: messageArg
+					messageArgs: new[] { messageArg }
 				);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private static bool DoesImplementOneOfSerializerInterfaces(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ServiceLocator/OldAndBrokenServiceLocatorAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ServiceLocator/OldAndBrokenServiceLocatorAnalyzer.cs
@@ -117,12 +117,10 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.ServiceLocator {
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 				Diagnostics.OldAndBrokenLocatorIsObsolete,
 				context.Operation.Syntax.GetLocation()
 			);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private void AnalyzeTypeUsage(
@@ -139,12 +137,10 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.ServiceLocator {
 				return;
 			}
 
-			Diagnostic diagnostic = Diagnostic.Create(
+			context.ReportDiagnostic(
 				Diagnostics.OldAndBrokenLocatorIsObsolete,
 				context.Symbol.Locations[ 0 ]
 			);
-
-			context.ReportDiagnostic( diagnostic );
 		}
 
 		private bool HasExemption(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ServiceLocator/SingletonLocatorAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ServiceLocator/SingletonLocatorAnalyzer.cs
@@ -101,11 +101,11 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.ServiceLocator {
 				return;
 			}
 
-			context.ReportDiagnostic( Diagnostic.Create(
+			context.ReportDiagnostic(
 				descriptor: Diagnostics.SingletonLocatorMisuse,
 				location: context.Operation.Syntax.GetLocation(),
-				typeArg.GetFullTypeName()
-			) );
+				messageArgs: new[] { typeArg.GetFullTypeName() }
+			);
 		}
 
 		private static IMethodSymbol? GetSingletonLocatorGetMethod(

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/System.Collections.Immutable/ImmutableCollectionsAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/System.Collections.Immutable/ImmutableCollectionsAnalyzer.cs
@@ -65,10 +65,8 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.SystemCollectionsImmutable {
 
 			// All usages are bad
 			context.ReportDiagnostic(
-				Diagnostic.Create(
-					Diagnostics.DontUseImmutableArrayConstructor,
-					node.GetLocation()
-				)
+				Diagnostics.DontUseImmutableArrayConstructor,
+				node.GetLocation()
 			);
 		}
 	}

--- a/src/D2L.CodeStyle.Analyzers/Async/BlockingAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/BlockingAnalyzer.cs
@@ -137,13 +137,13 @@ namespace D2L.CodeStyle.Analyzers.Async {
 					var decl = methodSymbol.DeclaringSyntaxReferences.First().GetSyntax( ctx.CancellationToken ) as MethodDeclarationSyntax;
 
 					ctx.ReportDiagnostic(
-						Diagnostic.Create(
-							Diagnostics.NonBlockingImplementationOfBlockingThing,
-							decl.Identifier.GetLocation(),
-							properties: FixArgs,
+						Diagnostics.NonBlockingImplementationOfBlockingThing,
+						location: decl.Identifier.GetLocation(),
+						properties: FixArgs,
+						messageArgs: new[] {
 							$"{methodSymbol.ContainingType.Name}.{methodSymbol.Name}",
-							$"{implementedBlockingThings[0].ContainingType.Name}.{implementedBlockingThings[0].Name}"
-						)
+							$"{implementedBlockingThings[ 0 ].ContainingType.Name}.{implementedBlockingThings[ 0 ].Name}"
+						}
 					);
 					return;
 				}
@@ -155,11 +155,9 @@ namespace D2L.CodeStyle.Analyzers.Async {
 				// TODO: code fix to remove [Blocking]
 
 				ctx.ReportDiagnostic(
-					Diagnostic.Create(
-						Diagnostics.AsyncMethodCannotBeBlocking,
-						attrData.ApplicationSyntaxReference.GetSyntax( ctx.CancellationToken ).GetLocation(),
-						methodSymbol.Name
-					)
+					Diagnostics.AsyncMethodCannotBeBlocking,
+					attrData.ApplicationSyntaxReference.GetSyntax( ctx.CancellationToken ).GetLocation(),
+					messageArgs: new[] { methodSymbol.Name }
 				);
 				return;
 			}
@@ -176,13 +174,13 @@ namespace D2L.CodeStyle.Analyzers.Async {
 				// TODO: code fix to remove [Blocking]
 
 				ctx.ReportDiagnostic(
-					Diagnostic.Create(
-						Diagnostics.DontIntroduceBlockingInImplementation,
-						attrData.ApplicationSyntaxReference.GetSyntax( ctx.CancellationToken ).GetLocation(),
+					Diagnostics.DontIntroduceBlockingInImplementation,
+					attrData.ApplicationSyntaxReference.GetSyntax( ctx.CancellationToken ).GetLocation(),
+					messageArgs: new[] {
 						$"{methodSymbol.ContainingType.Name}.{methodSymbol.Name}",
 						// Just use the first one as an example:
 						$"{implementedNonBlockingThings[0].ContainingType.Name}.{implementedNonBlockingThings[0].Name}"
-					)
+					}
 				);
 				return;
 			}
@@ -233,11 +231,9 @@ namespace D2L.CodeStyle.Analyzers.Async {
 
 			if( ReturnsAwaitableValue( myMethodSymbol, asyncResultType ) ) {
 				ctx.ReportDiagnostic(
-					Diagnostic.Create(
-						Diagnostics.AsyncMethodCannotCallBlockingMethod,
-						invocation.GetLocation(),
-						invokedMethodSymbol.Name
-					)
+					Diagnostics.AsyncMethodCannotCallBlockingMethod,
+					invocation.GetLocation(),
+					messageArgs: new[] { invokedMethodSymbol.Name }
 				);
 
 				// TODO: code fix that looks for an async equivalent and suggests calling it instead.
@@ -252,14 +248,14 @@ namespace D2L.CodeStyle.Analyzers.Async {
 			}
 
 			ctx.ReportDiagnostic(
-				Diagnostic.Create(
-					Diagnostics.BlockingCallersMustBeBlocking,
-					location: invocation.GetLocation(),
-					additionalLocations: new[] { methodNameLocation },
-					properties: FixArgs,
+				Diagnostics.BlockingCallersMustBeBlocking,
+				location: invocation.GetLocation(),
+				additionalLocations: new[] { methodNameLocation },
+				properties: FixArgs,
+				messageArgs: new[] {
 					invokedMethodSymbol.Name,
 					myMethodSymbol.Name
-				)
+				}
 			);
 		}
 
@@ -285,11 +281,9 @@ namespace D2L.CodeStyle.Analyzers.Async {
 				var attr = GetAttribute( thing, blockingAttr );
 
 				ctx.ReportDiagnostic(
-					Diagnostic.Create(
-						Diagnostics.UnnecessaryBlocking,
-						attr.ApplicationSyntaxReference.GetSyntax( ctx.CancellationToken ).GetLocation(),
-						thing.Name
-					)
+					Diagnostics.UnnecessaryBlocking,
+					attr.ApplicationSyntaxReference.GetSyntax( ctx.CancellationToken ).GetLocation(),
+					messageArgs: new[] { thing.Name }
 				);
 
 				// TODO: code fix to remove blocking
@@ -356,12 +350,12 @@ namespace D2L.CodeStyle.Analyzers.Async {
 			}
 
 			ctx.ReportDiagnostic(
-				Diagnostic.Create(
-					Diagnostics.OnlyCallBlockingMethodsFromMethods,
-					invocation.GetLocation(),
+				Diagnostics.OnlyCallBlockingMethodsFromMethods,
+				invocation.GetLocation(),
+				messageArgs: new[] {
 					invokedMethodSymbol.Name,
 					place
-				)
+				}
 			);
 
 			identifierLocation = null;

--- a/src/D2L.CodeStyle.Analyzers/Async/BlockingAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/BlockingAnalyzer.cs
@@ -138,7 +138,7 @@ namespace D2L.CodeStyle.Analyzers.Async {
 
 					ctx.ReportDiagnostic(
 						Diagnostics.NonBlockingImplementationOfBlockingThing,
-						location: decl.Identifier.GetLocation(),
+						decl.Identifier.GetLocation(),
 						properties: FixArgs,
 						messageArgs: new[] {
 							$"{methodSymbol.ContainingType.Name}.{methodSymbol.Name}",

--- a/src/D2L.CodeStyle.Analyzers/Build/MandatoryReferencesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Build/MandatoryReferencesAnalyzer.cs
@@ -25,10 +25,8 @@ namespace D2L.CodeStyle.Analyzers.Build {
 
 			if ( !hasAnnotationsReference ) {
 				ctx.ReportDiagnostic(
-					Diagnostic.Create(
-						Diagnostics.MustReferenceAnnotations,
-						Location.None
-					)
+					Diagnostics.MustReferenceAnnotations,
+					Location.None
 				);
 			}
 

--- a/src/D2L.CodeStyle.Analyzers/Extensions/ReportDiagnosticExtensions.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/ReportDiagnosticExtensions.cs
@@ -1,0 +1,188 @@
+﻿using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Diagnostics {
+
+	internal static class ReportDiagnosticExtensions {
+
+		#region CompilationAnalysisContext
+
+		public static void ReportDiagnostic(
+				this CompilationAnalysisContext context,
+				DiagnosticDescriptor descriptor,
+				Location? location,
+				params object?[]? messageArgs
+			) {
+
+			ReportDiagnostic(
+					context.ReportDiagnostic,
+					descriptor,
+					location,
+					messageArgs
+				);
+		}
+
+		public static void ReportDiagnostic(
+				this CompilationAnalysisContext context,
+				DiagnosticDescriptor descriptor,
+				ImmutableArray<Location> locations,
+				params object?[]? messageArgs
+			) {
+
+			ReportDiagnostic(
+					context.ReportDiagnostic,
+					descriptor,
+					locations,
+					messageArgs
+				);
+		}
+
+		#endregion
+
+		#region OperationAnalysisContext
+
+		public static void ReportDiagnostic(
+				this OperationAnalysisContext context,
+				DiagnosticDescriptor descriptor,
+				Location? location,
+				params object?[]? messageArgs
+			) {
+
+			ReportDiagnostic(
+					context.ReportDiagnostic,
+					descriptor,
+					location,
+					messageArgs
+				);
+		}
+
+		public static void ReportDiagnostic(
+				this OperationAnalysisContext context,
+				DiagnosticDescriptor descriptor,
+				ImmutableArray<Location> locations,
+				params object?[]? messageArgs
+			) {
+
+			ReportDiagnostic(
+					context.ReportDiagnostic,
+					descriptor,
+					locations,
+					messageArgs
+				);
+		}
+
+		#endregion
+
+		#region SymbolAnalysisContext
+
+		public static void ReportDiagnostic(
+				this SymbolAnalysisContext context,
+				DiagnosticDescriptor descriptor,
+				Location? location,
+				params object?[]? messageArgs
+			) {
+
+			ReportDiagnostic(
+					context.ReportDiagnostic,
+					descriptor,
+					location,
+					messageArgs
+				);
+		}
+
+		public static void ReportDiagnostic(
+				this SymbolAnalysisContext context,
+				DiagnosticDescriptor descriptor,
+				ImmutableArray<Location> locations,
+				params object?[]? messageArgs
+			) {
+
+			ReportDiagnostic(
+					context.ReportDiagnostic,
+					descriptor,
+					locations,
+					messageArgs
+				);
+		}
+
+		#endregion
+
+		#region SyntaxNodeAnalysisContext
+
+		public static void ReportDiagnostic(
+				this SyntaxNodeAnalysisContext context,
+				DiagnosticDescriptor descriptor,
+				Location? location,
+				params object?[]? messageArgs
+			) {
+
+			ReportDiagnostic(
+					context.ReportDiagnostic,
+					descriptor,
+					location,
+					messageArgs
+				);
+		}
+
+		public static void ReportDiagnostic(
+				this SyntaxNodeAnalysisContext context,
+				DiagnosticDescriptor descriptor,
+				ImmutableArray<Location> locations,
+				params object?[]? messageArgs
+			) {
+
+			ReportDiagnostic(
+					context.ReportDiagnostic,
+					descriptor,
+					locations,
+					messageArgs
+				);
+		}
+
+		#endregion
+
+		private static void ReportDiagnostic(
+				Action<Diagnostic> sink,
+				DiagnosticDescriptor descriptor,
+				Location? location,
+				object?[]? messageArgs
+			) {
+
+			Diagnostic diagnostic = Diagnostic.Create(
+					descriptor,
+					location,
+					messageArgs
+				);
+
+			sink( diagnostic );
+		}
+
+		private static void ReportDiagnostic(
+				Action<Diagnostic> sink,
+				DiagnosticDescriptor descriptor,
+				ImmutableArray<Location> locations,
+				object?[]? messageArgs
+			) {
+
+			Location? location;
+			IEnumerable<Location> additionalLocations;
+
+			if( locations.IsEmpty ) {
+				location = null;
+				additionalLocations = Enumerable.Empty<Location>();
+
+			} else {
+				location = locations[ 0 ];
+				additionalLocations = locations.Skip( 1 );
+			}
+
+			Diagnostic diagnostic = Diagnostic.Create(
+					descriptor,
+					location,
+					additionalLocations,
+					messageArgs
+				);
+
+			sink( diagnostic );
+		}
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Extensions/ReportDiagnosticExtensions.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/ReportDiagnosticExtensions.cs
@@ -1,188 +1,113 @@
 ﻿using System.Collections.Immutable;
 
+namespace Microsoft.CodeAnalysis {
+
+	internal static class ReportDiagnosticExtensions {
+
+		public static void ReportDiagnostic(
+				this SourceProductionContext context,
+				DiagnosticDescriptor descriptor,
+				Location? location = null,
+				IEnumerable<Location>? additionalLocations = null,
+				ImmutableDictionary<string, string?>? properties = null,
+				object?[]? messageArgs = null
+			) {
+
+			Diagnostic diagnostic = Diagnostic.Create(
+					descriptor: descriptor,
+					location: location,
+					additionalLocations: additionalLocations,
+					properties: properties,
+					messageArgs: messageArgs
+				);
+
+			context.ReportDiagnostic( diagnostic );
+		}
+	}
+}
+
 namespace Microsoft.CodeAnalysis.Diagnostics {
 
 	internal static class ReportDiagnosticExtensions {
 
-		#region CompilationAnalysisContext
-
 		public static void ReportDiagnostic(
 				this CompilationAnalysisContext context,
 				DiagnosticDescriptor descriptor,
-				Location? location,
-				params object?[]? messageArgs
+				Location? location = null,
+				IEnumerable<Location>? additionalLocations = null,
+				ImmutableDictionary<string, string?>? properties = null,
+				object?[]? messageArgs = null
 			) {
 
-			ReportDiagnostic(
-					context.ReportDiagnostic,
-					descriptor,
-					location,
-					messageArgs
+			Diagnostic diagnostic = Diagnostic.Create(
+					descriptor: descriptor,
+					location: location,
+					additionalLocations: additionalLocations,
+					properties: properties,
+					messageArgs: messageArgs
 				);
-		}
 
-		public static void ReportDiagnostic(
-				this CompilationAnalysisContext context,
-				DiagnosticDescriptor descriptor,
-				ImmutableArray<Location> locations,
-				params object?[]? messageArgs
-			) {
-
-			ReportDiagnostic(
-					context.ReportDiagnostic,
-					descriptor,
-					locations,
-					messageArgs
-				);
-		}
-
-		#endregion
-
-		#region OperationAnalysisContext
-
-		public static void ReportDiagnostic(
-				this OperationAnalysisContext context,
-				DiagnosticDescriptor descriptor,
-				Location? location,
-				params object?[]? messageArgs
-			) {
-
-			ReportDiagnostic(
-					context.ReportDiagnostic,
-					descriptor,
-					location,
-					messageArgs
-				);
+			context.ReportDiagnostic( diagnostic );
 		}
 
 		public static void ReportDiagnostic(
 				this OperationAnalysisContext context,
 				DiagnosticDescriptor descriptor,
-				ImmutableArray<Location> locations,
-				params object?[]? messageArgs
+				Location? location = null,
+				IEnumerable<Location>? additionalLocations = null,
+				ImmutableDictionary<string, string?>? properties = null,
+				object?[]? messageArgs = null
 			) {
 
-			ReportDiagnostic(
-					context.ReportDiagnostic,
-					descriptor,
-					locations,
-					messageArgs
+			Diagnostic diagnostic = Diagnostic.Create(
+					descriptor: descriptor,
+					location: location,
+					additionalLocations: additionalLocations,
+					properties: properties,
+					messageArgs: messageArgs
 				);
-		}
 
-		#endregion
-
-		#region SymbolAnalysisContext
-
-		public static void ReportDiagnostic(
-				this SymbolAnalysisContext context,
-				DiagnosticDescriptor descriptor,
-				Location? location,
-				params object?[]? messageArgs
-			) {
-
-			ReportDiagnostic(
-					context.ReportDiagnostic,
-					descriptor,
-					location,
-					messageArgs
-				);
+			context.ReportDiagnostic( diagnostic );
 		}
 
 		public static void ReportDiagnostic(
 				this SymbolAnalysisContext context,
 				DiagnosticDescriptor descriptor,
-				ImmutableArray<Location> locations,
-				params object?[]? messageArgs
+				Location? location = null,
+				IEnumerable<Location>? additionalLocations = null,
+				ImmutableDictionary<string, string?>? properties = null,
+				object?[]? messageArgs = null
 			) {
 
-			ReportDiagnostic(
-					context.ReportDiagnostic,
-					descriptor,
-					locations,
-					messageArgs
+			Diagnostic diagnostic = Diagnostic.Create(
+					descriptor: descriptor,
+					location: location,
+					additionalLocations: additionalLocations,
+					properties: properties,
+					messageArgs: messageArgs
 				);
-		}
 
-		#endregion
-
-		#region SyntaxNodeAnalysisContext
-
-		public static void ReportDiagnostic(
-				this SyntaxNodeAnalysisContext context,
-				DiagnosticDescriptor descriptor,
-				Location? location,
-				params object?[]? messageArgs
-			) {
-
-			ReportDiagnostic(
-					context.ReportDiagnostic,
-					descriptor,
-					location,
-					messageArgs
-				);
+			context.ReportDiagnostic( diagnostic );
 		}
 
 		public static void ReportDiagnostic(
 				this SyntaxNodeAnalysisContext context,
 				DiagnosticDescriptor descriptor,
-				ImmutableArray<Location> locations,
-				params object?[]? messageArgs
-			) {
-
-			ReportDiagnostic(
-					context.ReportDiagnostic,
-					descriptor,
-					locations,
-					messageArgs
-				);
-		}
-
-		#endregion
-
-		private static void ReportDiagnostic(
-				Action<Diagnostic> sink,
-				DiagnosticDescriptor descriptor,
-				Location? location,
-				object?[]? messageArgs
+				Location? location = null,
+				IEnumerable<Location>? additionalLocations = null,
+				ImmutableDictionary<string, string?>? properties = null,
+				object?[]? messageArgs = null
 			) {
 
 			Diagnostic diagnostic = Diagnostic.Create(
-					descriptor,
-					location,
-					messageArgs
+					descriptor: descriptor,
+					location: location,
+					additionalLocations: additionalLocations,
+					properties: properties,
+					messageArgs: messageArgs
 				);
 
-			sink( diagnostic );
-		}
-
-		private static void ReportDiagnostic(
-				Action<Diagnostic> sink,
-				DiagnosticDescriptor descriptor,
-				ImmutableArray<Location> locations,
-				object?[]? messageArgs
-			) {
-
-			Location? location;
-			IEnumerable<Location> additionalLocations;
-
-			if( locations.IsEmpty ) {
-				location = null;
-				additionalLocations = Enumerable.Empty<Location>();
-
-			} else {
-				location = locations[ 0 ];
-				additionalLocations = locations.Skip( 1 );
-			}
-
-			Diagnostic diagnostic = Diagnostic.Create(
-					descriptor,
-					location,
-					additionalLocations,
-					messageArgs
-				);
-
-			sink( diagnostic );
+			context.ReportDiagnostic( diagnostic );
 		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Extensions/ReportDiagnosticExtensions.cs
+++ b/src/D2L.CodeStyle.Analyzers/Extensions/ReportDiagnosticExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis {
 		public static void ReportDiagnostic(
 				this SourceProductionContext context,
 				DiagnosticDescriptor descriptor,
-				Location? location = null,
+				Location location,
 				IEnumerable<Location>? additionalLocations = null,
 				ImmutableDictionary<string, string?>? properties = null,
 				object?[]? messageArgs = null
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics {
 		public static void ReportDiagnostic(
 				this CompilationAnalysisContext context,
 				DiagnosticDescriptor descriptor,
-				Location? location = null,
+				Location location,
 				IEnumerable<Location>? additionalLocations = null,
 				ImmutableDictionary<string, string?>? properties = null,
 				object?[]? messageArgs = null
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics {
 		public static void ReportDiagnostic(
 				this OperationAnalysisContext context,
 				DiagnosticDescriptor descriptor,
-				Location? location = null,
+				Location location,
 				IEnumerable<Location>? additionalLocations = null,
 				ImmutableDictionary<string, string?>? properties = null,
 				object?[]? messageArgs = null
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics {
 		public static void ReportDiagnostic(
 				this SymbolAnalysisContext context,
 				DiagnosticDescriptor descriptor,
-				Location? location = null,
+				Location location,
 				IEnumerable<Location>? additionalLocations = null,
 				ImmutableDictionary<string, string?>? properties = null,
 				object?[]? messageArgs = null
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics {
 		public static void ReportDiagnostic(
 				this SyntaxNodeAnalysisContext context,
 				DiagnosticDescriptor descriptor,
-				Location? location = null,
+				Location location,
 				IEnumerable<Location>? additionalLocations = null,
 				ImmutableDictionary<string, string?>? properties = null,
 				object?[]? messageArgs = null

--- a/src/D2L.CodeStyle.Analyzers/Helpers/AllowedTypeList.cs
+++ b/src/D2L.CodeStyle.Analyzers/Helpers/AllowedTypeList.cs
@@ -70,12 +70,14 @@ namespace D2L.CodeStyle.Analyzers.Helpers {
 					continue;
 				}
 
-				ctx.ReportDiagnostic( Diagnostic.Create(
+				ctx.ReportDiagnostic(
 					descriptor: Diagnostics.UnnecessaryAllowedListEntry,
 					location: entry.Locations[0],
-					FormatEntry( entry ),
-					m_allowedListFileName
-				) );
+					messageArgs: new[] {
+						FormatEntry( entry ),
+						m_allowedListFileName
+					}
+				);
 			}
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ImmutabilityAnalyzer.cs
@@ -247,7 +247,7 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			AnnotationsContext annotationsContext,
 			ImmutabilityContext immutabilityContext,
 			SimpleNameSyntax syntax,
-			Func<int,Location> getArgumentLocation
+			Func<int, Location> getArgumentLocation
 		) {
 			if( syntax.IsFromDocComment() ) {
 				// ignore things in doccomments such as crefs
@@ -302,10 +302,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				}
 
 				// Create the diagnostic on the parameter (including the attribute)
-				var diagnostic = Diagnostic.Create(
+				ctx.ReportDiagnostic(
 					Diagnostics.UnexpectedConditionalImmutability,
-					parameter.DeclaringSyntaxReferences[0].GetSyntax( ctx.CancellationToken ).GetLocation() );
-				ctx.ReportDiagnostic( diagnostic );
+					parameter.DeclaringSyntaxReferences[ 0 ].GetSyntax( ctx.CancellationToken ).GetLocation()
+				);
 			}
 		}
 
@@ -326,13 +326,15 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			}
 
 			// Create the diagnostic on the parameter (excluding the attribute)
-			var diagnostic = Diagnostic.Create(
+			ctx.ReportDiagnostic(
 				Diagnostics.ConflictingImmutability,
-				symbol.DeclaringSyntaxReferences[0].GetSyntax( ctx.CancellationToken ).GetLastToken().GetLocation(),
-				"Immutable",
-				"ConditionallyImmutable.OnlyIf",
-				symbol.Kind.ToString().ToLower() );
-			ctx.ReportDiagnostic( diagnostic );
+				symbol.DeclaringSyntaxReferences[ 0 ].GetSyntax( ctx.CancellationToken ).GetLastToken().GetLocation(),
+				messageArgs: new[] {
+					"Immutable",
+					"ConditionallyImmutable.OnlyIf",
+					symbol.Kind.ToString().ToLower()
+				}
+			);
 		}
 
 		private static void AnalyzeConflictingImmutabilityOnMember(
@@ -355,35 +357,41 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 			if( hasImmutable && hasConditionallyImmutable ) {
 				// [Immutable] and [ConditionallyImmutable] both exist,
 				// so create a diagnostic
-				var diagnostic = Diagnostic.Create(
+				ctx.ReportDiagnostic(
 					Diagnostics.ConflictingImmutability,
 					syntax.Identifier.GetLocation(),
-					"Immutable",
-					"ConditionallyImmutable",
-					syntax.Keyword );
-				ctx.ReportDiagnostic( diagnostic );
+					messageArgs: new object[] {
+						"Immutable",
+						"ConditionallyImmutable",
+						syntax.Keyword
+					}
+				);
 			}
 			if( hasImmutable && hasImmutableBase ) {
 				// [Immutable] and [ImmutableBaseClassAttribute] both exist,
 				// so create a diagnostic
-				var diagnostic = Diagnostic.Create(
+				ctx.ReportDiagnostic(
 					Diagnostics.ConflictingImmutability,
 					syntax.Identifier.GetLocation(),
-					"Immutable",
-					"ImmutableBaseClassAttribute",
-					syntax.Keyword );
-				ctx.ReportDiagnostic( diagnostic );
+					messageArgs: new object[] {
+						"Immutable",
+						"ImmutableBaseClassAttribute",
+						syntax.Keyword
+					}
+				);
 			}
 			if( hasConditionallyImmutable && hasImmutableBase ) {
 				// [ConditionallyImmutable] and [ImmutableBaseClassAttribute] both exist,
 				// so create a diagnostic
-				var diagnostic = Diagnostic.Create(
+				ctx.ReportDiagnostic(
 					Diagnostics.ConflictingImmutability,
 					syntax.Identifier.GetLocation(),
-					"ConditionallyImmutable",
-					"ImmutableBaseClassAttribute",
-					syntax.Keyword );
-				ctx.ReportDiagnostic( diagnostic );
+					messageArgs: new object[] {
+						"ConditionallyImmutable",
+						"ImmutableBaseClassAttribute",
+						syntax.Keyword
+					}
+				 );
 			}
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/ReadOnlyParameterAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ReadOnlyParameterAnalyzer.cs
@@ -61,11 +61,11 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				 * public void Foo( [ReadOnly] ref int foo )
 				 * public void Foo( [ReadOnly] out int foo )
 				 */
-				ctx.ReportDiagnostic( Diagnostic.Create(
+				ctx.ReportDiagnostic(
 					Diagnostics.ReadOnlyParameterIsnt,
 					syntax.GetLocation(),
-					"is an in/ref/out parameter"
-				) );
+					messageArgs: new[] { "is an in/ref/out parameter" }
+				);
 			}
 
 			IMethodSymbol method = parameter.ContainingSymbol as IMethodSymbol;
@@ -88,11 +88,11 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				 *   SomeRefFunc( ref foo ); // pass by ref, potential for write
 				 * }
 				 */
-				ctx.ReportDiagnostic( Diagnostic.Create(
+				ctx.ReportDiagnostic(
 					Diagnostics.ReadOnlyParameterIsnt,
 					syntax.GetLocation(),
-					"is assigned to and/or passed by reference"
-				) );
+					messageArgs: new[] { "is assigned to and/or passed by reference" }
+				);
 			}
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/StatelessFuncAnalyzer.cs
@@ -98,7 +98,6 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				return;
 			}
 
-			Diagnostic diag;
 			switch( operationToInspect ) {
 				// this is the case when a method reference is used
 				// eg Func<string, int> func = int.Parse
@@ -109,10 +108,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 
 					// non-static member access means that state could
 					// be used / held.
-					diag = Diagnostic.Create(
+					context.ReportDiagnostic(
 						Diagnostics.StatelessFuncIsnt,
 						argumentOperation.Syntax.GetLocation(),
-						$"{ argumentOperation.Syntax } is not static"
+						messageArgs: new[] { $"{ argumentOperation.Syntax } is not static" }
 					);
 					break;
 
@@ -124,10 +123,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						return;
 					}
 
-					diag = Diagnostic.Create(
+					context.ReportDiagnostic(
 						Diagnostics.StatelessFuncIsnt,
 						argumentOperation.Syntax.GetLocation(),
-						"Lambda is not static"
+						messageArgs: new[] { "Lambda is not static" }
 					);
 					break;
 
@@ -140,10 +139,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 					// we are rejecting this because it is tricky to
 					// analyze properly, but also a bit ugly and should
 					// never really be necessary
-					diag = Diagnostic.Create(
+					context.ReportDiagnostic(
 						Diagnostics.StatelessFuncIsnt,
 						argumentOperation.Syntax.GetLocation(),
-						$"Invocations are not allowed: { argumentOperation.Syntax }"
+						messageArgs: new[] { $"Invocations are not allowed: { argumentOperation.Syntax }" }
 					);
 
 					break;
@@ -171,10 +170,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 						return;
 					}
 
-					diag = Diagnostic.Create(
+					context.ReportDiagnostic(
 						Diagnostics.StatelessFuncIsnt,
 						argumentOperation.Syntax.GetLocation(),
-						$"Parameter { argumentOperation.Syntax } is not marked [StatelessFunc]."
+						messageArgs: new[] { $"Parameter { argumentOperation.Syntax } is not marked [StatelessFunc]." }
 					);
 					break;
 
@@ -186,10 +185,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				 * type check.
 				 */
 				case ILocalReferenceOperation:
-					diag = Diagnostic.Create(
+					context.ReportDiagnostic(
 						Diagnostics.StatelessFuncIsnt,
 						argumentOperation.Syntax.GetLocation(),
-						$"Unable to determine if { argumentOperation.Syntax } is stateless."
+						messageArgs: new[] { $"Unable to determine if { argumentOperation.Syntax } is stateless." }
 					);
 
 					break;
@@ -197,16 +196,14 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 				default:
 					// we need StatelessFunc<T> to be ultra safe, so we'll
 					// reject usages we do not understand yet
-					diag = Diagnostic.Create(
+					context.ReportDiagnostic(
 						Diagnostics.StatelessFuncIsnt,
 						argumentOperation.Syntax.GetLocation(),
-						$"Unable to determine safety of { argumentOperation.Syntax }. This is an unexpectes usage of StatelessFunc<T>"
+						messageArgs: new[] { $"Unable to determine safety of { argumentOperation.Syntax }. This is an unexpectes usage of StatelessFunc<T>" }
 					);
 
 					break;
 			}
-
-			context.ReportDiagnostic( diag );
 		}
 
 		private static bool IsStatelessFunc(

--- a/src/D2L.CodeStyle.Analyzers/Language/AttributeAliasesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AttributeAliasesAnalyzer.cs
@@ -44,12 +44,10 @@ namespace D2L.CodeStyle.Analyzers.Language {
 					continue;
 				}
 
-				Diagnostic d = Diagnostic.Create(
+				context.ReportDiagnostic(
 						Diagnostics.AliasingAttributeNamesNotSupported,
 						attribute.GetLocation()
 					);
-
-				context.ReportDiagnostic( d );
 				return;
 			}
 		}

--- a/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.cs
@@ -63,10 +63,10 @@ namespace D2L.CodeStyle.Analyzers.Language {
 				return;
 			}
 
-			context.ReportDiagnostic( Diagnostic.Create(
+			context.ReportDiagnostic(
 				Diagnostics.AwaitedTaskNotConfigured,
 				operation.Syntax.GetLocation()
-			) );
+			);
 		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/Language/ClassShouldBeSealedAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/ClassShouldBeSealedAnalyzer.cs
@@ -154,10 +154,10 @@ namespace D2L.CodeStyle.Analyzers.Language {
 		) {
 			foreach( var unsealed in privateOrInternalUnsealedClasses ) {
 				if( !privateOrInternalBaseClasses.ContainsKey( unsealed.Key ) ) {
-					context.ReportDiagnostic( Diagnostic.Create(
+					context.ReportDiagnostic(
 						Diagnostics.ClassShouldBeSealed,
 						unsealed.Value
-					) );
+					);
 				}
 			}
 		}

--- a/src/D2L.CodeStyle.Analyzers/Language/StructShouldBeReadonlyAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/StructShouldBeReadonlyAnalyzer.cs
@@ -72,11 +72,11 @@ namespace D2L.CodeStyle.Analyzers.Language {
 				.Identifier
 				.GetLocation();
 
-			context.ReportDiagnostic( Diagnostic.Create(
+			context.ReportDiagnostic(
 				Diagnostics.StructShouldBeReadonly,
 				location,
-				symbol.MetadataName
-			) );
+				messageArgs: new[] { symbol.MetadataName }
+			);
 		}
 
 		private static bool ShouldBeReadOnly( INamedTypeSymbol symbol ) {


### PR DESCRIPTION
Replacing the `context.ReportDiagnostic( Diagnostic.Create( ... ) )` pattern with a single method per context type.  