### PR TITLE
Generate conditional access, member binding expressions + test

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
@@ -20,7 +20,6 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 	private bool m_removeAsyncAnywhere;
 
 	public TransformResult<MethodDeclarationSyntax> Transform( MethodDeclarationSyntax decl ) {
-		// TODO: remove CancellationToken parameters
 		decl = decl.WithAttributeLists( ReplaceGenerateSyncAttribute( decl.AttributeLists ) )
 			.WithModifiers( RemoveAsyncModifier( decl.Modifiers ) )
 			.WithIdentifier( RemoveAsyncSuffix( decl.Identifier ) )
@@ -327,6 +326,13 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 
 			AnonymousObjectCreationExpressionSyntax anonCreationExpr => anonCreationExpr
 				.WithInitializers( TransformAnonDecls( anonCreationExpr.Initializers ) ),
+
+			ConditionalAccessExpressionSyntax condAccessExpr => condAccessExpr
+				.WithExpression( Transform( condAccessExpr.Expression ) )
+				.WithWhenNotNull( Transform( condAccessExpr.WhenNotNull ) ),
+
+			MemberBindingExpressionSyntax memBindExpr => memBindExpr
+				.WithName( Transform( memBindExpr.Name ) ),
 
 			_ => UnhandledSyntax( expr )
 		};

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/AsyncToSyncMethodTransformerTests.cs
@@ -431,6 +431,15 @@ void Bar() {
 	}
 
 	[Test]
+	public void ConditionalAccessExpression() {
+		var actual = Transform( @"[GenerateSync] async Task BarAsync() { await m_baz?.PushAsync(); }" );
+
+		Assert.IsTrue( actual.Success );
+		Assert.IsEmpty( actual.Diagnostics );
+		Assert.AreEqual( @"[Blocking] void Bar() { m_baz?.Push(); }", actual.Value.ToFullString() );
+	}
+
+	[Test]
 		public void Silly() {
 		var actual = Transform( @"[GenerateSync]
 async Task<int> HelloAsync() {


### PR DESCRIPTION
The two expressions are closely related (member binding expression occurs when conditional access member is... accessed)