### PR TITLE
deps: update CodeAnalysis packages

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -20,6 +20,7 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CA2016,Nullable</WarningsAsErrors>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="D2L.CodeStyle.Analyzers.Tests" />
@@ -29,11 +30,11 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,7 +43,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/D2L.CodeStyle.Analyzers/Language/AttributeAliasesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AttributeAliasesAnalyzer.cs
@@ -104,7 +104,7 @@ namespace D2L.CodeStyle.Analyzers.Language {
 				}
 
 				// ignore aliases that just import the class from the namespace
-				string unqualifiedUsingName = usingDirective.Name.GetUnqualifiedNameAsString();
+				string? unqualifiedUsingName = usingDirective.Name?.GetUnqualifiedNameAsString();
 				if( StringComparer.Ordinal.Equals( alias.Name.ToString(), unqualifiedUsingName ) ) {
 					continue;
 				}

--- a/src/D2L.CodeStyle.SpecTests/D2L.CodeStyle.SpecTests.csproj
+++ b/src/D2L.CodeStyle.SpecTests/D2L.CodeStyle.SpecTests.csproj
@@ -8,12 +8,12 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="All" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
 	</ItemGroup>
 </Project>

--- a/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
+++ b/src/D2L.CodeStyle.TestAnalyzers/Common/Diagnostics.cs
@@ -24,7 +24,8 @@ namespace D2L.CodeStyle.TestAnalyzers.Common {
 			category: "Correctness",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
-			description: "Tests need to be correctly categorized in order to be run."
+			description: "Tests need to be correctly categorized in order to be run.",
+			customTags: new[] { "CompilationEnd" }
 		);
 
 		public static readonly DiagnosticDescriptor CustomServiceLocator = new DiagnosticDescriptor(
@@ -47,7 +48,8 @@ namespace D2L.CodeStyle.TestAnalyzers.Common {
             category: "Cleanliness",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "Unnecessarily listed in an analyzer allowed list."
+            description: "Unnecessarily listed in an analyzer allowed list.",
+            customTags: new[] { "CompilationEnd" }
         );
     }
 }

--- a/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
+++ b/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
@@ -20,6 +20,7 @@
     <IncludeSymbols>True</IncludeSymbols>
     <SuppressDependenciesWhenPacking>True</SuppressDependenciesWhenPacking>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,16 +29,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -4,12 +4,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/D2L.CodeStyle.TestAnalyzers.Tests/D2L.CodeStyle.TestAnalyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.TestAnalyzers.Tests/D2L.CodeStyle.TestAnalyzers.Tests.csproj
@@ -4,11 +4,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
| Roslyn package version | Minimum supported Visual Studio version |
| -- | -- |
| 4.7.0 | Visual Studio 2022 version 17.7 |

https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022