### PR TITLE
shortcirtcuit ReadOnlyParameterAnalyzer for parameters with no attributes

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Immutability/ReadOnlyParameterAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Immutability/ReadOnlyParameterAnalyzer.cs
@@ -49,6 +49,10 @@ namespace D2L.CodeStyle.Analyzers.Immutability {
 		) {
 			SemanticModel model = ctx.SemanticModel;
 
+			if( syntax.AttributeLists.Count == 0 ) {
+				return;
+			}
+
 			IParameterSymbol parameter = model.GetDeclaredSymbol( syntax, ctx.CancellationToken );
 
 			if( !IsMarkedReadOnly( readOnlyAttribute, parameter ) ) {


### PR DESCRIPTION
`D2L.CodeStyle.Analyzers.Immutability.ReadOnlyParameterAnalyzer (D2L0054) = 414 ms`
vs
`D2L.CodeStyle.Analyzers.Immutability.ReadOnlyParameterAnalyzer (D2L0054) = 11.521 s`
