### PR TITLE
Stumbled upon an issue whereby an object array being assigned null ca…

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/AsyncToSyncMethodTransformer.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace D2L.CodeStyle.Analyzers.Async.Generator;
 
@@ -111,7 +110,7 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 			return typeSynt;
 		}
 
-		if( returnTypeInfo.Type.ContainingNamespace.ToString() == "System.Threading.Tasks" ) {
+		if( returnTypeInfo.Type.ContainingNamespace?.ToString() == "System.Threading.Tasks" ) {
 			switch( returnTypeInfo.Type.MetadataName ) {
 				case "Task":
 					if( isReturnType ) {
@@ -134,7 +133,7 @@ internal sealed class AsyncToSyncMethodTransformer : SyntaxTransformer {
 					);
 					return typeSynt;
 			}
-		} else if( returnTypeInfo.Type.MetadataName == "IAsyncEnumerable`1" && returnTypeInfo.Type.ContainingNamespace.ToString() == "System.Collections.Generic" ) {
+		} else if( returnTypeInfo.Type.MetadataName == "IAsyncEnumerable`1" && returnTypeInfo.Type.ContainingNamespace?.ToString() == "System.Collections.Generic" ) {
 			return ( (GenericNameSyntax)typeSynt )
 				.WithIdentifier( SyntaxFactory.Identifier( "IEnumerable" ) )
 				.WithTriviaFrom( typeSynt );

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/SyncGeneratorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/SyncGeneratorTests.cs
@@ -76,6 +76,56 @@ partial class Bar {
 	}
 
 	[Test]
+	public void OneFileWithOneMethodThatHasObjectArray() {
+		var result = RunGenerator( @"
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using D2L.CodeStyle.Annotations;
+
+namespace Foo;
+
+sealed class Bar {
+	public void Baz() => Console.WriteLine( ""hello"" );
+
+	[GenerateSync]
+	public async Task BazAsync( StreamWriter x ) {
+		Object[] searchThings = null;
+		return;
+
+}
+
+	public int Add( int x, int y ) => x + y;
+}"
+
+	
+		);
+
+		AssertNewTrees( result, @"#pragma warning disable CS1572
+#nullable enable annotations
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using D2L.CodeStyle.Annotations;
+
+namespace Foo;
+
+partial class Bar {
+
+	[Blocking]
+	public void Baz( StreamWriter x ) {
+		Object[] searchThings = null;
+		return;
+
+}
+}"
+
+
+		);
+	}
+
+	[Test]
 	public void InterfaceMethod() {
 		var result = RunGenerator( @"
 using System;
@@ -174,6 +224,7 @@ partial class Abcdefg {
 }"
 		);
 	}
+
 
 	public (Compilation Before, Compilation After) RunGenerator( params string[] sources ) {
 		var oldCompilation = AsyncToSyncMethodTransformerTests.CreateSyncGeneratorTestCompilation(


### PR DESCRIPTION
We hit an issue in GenerateSync that was causing a null reference exception.  I've got a reproducible test, and a potential fix, but I've no idea if it's a valid fix or not to be honest..

VUL-785