### PR TITLE
Disable CS1572 at top of generated files

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/FileCollector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/FileCollector.cs
@@ -80,6 +80,8 @@ internal partial class SyncGenerator {
 		}
 
 		public string CollectSource() {
+			// TODO: Remove this and modify XML param elements in generator when changed/removed
+			m_out.AppendLine( "#pragma warning disable CS1572" );
 			// File-scoped usings:
 			m_out.Append( m_root.Usings.ToFullString() );
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/FileCollectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/FileCollectorTests.cs
@@ -23,7 +23,8 @@ public sealed class Y {
 			ImmutableArray<(TypeDeclarationSyntax, string)>.Empty 
 		);
 
-		Assert.AreEqual( "", collector.CollectSource() );
+		Assert.AreEqual( @"#pragma warning disable CS1572
+", collector.CollectSource() );
 	}
 
 	[Test]
@@ -50,7 +51,8 @@ public sealed class Y {
 			)
 		);
 
-		Assert.AreEqual( @"
+		Assert.AreEqual( @"#pragma warning disable CS1572
+
 using Foo;
 
 namespace X;
@@ -86,7 +88,8 @@ public sealed class Y<T, U> where T : new where U : T {
 			)
 		);
 
-		Assert.AreEqual( @"
+		Assert.AreEqual( @"#pragma warning disable CS1572
+
 using Foo;
 
 namespace X;
@@ -120,7 +123,8 @@ public partial {kind} X {{
 			)
 		);
 
-		Assert.AreEqual( @$"
+		Assert.AreEqual( @$"#pragma warning disable CS1572
+
 partial {kind} X {{
 	any text
 }}",
@@ -158,7 +162,8 @@ namespace A.B.C {
 			)
 		);
 
-		Assert.AreEqual( @"
+		Assert.AreEqual( @"#pragma warning disable CS1572
+
 using Foo;
 
 namespace A.B.C {
@@ -238,7 +243,8 @@ namespace Q {
 			myMethodsBefore.ToImmutableArray()
 		);
 
-		Assert.AreEqual( @"
+		Assert.AreEqual( @"#pragma warning disable CS1572
+
 using Foo;
 
 namespace A.B.C {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/SyncGeneratorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/SyncGeneratorTests.cs
@@ -57,7 +57,8 @@ sealed class Bar {
 }"
 		);
 
-		AssertNewTrees( result, @"
+		AssertNewTrees( result, @"#pragma warning disable CS1572
+
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -89,7 +90,8 @@ partial interface IFoo {
 }"
 		);
 
-		AssertNewTrees( result, @"
+		AssertNewTrees( result, @"#pragma warning disable CS1572
+
 using System;
 using System.Threading.Tasks;
 using D2L.CodeStyle.Annotations;
@@ -137,7 +139,8 @@ public sealed partial class Abcdefg {
 }"
 		);
 
-		AssertNewTrees( result, @"
+		AssertNewTrees( result, @"#pragma warning disable CS1572
+
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -149,7 +152,8 @@ partial class Bar {
 
 	[Blocking]
 	public void Baz( StreamWriter x ) { return; }
-}", @"
+}", @"#pragma warning disable CS1572
+
 using System;
 using System.IO;
 using System.Threading.Tasks;


### PR DESCRIPTION
Workaround so we don't have to selectively remove XML parameters for now