### PR TITLE
Add SerializationFrameworkAnalyzer

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializationFrameworkAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/Serialization/SerializationFrameworkAnalyzer.cs
@@ -1,0 +1,133 @@
+using System.Collections.Immutable;
+using D2L.CodeStyle.Analyzers.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace D2L.CodeStyle.Analyzers.ApiUsage.Serialization {
+
+	[DiagnosticAnalyzer( LanguageNames.CSharp )]
+	public sealed class SerializationFrameworkAnalyzer : DiagnosticAnalyzer {
+
+		private static readonly ImmutableArray<string> DisallowedTypeMetadataNames = ImmutableArray.Create(
+			"D2L.LP.Serialization.ISerializationWriter",
+			"D2L.LP.Serialization.ISerializer",
+			"D2L.LP.Serialization.ISerializationWriterExtensions",
+			"D2L.LP.Serialization.ITrySerializer"
+		);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+			Diagnostics.DangerousSerializationTypeReference
+		);
+
+		public override void Initialize( AnalysisContext context ) {
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis( GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics );
+			context.RegisterCompilationStartAction( RegisterAnalyzer );
+		}
+
+		public static void RegisterAnalyzer( CompilationStartAnalysisContext context ) {
+
+			ImmutableHashSet<ITypeSymbol> dangerousInterfaces = GetDangerousInterfaces( context.Compilation );
+
+			if( dangerousInterfaces.IsEmpty ) {
+				return;
+			}
+
+			context.RegisterOperationAction(
+				context => {
+					IInvocationOperation invocation = (IInvocationOperation)context.Operation;
+					AnalyzeMemberUsage( context, invocation.TargetMethod, dangerousInterfaces );
+				},
+				OperationKind.Invocation
+			);
+
+			context.RegisterOperationAction(
+				context => {
+					IMethodReferenceOperation reference = (IMethodReferenceOperation)context.Operation;
+					AnalyzeMemberUsage( context, reference.Method, dangerousInterfaces );
+				},
+				OperationKind.MethodReference
+			);
+
+			context.RegisterOperationAction(
+				context => {
+					IPropertyReferenceOperation reference = (IPropertyReferenceOperation)context.Operation;
+					AnalyzeMemberUsage( context, reference.Property, dangerousInterfaces );
+				},
+				OperationKind.PropertyReference
+			);
+
+			context.RegisterSymbolAction(
+				context => {
+					IFieldSymbol field = (IFieldSymbol)context.Symbol;
+					AnalyzeTypeUsage( context, field.Type, dangerousInterfaces );
+				},
+				SymbolKind.Field
+			);
+
+			context.RegisterSymbolAction(
+				context => {
+					IPropertySymbol property = (IPropertySymbol)context.Symbol;
+					AnalyzeTypeUsage( context, property.Type, dangerousInterfaces );
+				},
+				SymbolKind.Property
+			);
+		}
+
+		private static void AnalyzeMemberUsage(
+			OperationAnalysisContext context,
+			ISymbol member,
+			ImmutableHashSet<ITypeSymbol> bannedTypes
+		) {
+			if( !ImplementsDangerousInterface( bannedTypes, member.ContainingType ) ) {
+				return;
+			}
+
+			if( IsSerializationFrameworkInternal( context.ContainingSymbol ) ) {
+				return;
+			}
+
+			context.ReportDiagnostic(
+				Diagnostics.DangerousSerializationTypeReference,
+				context.Operation.Syntax.GetLocation()
+			);
+		}
+
+		private static void AnalyzeTypeUsage(
+			SymbolAnalysisContext context,
+			ITypeSymbol type,
+			ImmutableHashSet<ITypeSymbol> bannedTypes
+		) {
+			if( !ImplementsDangerousInterface( bannedTypes, type ) ) {
+				return;
+			}
+
+			if( IsSerializationFrameworkInternal( context.Symbol ) ) {
+				return;
+			}
+
+			context.ReportDiagnostic(
+				Diagnostics.DangerousSerializationTypeReference,
+				context.Symbol.Locations[0]
+			);
+		}
+
+		private static bool ImplementsDangerousInterface( ImmutableHashSet<ITypeSymbol> dangerousInterface, ITypeSymbol type ) =>
+			dangerousInterface.Contains( type ) || type.AllInterfaces.Any( dangerousInterface.Contains );
+
+		private static bool IsSerializationFrameworkInternal( ISymbol symbol ) =>
+			symbol.GetAllContainingTypes().Any( Attributes.SerializationFramework.IsDefined );
+
+		private static ImmutableHashSet<ITypeSymbol> GetDangerousInterfaces( Compilation compilation ) {
+			ImmutableHashSet<ITypeSymbol> bannedTypes = DisallowedTypeMetadataNames
+				.Select( compilation.GetTypeByMetadataName )
+				.Where( t => !t.IsNullOrErrorType() )
+				.OfType<ITypeSymbol>()
+				.ToImmutableHashSet();
+
+			return bannedTypes;
+		}
+
+	}
+}

--- a/src/D2L.CodeStyle.Analyzers/Attributes.cs
+++ b/src/D2L.CodeStyle.Analyzers/Attributes.cs
@@ -8,6 +8,7 @@ namespace D2L.CodeStyle.Analyzers {
 		internal static readonly RoslynAttribute Singleton = new RoslynAttribute( "D2L.LP.Extensibility.Activation.Domain.SingletonAttribute" );
 		internal static readonly RoslynAttribute DIFramework = new RoslynAttribute( "D2L.LP.Extensibility.Activation.Domain.DIFrameworkAttribute" );
 		internal static readonly RoslynAttribute Dependency = new RoslynAttribute( "D2L.LP.Extensibility.Activation.Domain.DependencyAttribute" );
+		internal static readonly RoslynAttribute SerializationFramework = new RoslynAttribute( "D2L.LP.Serialization.SerializationFrameworkAttribute" );
 
 		internal sealed class RoslynAttribute {
 

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -6,7 +6,7 @@
     <Title>D2L.CodeStyle.Analyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle analyzers</Description>
-    <Version>0.203.0</Version>
+    <Version>0.204.0</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Brightspace/D2L.CodeStyle</PackageProjectUrl>
     <Authors>D2L</Authors>

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -757,5 +757,14 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
+
+		public static readonly DiagnosticDescriptor DangerousSerializationTypeReference = new DiagnosticDescriptor(
+			id: "D2L0102",
+			title: "Internal serialization type references are restricted to serialization framework internals",
+			messageFormat: "Internal serialization types shouldn't be used outside of the serialization framework. Use 'ISerialization' or 'IDeserialization' implementations instead.",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		);
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializationFrameworkAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/SerializationFrameworkAnalyzer.cs
@@ -1,0 +1,157 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.ApiUsage.Serialization.SerializationFrameworkAnalyzer
+
+using System;
+using D2L.LP.Serialization
+
+namespace D2L.LP.Serialization {
+
+	public sealed class SerializationFrameworkAttribute : Attribute { }
+
+	[SerializationFramework]
+	public class DangerousExplicitClass : ISerializer, ITrySerializer, ISerializationWriter {
+		public void Foo() { }	
+		void ISerializer.Serialize() { }
+		bool ITrySerializer.TrySerialize() { return true; }
+		void ISerializationWriter.Write() { }
+	}
+
+	[SerializationFramework]
+	public class DangerousImplicitClass : ISerializer, ITrySerializer, ISerializationWriter {
+		public void Serialize() { }
+		public bool TrySerialize() { return true; }
+		public void Write() { }
+	}
+
+	public interface ISerializer {
+		public void Serialize();
+	}
+
+	public interface ITrySerializer {
+		public bool TrySerialize();
+	}
+
+	public interface ISerializationWriter {
+		public void Write();
+	}
+
+	[SerializationFramework]
+	public static class ISerializationWriterExtensions {
+		public static void Write( this ISerializationWriter writer, string _ ) {
+			writer.Write();
+		}
+	}
+
+	[SerializationFramework]
+	public static class SerializationFactory {
+		public static ISerializer Serializer {
+			get { return new DangerousExplicitClass(); }
+		}
+		public static ITrySerializer TrySerializer {
+			get { return new DangerousExplicitClass(); }
+		}
+		public static ISerializer SerializationWriter {
+			get { return new DangerousExplicitClass(); }
+		}
+	}
+
+}
+
+namespace D2L.CodeStyle.Analyzers.SerializationFrameworkAnalyzer.Examples {
+	using D2L.LP.Serialization;
+
+	public sealed class BadClass {
+
+		private DangerousExplicitClass /* DangerousSerializationTypeReference */ m_dangerousExplicitClass /**/;
+		private DangerousImplicitClass /* DangerousSerializationTypeReference */ m_dangerousImplicitClass /**/;
+
+		public void Uses_ISerializer() {
+			ISerializer explicitSerializer = SerializationFactory.Serializer;
+			/* DangerousSerializationTypeReference */
+			explicitSerializer.Serialize() /**/ ;
+		}
+
+		public void Uses_ITrySerializer() {
+			ITrySerializer explicitTrySerializer = SerializationFactory.TrySerializer;
+			/* DangerousSerializationTypeReference */
+			explicitTrySerializer.TrySerialize() /**/ ;
+		}
+
+		public void Uses_ISerializationWriter() {
+			ISerializationWriter explicitWriter = SerializationFactory.SerializationWriter;
+			/* DangerousSerializationTypeReference */
+			explicitWriter.Write() /**/ ;
+		}
+
+		public void Uses_ISerializationWriterExtensions() {
+			ISerializationWriter explicitWriter = SerializationFactory.SerializationWriter;
+			/* DangerousSerializationTypeReference */
+			explicitWriter.Write( "foo" ) /**/ ;
+		}
+
+		public void Uses_DangerousImplicitReferences() {
+			DangerousImplicitClass dangerousClass = new DangerousImplicitClass();
+			/* DangerousSerializationTypeReference */
+			dangerousClass.Serialize() /**/ ;
+			/* DangerousSerializationTypeReference */
+			dangerousClass.TrySerialize() /**/ ;
+		}
+
+		public void Uses_DangerousImplementingType() {
+			DangerousExplicitClass dangerousClass = new DangerousExplicitClass();
+			/* DangerousSerializationTypeReference */
+			dangerousClass.Foo() /**/ ;
+		}
+
+	}
+
+	[SerializationFramework]
+	public sealed class SerializationFrameworkClass {
+
+		private readonly ISerializer m_serializer;
+		private readonly ITrySerializer m_trySerializer;
+		private readonly ISerializationWriter m_serializationWriter;
+
+		public SerializationFrameworkClass(
+			ISerializer serializer,
+			ITrySerializer trySerializer,
+			ISerializationWriter serializationWriter
+		) {
+			m_serializer = serializer;
+			m_trySerializer = trySerializer;
+			m_serializationWriter = serializationWriter;
+		}
+
+		public void InSerializationClass() {
+			ISerializer ok = SerializationFactory.Serializer;
+			ok.Serialize();
+
+			ITrySerializer alsoOk = SerializationFactory.TrySerializer;
+			alsoOk.TrySerialize();
+
+			ISerializationWriter okayToo = SerializationFactory.SerializationWriter;
+			okayToo.Write();
+		}
+
+		public ISerializer Serializer {
+			get { return m_serializer; }
+		}
+	}
+
+	[SerializationFramework]
+	public sealed class SerializationFrameworkUsageInNestedClass {
+		private static class Nested {
+			public static void Usage() {
+				ISerializer ok = SerializationFactory.Serializer;
+				ok.Serialize();
+
+				ITrySerializer alsoOk = SerializationFactory.TrySerializer;
+				alsoOk.TrySerialize();
+
+				ISerializationWriter okayToo = SerializationFactory.SerializationWriter;
+				okayToo.Write();
+			}
+		}
+	}
+
+
+}


### PR DESCRIPTION
This analyzer restricts the use of these interfaces and their implementations:
- `ISerializationWriter`
- `ISerializationWriterExtensions`
- `ISerializer`
- `ITrySerializer`

Invocation, property, and field references are only permitted in classes annotated with the `[SerializationFramework]` attribute

There is one small problem/catch to this analyzer though - implementing types may still be referenced through another safe interface. Given some safe interface `a` and a dangerous interface `d`, a serialiser `s` such that `s : a, d` may invoke dangerous behaviour through `a`. Although, I don't _think_ this can be solved without a noticeable/significant performance hit.

I built the LMS with this analyzer to roughly gauge the performance. It seems to be a bit worse than the OBSL analyser which was the basis for a lot of this code. I figure this is a because for each type `t` we sometimes check `t.AllInterfaces.Any( dangerousInterface.Contains )` in addition to the `dangerousInterfaces.Contains( t )` that the OBSL analyser checks
![image](https://github.com/Brightspace/D2L.CodeStyle/assets/66925241/957597ac-69f0-4ab4-bdbe-4abf2c5ceaff)

Before merging, the annotations should be added in the LMS:
- https://github.com/Brightspace/lms/pull/42303
- https://github.com/Brightspace/lms/pull/42304
- https://github.com/Brightspace/lms/pull/42305
- https://github.com/Brightspace/lms/pull/42306


ref: https://github.com/Brightspace/lms-dotnet-migration-issues/issues/135