### PR TITLE
Pulling out SpecTestFixtureBase

### DIFF
--- a/D2L.CodeStyle.sln
+++ b/D2L.CodeStyle.sln
@@ -1,19 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2035
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.Annotations", "src\D2L.CodeStyle.Annotations\D2L.CodeStyle.Annotations.csproj", "{1812AF7E-59B1-4764-8090-F84446A71C4E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "D2L.CodeStyle.Annotations", "src\D2L.CodeStyle.Annotations\D2L.CodeStyle.Annotations.csproj", "{1812AF7E-59B1-4764-8090-F84446A71C4E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{3873E5AD-A61F-4CE4-B2E1-5AD83D25BF79}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.Analyzers", "src\D2L.CodeStyle.Analyzers\D2L.CodeStyle.Analyzers.csproj", "{FE7608CD-C8B1-43DD-BBCC-9B1917C9CA73}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "D2L.CodeStyle.Analyzers", "src\D2L.CodeStyle.Analyzers\D2L.CodeStyle.Analyzers.csproj", "{FE7608CD-C8B1-43DD-BBCC-9B1917C9CA73}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.Analyzers.Tests", "tests\D2L.CodeStyle.Analyzers.Test\D2L.CodeStyle.Analyzers.Tests.csproj", "{1C54E78A-E12B-45C3-BA6E-31DB5C63B389}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "D2L.CodeStyle.Analyzers.Tests", "tests\D2L.CodeStyle.Analyzers.Test\D2L.CodeStyle.Analyzers.Tests.csproj", "{1C54E78A-E12B-45C3-BA6E-31DB5C63B389}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.TestAnalyzers", "src\D2L.CodeStyle.TestAnalyzers\D2L.CodeStyle.TestAnalyzers.csproj", "{A4AF66E9-BDC1-4B24-A249-A1C9BC094FD5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "D2L.CodeStyle.TestAnalyzers", "src\D2L.CodeStyle.TestAnalyzers\D2L.CodeStyle.TestAnalyzers.csproj", "{A4AF66E9-BDC1-4B24-A249-A1C9BC094FD5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.TestAnalyzers.Tests", "tests\D2L.CodeStyle.TestAnalyzers.Tests\D2L.CodeStyle.TestAnalyzers.Tests.csproj", "{2F10EDAF-8585-4B4C-A82A-BABC5D23A186}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "D2L.CodeStyle.TestAnalyzers.Tests", "tests\D2L.CodeStyle.TestAnalyzers.Tests\D2L.CodeStyle.TestAnalyzers.Tests.csproj", "{2F10EDAF-8585-4B4C-A82A-BABC5D23A186}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "D2L.CodeStyle.SpecTests", "src\D2L.CodeStyle.SpecTests\D2L.CodeStyle.SpecTests.csproj", "{C7B3A703-A549-48AA-90A6-A145C91D4F85}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,14 @@ Global
 		{2F10EDAF-8585-4B4C-A82A-BABC5D23A186}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2F10EDAF-8585-4B4C-A82A-BABC5D23A186}.Release|x86.ActiveCfg = Release|Any CPU
 		{2F10EDAF-8585-4B4C-A82A-BABC5D23A186}.Release|x86.Build.0 = Release|Any CPU
+		{C7B3A703-A549-48AA-90A6-A145C91D4F85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7B3A703-A549-48AA-90A6-A145C91D4F85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7B3A703-A549-48AA-90A6-A145C91D4F85}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C7B3A703-A549-48AA-90A6-A145C91D4F85}.Debug|x86.Build.0 = Debug|Any CPU
+		{C7B3A703-A549-48AA-90A6-A145C91D4F85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7B3A703-A549-48AA-90A6-A145C91D4F85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7B3A703-A549-48AA-90A6-A145C91D4F85}.Release|x86.ActiveCfg = Release|Any CPU
+		{C7B3A703-A549-48AA-90A6-A145C91D4F85}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/D2L.CodeStyle.SpecTests/D2L.CodeStyle.SpecTests.csproj
+++ b/src/D2L.CodeStyle.SpecTests/D2L.CodeStyle.SpecTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="IsExternalInit" Version="1.0.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="All" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+	</ItemGroup>
+</Project>

--- a/src/D2L.CodeStyle.SpecTests/SpecTest.cs
+++ b/src/D2L.CodeStyle.SpecTests/SpecTest.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 
-namespace D2L.CodeStyle.Analyzers {
+namespace D2L.CodeStyle.SpecTests {
 
-	internal sealed record SpecTest(
+	public sealed record SpecTest(
 		string Name,
 		string Source,
 		ImmutableArray<AdditionalText> AdditionalFiles,

--- a/src/D2L.CodeStyle.SpecTests/SpecTestFixtureBase.cs
+++ b/src/D2L.CodeStyle.SpecTests/SpecTestFixtureBase.cs
@@ -1,5 +1,4 @@
-﻿using System.CodeDom.Compiler;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
@@ -9,10 +8,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 
-namespace D2L.CodeStyle.Analyzers {
+namespace D2L.CodeStyle.SpecTests {
 
-	[TestFixtureSource( typeof( SpecTestsProvider ), nameof( SpecTestsProvider.GetAll ) )]
-	internal sealed class Spec {
+	public abstract class SpecTestFixtureBase {
 
 		private readonly SpecTest m_test;
 		private ImmutableArray<PrettyDiagnostic> m_expectedDiagnostics;
@@ -23,7 +21,7 @@ namespace D2L.CodeStyle.Analyzers {
 		/// Parameterized test fixture
 		/// </summary>
 		/// <param name="test">Provided by the <see cref="TestFixtureSourceAttribute"/>.</param>
-		public Spec( SpecTest test ) {
+		public SpecTestFixtureBase( SpecTest test ) {
 			m_test = test;
 		}
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\D2L.CodeStyle.Analyzers\D2L.CodeStyle.Analyzers.csproj" />
     <ProjectReference Include="..\..\src\D2L.CodeStyle.Annotations\D2L.CodeStyle.Annotations.csproj" />
+    <ProjectReference Include="..\..\src\D2L.CodeStyle.SpecTests\D2L.CodeStyle.SpecTests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/D2L.CodeStyle.Analyzers.Test/Spec.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Spec.cs
@@ -1,0 +1,11 @@
+﻿using D2L.CodeStyle.SpecTests;
+using NUnit.Framework;
+
+namespace D2L.CodeStyle.Analyzers {
+
+	[TestFixtureSource( typeof( SpecTestsProvider ), nameof( SpecTestsProvider.GetAll ) )]
+	internal sealed class Spec : SpecTestFixtureBase {
+
+		public Spec( SpecTest test ) : base( test ) { }
+	}
+}

--- a/tests/D2L.CodeStyle.Analyzers.Test/SpecTestsProvider.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/SpecTestsProvider.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using D2L.CodeStyle.SpecTests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 


### PR DESCRIPTION
Pulling out `SpecTestFixtureBase` into `D2L.CodeStyle.SpecTests` which can be as well used by:

* `D2L.CodeStyle.TestAnalyzers.Tests`
* `D2L.Lms.Analyzers.Tests`