### PR TITLE
Revert "Allow OnlyVisibleToType on interfaces."

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -766,14 +766,5 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
-
-		public static readonly DiagnosticDescriptor TypeNotVisibleToCaller = new DiagnosticDescriptor(
-			id: "D2L0103",
-			title: "Type is not visible to caller",
-			messageFormat: "The type '{0}' has restricted its visibility to an explicit set of callers",
-			category: "Correctness",
-			defaultSeverity: DiagnosticSeverity.Error,
-			isEnabledByDefault: true
-		);
 	}
 }

--- a/src/D2L.CodeStyle.Annotations/Contract/OnlyVisibleToTypeAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/Contract/OnlyVisibleToTypeAttribute.cs
@@ -3,7 +3,7 @@
 namespace D2L.CodeStyle.Annotations.Contract {
 
 	[AttributeUsage(
-		validOn: AttributeTargets.Constructor | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Property,
+		validOn: AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property,
 		AllowMultiple = true,
 		Inherited = false
 	)]

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/OnlyVisibleToAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/OnlyVisibleToAnalyzer.cs
@@ -9,7 +9,7 @@ using Targets;
 namespace D2L.CodeStyle.Annotations.Contract {
 
 	[AttributeUsage(
-		validOn: AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Property,
+		validOn: AttributeTargets.Method | AttributeTargets.Property,
 		AllowMultiple = true,
 		Inherited = false
 	)]
@@ -84,7 +84,7 @@ namespace Targets {
 
 namespace TestCases {
 
-	public static partial class AllowedCaller {
+	public static class AllowedCaller {
 
 		public const string MetadataName = "TestCases.AllowedCaller";
 
@@ -200,34 +200,6 @@ namespace TestCases {
 		public const string MetadataName = "TestCases.AllowedCallerB";
 		public static void Test() {
 			MultipleTargets.Action();
-		}
-	}
-}
-
-// ===============================================================================
-
-namespace Targets {
-	[OnlyVisibleToType( TestCases.AllowedCaller.MetadataName, "OnlyVisibleToAnalyzer" )]
-	public interface ITypeRestrictedInterface { }
-	public interface ITypeUnrestrictedInterface { }
-}
-
-namespace TestCases {
-	public static partial class AllowedCaller {
-		public static void UnrestrictedInterface() {
-			ITypeUnrestrictedInterface @interface = null;
-		}
-		public static void RestrictedInterface() {
-			ITypeRestrictedInterface @interface = null;
-		}
-	}
-
-	public static partial class DisallowedCaller {
-		public static void UnrestrictedInterface() {
-			ITypeUnrestrictedInterface @interface = null;
-		}
-		public static void RestrictedInterface() {
-			/* TypeNotVisibleToCaller(ITypeRestrictedInterface) */ ITypeRestrictedInterface /**/ @interface = null;
 		}
 	}
 }


### PR DESCRIPTION
Reverts Brightspace/D2L.CodeStyle#925

I think this needs a little more planning - there are a lot of ways interfaces can be referenced.