### PR TITLE
SPLA-3307: Update ConstantAttributeAnalyzer to check for compound assignment

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
@@ -197,9 +197,6 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 			if( @operator is null ) {
 				return;
 			}
-			if( @operator.Parameters.Length != 1 ) {
-				return;
-			}
 
 			// Operator parameter is not [Constant], so do nothing
 			IParameterSymbol parameter = @operator.Parameters[0];

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
@@ -63,6 +63,15 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 			);
 
 			context.RegisterOperationAction(
+				ctx => AnalyzeCompoundAssignment(
+					ctx,
+					(ICompoundAssignmentOperation)ctx.Operation,
+					constantAttribute
+				),
+				OperationKind.CompoundAssignment
+			);
+
+			context.RegisterOperationAction(
 				ctx => AnalyzeMethodReference(
 					ctx,
 					(IMethodReferenceOperation)ctx.Operation,
@@ -173,6 +182,35 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 			context.ReportDiagnostic(
 				descriptor: Diagnostics.NonConstantPassedToConstantParameter,
 				location: operand.Syntax.GetLocation(),
+				messageArgs: new[] { parameter.Name }
+			);
+		}
+
+		private static void AnalyzeCompoundAssignment(
+			OperationAnalysisContext context,
+			ICompoundAssignmentOperation compoundAssignment,
+			INamedTypeSymbol constantAttribute
+		) {
+
+			// Get implicit operator for the compound assignment
+			IMethodSymbol @operator = compoundAssignment.OutConversion.MethodSymbol;
+			if( @operator is null ) {
+				return;
+			}
+			if( @operator.Parameters.Length != 1 ) {
+				return;
+			}
+
+			// Operator parameter is not [Constant], so do nothing
+			IParameterSymbol parameter = @operator.Parameters[0];
+			if( !HasAttribute( parameter, constantAttribute ) ) {
+				return;
+			}
+
+			// Compound assignment with operator parameter that has [Constant] cannot be constant, so report it
+			context.ReportDiagnostic(
+				descriptor: Diagnostics.NonConstantPassedToConstantParameter,
+				location: compoundAssignment.Value.Syntax.GetLocation(),
 				messageArgs: new[] { parameter.Name }
 			);
 		}

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
@@ -197,6 +197,13 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 			if( @operator is null ) {
 				return;
 			}
+			if( @operator.Parameters.Length != 1 ) {
+				context.ReportDiagnostic(
+					descriptor: Diagnostics.UnexpectedNumberOfParametersForImplicitOperator,
+					location: compoundAssignment.Value.Syntax.GetLocation()
+				);
+				return;
+			}
 
 			// Operator parameter is not [Constant], so do nothing
 			IParameterSymbol parameter = @operator.Parameters[0];

--- a/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
+++ b/src/D2L.CodeStyle.Analyzers/Diagnostics.cs
@@ -765,5 +765,14 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		);
+
+		public static readonly DiagnosticDescriptor UnexpectedNumberOfParametersForImplicitOperator = new DiagnosticDescriptor(
+			id: "D2L0104",
+			title: "Unexpected number of parameters for implicit operator",
+			messageFormat: "The implicit operator has an unexpected number of parameters. Update analyzer to handle this case.",
+			category: "Safety",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		);
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConstantAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConstantAttributeAnalyzer.cs
@@ -269,6 +269,22 @@ namespace SpecTests {
 			{ Types.ConstantStruct v = trusted; }
 			{ Types.ConstantStruct v = /* NonConstantPassedToConstantParameter(value) */ variable /**/; }
 			{ Types.ConstantStruct v = /* NonConstantPassedToConstantParameter(value) */ untrusted /**/; }
+			{
+				Types.ConstantStruct v = Constants.String;
+				v += /* NonConstantPassedToConstantParameter(value) */ "abc" /**/;
+			}
+			{
+				Types.ConstantStruct v = Constants.String;
+				v += /* NonConstantPassedToConstantParameter(value) */ trusted /**/;
+			}
+			{
+				Types.ConstantStruct v = Constants.String;
+				v += /* NonConstantPassedToConstantParameter(value) */ variable /**/;
+			}
+			{
+				Types.ConstantStruct v = Constants.String;
+				v += /* NonConstantPassedToConstantParameter(value) */ "a" + "b" /**/;
+			}
 
 			{ Types.NonConstantStruct v = "abc"; }
 			{ Types.NonConstantStruct v = Constants.String; }
@@ -276,6 +292,22 @@ namespace SpecTests {
 			{ Types.NonConstantStruct v = trusted; }
 			{ Types.NonConstantStruct v = variable; }
 			{ Types.NonConstantStruct v = untrusted; }
+			{
+				Types.NonConstantStruct v = Constants.String;
+				v += "abc";
+			}
+			{
+				Types.NonConstantStruct v = Constants.String;
+				v += trusted;
+			}
+			{
+				Types.NonConstantStruct v = Constants.String;
+				v += variable;
+			}
+			{
+				Types.NonConstantStruct v = Constants.String;
+				v += "a" + "b";
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
Updated `ConstantAttributeAnalyzer` to check for compound assignment.

Story: https://desire2learn.atlassian.net/browse/SPLA-3307