### PR TITLE
D2L.CodeStyle.TestAnalyzers WarningsAsErrors

### DIFF
--- a/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
@@ -9,7 +9,7 @@ namespace D2L.CodeStyle.TestAnalyzers.Common {
 
 		public static readonly DiagnosticDescriptor ConfigTestSetupStrings = new DiagnosticDescriptor(
 			id: "D2LTESTS003",
-			title: "Use nameof in ConfigTestSetup attributes.",
+			title: "Use nameof in ConfigTestSetup attributes",
 			messageFormat: "String arguments in ConfigTestSetup are not allowed. Use nameof({0}) instead.",
 			category: "Cleanliness",
 			defaultSeverity: DiagnosticSeverity.Error,
@@ -29,7 +29,7 @@ namespace D2L.CodeStyle.TestAnalyzers.Common {
 
 		public static readonly DiagnosticDescriptor CustomServiceLocator = new DiagnosticDescriptor(
 			id: "D2LTESTS005",
-			title: "Use the default test service locator.",
+			title: "Use the default test service locator",
 			messageFormat: "Custom service locators should not be used. Use static TestServiceLocator.Get<T>() or TestServiceLocatorFactory.Default instead.",
 			category: "Cleanliness",
 			defaultSeverity: DiagnosticSeverity.Error,
@@ -43,7 +43,7 @@ namespace D2L.CodeStyle.TestAnalyzers.Common {
         public static readonly DiagnosticDescriptor UnnecessaryAllowedListEntry = new DiagnosticDescriptor(
             id: "D2LTESTS007",
             title: "Unnecessarily listed in an analyzer allowed list",
-            messageFormat: "The entry for {0} in {1} is unnecessary.",
+            messageFormat: "The entry for {0} in {1} is unnecessary",
             category: "Cleanliness",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
+++ b/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
@@ -14,10 +14,12 @@
     <Copyright>Copyright © D2L Corporation 2018</Copyright>
     <DevelopmentDependency>true</DevelopmentDependency>
 
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <IncludeSymbols>True</IncludeSymbols>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <SuppressDependenciesWhenPacking>True</SuppressDependenciesWhenPacking>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,7 +28,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/D2L.CodeStyle.TestAnalyzers/GlobalSuppressions.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/GlobalSuppressions.cs
@@ -1,0 +1,12 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage(
+	"MicrosoftCodeAnalysisReleaseTracking",
+	"RS2008:Enable analyzer release tracking",
+	Justification = "Not maintaing a releases file at this time."
+)]

--- a/src/D2L.CodeStyle.TestAnalyzers/ServiceLocator/CustomTestServiceLocatorAnalyzer.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/ServiceLocator/CustomTestServiceLocatorAnalyzer.cs
@@ -25,7 +25,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ServiceLocator {
 			);
 		}
 
-		public void RegisterServiceLocatorAnalyzer(
+		public static void RegisterServiceLocatorAnalyzer(
 			CompilationStartAnalysisContext context
 		) {
 			INamedTypeSymbol factoryType = context.Compilation
@@ -80,7 +80,7 @@ namespace D2L.CodeStyle.TestAnalyzers.ServiceLocator {
 		}
 
 		// Prevent static usage of TestServiceLocator.Create() methods.
-		private void PreventCustomLocatorUsage(
+		private static void PreventCustomLocatorUsage(
 			OperationAnalysisContext context,
 			IMethodSymbol methodSymbol,
 			AllowedTypeList allowedTypeList,


### PR DESCRIPTION
* Enable latest Microsoft.CodeAnalysis.NetAnalyzers
* Enable SuppressDependenciesWhenPacking to fix NU5128 warning
* Enable TreatWarningsAsErrors
* Disable MicrosoftCodeAnalysisReleaseTracking
* Fix some warnings