### PR TITLE
Rm "async" anywhere from IAsyncEnumerable & methods returning it

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
@@ -339,7 +339,6 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 
 	private ExpressionSyntax Transform( InvocationExpressionSyntax invocationExpr) {
 		if( Model.GetTypeInfo( invocationExpr ).ConvertedType?.Name == "IAsyncEnumerable" ) {
-			// Remove all "Async" in the expression
 			return SyntaxFactory.ParseExpression( invocationExpr.ToString().Replace( "Async", "" ) );
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
@@ -333,7 +333,8 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 	}
 
 	private ExpressionSyntax Transform( InvocationExpressionSyntax invocationExpr) {
-		if( Model.GetTypeInfo( invocationExpr ).ConvertedType?.Name == "IAsyncEnumerable" ) {
+		ITypeSymbol? returnTypeInfo = Model.GetTypeInfo( invocationExpr ).Type;
+		if( returnTypeInfo?.MetadataName == "IAsyncEnumerable`1" && returnTypeInfo.ContainingNamespace.ToString() == "System.Collections.Generic" ) {
 			return invocationExpr.WithExpression( SyntaxFactory.ParseExpression( invocationExpr.Expression.ToString().Replace( "Async", "" ) ) );
 		}
 

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
@@ -123,9 +123,7 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 					);
 					return typeSynt;
 			}
-		}
-
-		if( returnTypeInfo.Type.MetadataName == "IAsyncEnumerable`1" ) {
+		} else if( returnTypeInfo.Type.MetadataName == "IAsyncEnumerable`1" && returnTypeInfo.Type.ContainingNamespace.ToString() == "System.Collections.Generic" ) {
 			return ( (GenericNameSyntax)typeSynt )
 				.WithIdentifier( SyntaxFactory.Identifier( "IEnumerable" ) )
 				.WithTriviaFrom( typeSynt );

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
@@ -332,7 +332,7 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 		ExpressionSyntax newExpr = invocationExpr;
 		var memberAccess = invocationExpr.Expression as MemberAccessExpressionSyntax;
 
-		if( string.Equals( memberAccess?.Name?.Identifier.ValueText, "ConfigureAwait", StringComparison.Ordinal ) ) {
+		if( memberAccess is not null && ShouldRemoveInvocation( memberAccess ) ) {
 			if( memberAccess?.Expression is not null ) {
 				newExpr = memberAccess.Expression;
 				return Transform( newExpr );
@@ -358,6 +358,14 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 	bool ShouldWrapMemberAccessInTaskRun( MemberAccessExpressionSyntax memberAccessExpr ) {
 		return (memberAccessExpr.Expression.ToString(), memberAccessExpr.Name.Identifier.ValueText) switch {
 			(_, "ReadAsStringAsync") => true,
+			_ => false
+		};
+	}
+
+	bool ShouldRemoveInvocation( MemberAccessExpressionSyntax memberAccessExpr ) {
+		return (memberAccessExpr.Expression.ToString(), memberAccessExpr.Name.Identifier.ValueText) switch {
+			(_, "ConfigureAwait" ) => true,
+			(_, "SafeAsync" ) => true,
 			_ => false
 		};
 	}

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
@@ -125,13 +125,10 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 			}
 		}
 
-		switch( returnTypeInfo.Type.MetadataName ) {
-			case "IAsyncEnumerable":
-				return SyntaxFactory.ParseTypeName( "IEnumerable" ).WithTriviaFrom( typeSynt );
-			case "IAsyncEnumerable`1":
-				return ( (GenericNameSyntax)typeSynt )
-					.WithIdentifier( SyntaxFactory.Identifier( "IEnumerable" ) )
-					.WithTriviaFrom( typeSynt );
+		if( returnTypeInfo.Type.MetadataName == "IAsyncEnumerable`1" ) {
+			return ( (GenericNameSyntax)typeSynt )
+				.WithIdentifier( SyntaxFactory.Identifier( "IEnumerable" ) )
+				.WithTriviaFrom( typeSynt );
 		}
 
 		if( isReturnType ) { ReportDiagnostic( Diagnostics.NonTaskReturnType, typeSynt.GetLocation() ); }

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
@@ -339,7 +339,7 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 
 	private ExpressionSyntax Transform( InvocationExpressionSyntax invocationExpr) {
 		if( Model.GetTypeInfo( invocationExpr ).ConvertedType?.Name == "IAsyncEnumerable" ) {
-			return SyntaxFactory.ParseExpression( invocationExpr.ToString().Replace( "Async", "" ) );
+			return invocationExpr.WithExpression( SyntaxFactory.ParseExpression( invocationExpr.Expression.ToString().Replace( "Async", "" ) ) );
 		}
 
 		ExpressionSyntax newExpr = invocationExpr;

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
@@ -503,7 +503,8 @@ using D2L.CodeStyle.Annotations;
 using System.Threading;
 
 class TestType{{
-{methodSource}IAsyncEnumerator<string> MethodReturningIAsyncEnumerator() {{
+{methodSource}async IAsyncEnumerator<string> MethodReturningIAsyncEnumerator() {{
+		await Task.Delay(1000);
 		yield return ""test"";
 	}}
 }}" );

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
@@ -130,6 +130,15 @@ internal sealed class AsyncToSyncMethodTransformerTests {
 	}
 
 	[Test]
+	public void SafeAsync() {
+		var actual = Transform( @"[GenerateSync] async Task BarAsync() { await m_baz.WriteLineAsync( line ).SafeAsync(); }" );
+
+		Assert.IsTrue( actual.Success );
+		Assert.IsEmpty( actual.Diagnostics );
+		Assert.AreEqual( "[Blocking] void Bar() { m_baz.WriteLine( line ); }", actual.Value.ToFullString() );
+	}
+
+	[Test]
 	public void FromResult() {
 		var actual = Transform( @"[GenerateSync] Task<Baz> BarAsync() { return Task.FromResult( baz ); }" );
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
@@ -329,6 +329,15 @@ void Bar() {
 	}
 
 	[Test]
+	public void IAsyncEnumerable() {
+		var actual = Transform( @"[GenerateSync] async Task BarAsync() { IAsyncEnumerable<string> empty = AsyncEnumerable.Empty<string>(); }" );
+
+		Assert.IsTrue( actual.Success );
+		Assert.IsEmpty( actual.Diagnostics );
+		Assert.AreEqual( @"[Blocking] void Bar() { IEnumerable<string> empty = Enumerable.Empty<string>(); }", actual.Value.ToFullString() );
+	}
+
+	[Test]
 		public void Silly() {
 		var actual = Transform( @"[GenerateSync]
 async Task<int> HelloAsync() {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
@@ -555,7 +555,8 @@ class TestType{{
 
 			typeof( object ),
 			typeof( Task ),
-			typeof( GenerateSyncAttribute )
+			typeof( GenerateSyncAttribute ),
+			typeof( IAsyncEnumerable<object> )
 
 		}.Select( t => t.Assembly.Location )
 		.Distinct()

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
@@ -330,7 +330,7 @@ void Bar() {
 
 	[Test]
 	public void IAsyncEnumerable() {
-		var actual = TransformWithIAsyncEnumerator( @"[GenerateSync] async Task BarAsync() { IAsyncEnumerable<string> m_enum = MethodReturningIAsyncEnumerable(); }" );
+		var actual = TransformWithIAsyncEnumerable( @"[GenerateSync] async Task BarAsync() { IAsyncEnumerable<string> m_enum = MethodReturningIAsyncEnumerable(); }" );
 
 		Assert.IsTrue( actual.Success );
 		Assert.IsEmpty( actual.Diagnostics );
@@ -339,7 +339,7 @@ void Bar() {
 
 	[Test]
 	public void IAsyncEnumerable_WithParameterContainingAsyncInName() {
-		var actual = TransformWithIAsyncEnumerator( @"
+		var actual = TransformWithIAsyncEnumerable( @"
 			[GenerateSync] async Task BarAsync() {
 				int parameterWithAsyncInName = 0;
 				IAsyncEnumerable<string> m_enum = MethodReturningIAsyncEnumerable( parameterWithAsyncInName );
@@ -489,8 +489,8 @@ int Hello() {
 		return transformer.Transform( methodDecl );
 	}
 
-	public static TransformResult<MethodDeclarationSyntax> TransformWithIAsyncEnumerator( string methodSource ) {
-		var (compilation, methodDecl) = ParseMethodWithIAsyncEnumerator( methodSource );
+	public static TransformResult<MethodDeclarationSyntax> TransformWithIAsyncEnumerable( string methodSource ) {
+		var (compilation, methodDecl) = ParseMethodWithIAsyncEnumerable( methodSource );
 
 		var transformer = new AsyncToSyncMethodTransformer(
 			compilation.GetSemanticModel( methodDecl.SyntaxTree ),
@@ -503,8 +503,8 @@ int Hello() {
 	public static (Compilation, MethodDeclarationSyntax) ParseMethod( string methodSource ) {
 		var wrappedAndParsed = CSharpSyntaxTree.ParseText( @$"
 using System.Threading.Tasks;
-using D2L.CodeStyle.Annotations;
 using System.Threading;
+using D2L.CodeStyle.Annotations;
 
 class TestType{{{methodSource}}}" );
 
@@ -516,14 +516,15 @@ class TestType{{{methodSource}}}" );
 	}
 
 
-	public static (Compilation, MethodDeclarationSyntax) ParseMethodWithIAsyncEnumerator( string methodSource ) {
+	public static (Compilation, MethodDeclarationSyntax) ParseMethodWithIAsyncEnumerable( string methodSource ) {
 		var wrappedAndParsed = CSharpSyntaxTree.ParseText( @$"
 using System.Threading.Tasks;
-using D2L.CodeStyle.Annotations;
 using System.Threading;
+using System.Collections.Generic;
+using D2L.CodeStyle.Annotations;
 
 class TestType{{
-{methodSource}async IAsyncEnumerator<string> MethodReturningIAsyncEnumerator() {{
+{methodSource}async IAsyncEnumerable<string> MethodReturningIAsyncEnumerable() {{
 		await Task.Delay(1000);
 		yield return ""test"";
 	}}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
@@ -338,6 +338,26 @@ void Bar() {
 	}
 
 	[Test]
+	public void IAsyncEnumerable_WithParameterContainingAsyncInName() {
+		var actual = TransformWithIAsyncEnumerator( @"
+			[GenerateSync] async Task BarAsync() {
+				int parameterWithAsyncInName = 0;
+				IAsyncEnumerable<string> m_enum = MethodReturningIAsyncEnumerable( parameterWithAsyncInName );
+			}"
+		);
+
+		Assert.IsTrue( actual.Success );
+		Assert.IsEmpty( actual.Diagnostics );
+		Assert.AreEqual( @"
+			[Blocking] void Bar() {
+				int parameterWithAsyncInName = 0;
+				IEnumerable<string> m_enum = MethodReturningIEnumerable( parameterWithAsyncInName );
+			}",
+			actual.Value.ToFullString()
+		);
+	}
+
+	[Test]
 		public void Silly() {
 		var actual = Transform( @"[GenerateSync]
 async Task<int> HelloAsync() {


### PR DESCRIPTION
[TA177961](https://rally1.rallydev.com/#/?detail=/task/718746909081&fdp=true)

Motivation is that the sync generator currently can't convert IAsyncEnumerable and most related functions because the Async keyword isn't at the end, for example here:
https://github.com/Brightspace/lms/blob/c4f2338b4d7f6b582b8c56ac959fd953f0846ec3/lp/framework/core/D2L.LP/LP/Security/OAuth2/AccessTokens/Keys/MsSqlKeyDataProvider.cs#L63

In general, there is no clear naming convention for methods that return IAsyncEnumerable except for adding the keyword async somewhere: https://stackoverflow.com/questions/59439281/is-there-a-definitive-naming-convention-for-methods-returning-iasyncenumerable/59452285#59452285

So for converting these we will change all variables/return types defined IAsyncEnumerable to IEnumerable, as well as removing "async" from any method that returns an IAsyncEnumerable.

I also had to make new test methods for this because we needed another method in the class that returns an IAsyncEnumerable