### PR TITLE
Default to .NET Standard 2.0 for all projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<Deterministic>true</Deterministic>
 		<LangVersion>10.0</LangVersion>
 		<ImplicitUsings>true</ImplicitUsings>

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-
     <Title>D2L.CodeStyle.Analyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle analyzers</Description>

--- a/src/D2L.CodeStyle.SpecTests/D2L.CodeStyle.SpecTests.csproj
+++ b/src/D2L.CodeStyle.SpecTests/D2L.CodeStyle.SpecTests.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="IsExternalInit" Version="1.0.2">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
+++ b/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-
     <Title>D2L.CodeStyle.TestAnalyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle test analyzers</Description>


### PR DESCRIPTION
Moving this to the default because it makes sense: "annotations"-style DLLs we ship should probably target that for simplicity (the existing Annotations DLL also multi-targets net20 which we can probably drop?), and the analyzers have to target netstandard2.0.

Our test projects will need to override this; currently we run our tests in net48 for some reason, but we should target net7/8/etc. I think.

Overall I think this will keep the csproj's simpler, especially once I split the packages.