### PR TITLE
Allow users to suppress the sync generator

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/SyncGenerator.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/SyncGenerator.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace D2L.CodeStyle.Analyzers.Async.Generator;
 

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -46,4 +46,8 @@
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <CompilerVisibleProperty Include="SuppressSyncGenerator" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This will allow .NET core projects to not generate sync stuff (which will often not want to support sync)