### PR TITLE
respect end_of_line and charset in editorconfig

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/FileCollector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/FileCollector.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace D2L.CodeStyle.Analyzers.Async.Generator;
 
@@ -57,21 +58,25 @@ internal partial class SyncGenerator {
 
 		private readonly StringBuilder m_out = new();
 		private readonly string? m_endOfLine;
+		private readonly Encoding m_encoding;
 
 		private FileCollector(
 			CompilationUnitSyntax root,
 			Dictionary<TypeDeclarationSyntax, IEnumerable<string>> methods,
-			string? endOfLine
+			string? endOfLine,
+			Encoding encoding
 		) {
 			m_root = root;
 			m_methods = methods;
 			m_endOfLine = endOfLine;
+			m_encoding = encoding;
 		}
 
 		public static FileCollector Create(
 			CompilationUnitSyntax root,
 			ImmutableArray<(TypeDeclarationSyntax Parent, string Source)> methods,
-			string? endOfLine
+			string? endOfLine,
+			Encoding encoding
 		) {
 			var groupedMethods = methods
 				.GroupBy( static m => m.Parent )
@@ -80,10 +85,10 @@ internal partial class SyncGenerator {
 					static g => g.Select( static m => m.Source )
 				);
 
-			return new FileCollector( root, groupedMethods, endOfLine );
+			return new FileCollector( root, groupedMethods, endOfLine, encoding );
 		}
 
-		public string CollectSource() {
+		public SourceText CollectSource() {
 			// TODO: Remove this and modify XML param elements in generator when changed/removed
 			if( m_endOfLine != null ) {
 				m_out.Append( "#pragma warning disable CS1572" + m_endOfLine );
@@ -111,7 +116,7 @@ internal partial class SyncGenerator {
 				throw new BugException( "left over methods" );
 			}
 
-			return m_out.ToString();
+			return SourceText.From( m_out.ToString(), m_encoding );
 		}
 
 		private bool WriteChildren( SyntaxNode node ) {

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/FileCollector.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/FileCollector.cs
@@ -56,18 +56,22 @@ internal partial class SyncGenerator {
 		private readonly LinkedList<PieceOfSyntax[]> m_preambles = new();
 
 		private readonly StringBuilder m_out = new();
+		private readonly string? m_endOfLine;
 
 		private FileCollector(
 			CompilationUnitSyntax root,
-			Dictionary<TypeDeclarationSyntax, IEnumerable<string>> methods
+			Dictionary<TypeDeclarationSyntax, IEnumerable<string>> methods,
+			string? endOfLine
 		) {
 			m_root = root;
 			m_methods = methods;
+			m_endOfLine = endOfLine;
 		}
 
 		public static FileCollector Create(
 			CompilationUnitSyntax root,
-			ImmutableArray<(TypeDeclarationSyntax Parent, string Source)> methods
+			ImmutableArray<(TypeDeclarationSyntax Parent, string Source)> methods,
+			string? endOfLine
 		) {
 			var groupedMethods = methods
 				.GroupBy( static m => m.Parent )
@@ -76,15 +80,24 @@ internal partial class SyncGenerator {
 					static g => g.Select( static m => m.Source )
 				);
 
-			return new FileCollector( root, groupedMethods );
+			return new FileCollector( root, groupedMethods, endOfLine );
 		}
 
 		public string CollectSource() {
 			// TODO: Remove this and modify XML param elements in generator when changed/removed
-			m_out.AppendLine( "#pragma warning disable CS1572" );
+			if( m_endOfLine != null ) {
+				m_out.Append( "#pragma warning disable CS1572" + m_endOfLine );
+			} else {
+				m_out.AppendLine( "#pragma warning disable CS1572" );
+			}
 			// This allows us to copy+paste annotations but otherwise does not emit diagnostics
 			// otherwise we get "CS8669: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. Auto-generated code requires an explicit '#nullable' directive in source."
-			m_out.AppendLine( "#nullable enable annotations" );
+			if( m_endOfLine != null ) {
+				m_out.Append( "#nullable enable annotations" + m_endOfLine );
+			} else {
+				m_out.AppendLine( "#nullable enable annotations" );
+			}
+
 			// File-scoped usings:
 			m_out.Append( m_root.Usings.ToFullString() );
 

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/SyncGenerator.Results.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/SyncGenerator.Results.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace D2L.CodeStyle.Analyzers.Async.Generator;
 
@@ -23,7 +24,7 @@ internal sealed partial class SyncGenerator {
 	/// </summary>
 	private readonly record struct FileGenerationResult(
 		string HintName,
-		string GeneratedSource,
+		SourceText GeneratedSource,
 		ImmutableArray<Diagnostic> Diagnostics
 	);
 }

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/SyncGenerator.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/SyncGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -8,6 +9,8 @@ namespace D2L.CodeStyle.Analyzers.Async.Generator;
 
 [Generator]
 internal sealed partial class SyncGenerator : IIncrementalGenerator {
+	private static readonly Encoding UTF8WithoutBom = new UTF8Encoding( encoderShouldEmitUTF8Identifier: false );
+
 	public void Initialize( IncrementalGeneratorInitializationContext context ) {
 		var options = context.AnalyzerConfigOptionsProvider
 			.Select( ParseConfig );
@@ -164,6 +167,7 @@ internal sealed partial class SyncGenerator : IIncrementalGenerator {
 			}
 
 			var fileOptions = configOptionsProvider.GetOptions( file.Data.Key.SyntaxTree );
+
 			fileOptions.TryGetValue( "end_of_line", out var endOfLineValue );
 			var endOfLine = endOfLineValue?.Trim() switch {
 				"crlf" => "\r\n",
@@ -172,10 +176,21 @@ internal sealed partial class SyncGenerator : IIncrementalGenerator {
 				_ => null,
 			};
 
+			fileOptions.TryGetValue( "charset", out var charsetValue );
+			var encoding = charsetValue?.Trim().ToLower() switch {
+				"latin-1" => Encoding.GetEncoding( "iso-8859-1" ),
+				"utf-8" => UTF8WithoutBom,
+				"utf-8-bom" => Encoding.UTF8,
+				"utf-16le" => Encoding.Unicode,
+				"utf-16be" => Encoding.BigEndianUnicode,
+				_ => Encoding.Default,
+			};
+
 			var collector = FileCollector.Create(
 				file.Data.Key,
 				generatedMethods.ToImmutable(),
-				endOfLine
+				endOfLine,
+				encoding
 			);
 
 			var generatedFile = collector.CollectSource();
@@ -198,7 +213,7 @@ internal sealed partial class SyncGenerator : IIncrementalGenerator {
 
 		context.AddSource(
 			hintName: result.HintName,
-			source: result.GeneratedSource
+			sourceText: result.GeneratedSource
 		);
 	}
 

--- a/src/D2L.CodeStyle.Analyzers/Async/Generator/SyncGenerator.cs
+++ b/src/D2L.CodeStyle.Analyzers/Async/Generator/SyncGenerator.cs
@@ -38,7 +38,8 @@ internal sealed partial class SyncGenerator : IIncrementalGenerator {
 		// that when any file with [GenerateSync] has changed.
 		IncrementalValuesProvider<FileGenerationResult> generatedFiles =
 			generatedMethods.Collect()
-				.SelectMany( GenerateFiles );
+				.Combine( context.AnalyzerConfigOptionsProvider )
+				.SelectMany( ( x, ct ) => GenerateFiles( x.Left, x.Right, ct ) );
 
 		context.RegisterSourceOutput( generatedFiles, WriteFiles );
 	}
@@ -132,6 +133,7 @@ internal sealed partial class SyncGenerator : IIncrementalGenerator {
 
 	private static IEnumerable<FileGenerationResult> GenerateFiles(
 		ImmutableArray<MethodGenerationResult> methodResults,
+		AnalyzerConfigOptionsProvider configOptionsProvider,
 		CancellationToken cancellationToken
 	) {
 		var methodsByFile = methodResults
@@ -161,9 +163,19 @@ internal sealed partial class SyncGenerator : IIncrementalGenerator {
 				generatedMethods.Add( ((method.Original.Parent as TypeDeclarationSyntax)!, method.GeneratedSyntax ) );
 			}
 
+			var fileOptions = configOptionsProvider.GetOptions( file.Data.Key.SyntaxTree );
+			fileOptions.TryGetValue( "end_of_line", out var endOfLineValue );
+			var endOfLine = endOfLineValue?.Trim() switch {
+				"crlf" => "\r\n",
+				"lf" => "\n",
+				"cr" => "\r",
+				_ => null,
+			};
+
 			var collector = FileCollector.Create(
 				file.Data.Key,
-				generatedMethods.ToImmutable()
+				generatedMethods.ToImmutable(),
+				endOfLine
 			);
 
 			var generatedFile = collector.CollectSource();

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -6,7 +6,7 @@
     <Title>D2L.CodeStyle.Analyzers</Title>
     <Product>D2L.CodeStyle</Product>
     <Description>D2L.CodeStyle analyzers</Description>
-    <Version>0.220.0</Version>
+    <Version>0.221.0</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Brightspace/D2L.CodeStyle</PackageProjectUrl>
     <Authors>D2L</Authors>

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/FileCollectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/FileCollectorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -21,12 +22,13 @@ public sealed class Y {
 		var collector = FileCollector.Create(
 			root,
 			ImmutableArray<(TypeDeclarationSyntax, string)>.Empty,
-			endOfLine: null
+			endOfLine: null,
+			encoding: Encoding.Default
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
 #nullable enable annotations
-", collector.CollectSource() );
+", collector.CollectSource().ToString() );
 	}
 
 	[TestCase( "\n" )]
@@ -54,7 +56,8 @@ public sealed class Y {
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\tany text" + endOfLine)
 			),
-			endOfLine
+			endOfLine: endOfLine,
+			encoding: Encoding.Default
 		);
 
 		var expected = string.Join( endOfLine, [
@@ -70,7 +73,7 @@ public sealed class Y {
 			"}",
 		] );
 
-		Assert.AreEqual( expected, collector.CollectSource() );
+		Assert.AreEqual( expected, collector.CollectSource().ToString() );
 	}
 
 	[Test]
@@ -95,7 +98,8 @@ public sealed class Y {
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\tany text\r\n")
 			),
-			endOfLine: null
+			endOfLine: null,
+			encoding: Encoding.Default
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
@@ -108,7 +112,7 @@ namespace X;
 partial class Y {
 	any text
 }",
-			collector.CollectSource()
+			collector.CollectSource().ToString()
 		);
 	}
 
@@ -134,7 +138,8 @@ public sealed class Y<T, U> where T : new where U : T {
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\tany text\r\n")
 			),
-			endOfLine: null
+			endOfLine: null,
+			encoding: Encoding.Default
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
@@ -147,7 +152,7 @@ namespace X;
 partial class Y<T, U> {
 	any text
 }",
-			collector.CollectSource()
+			collector.CollectSource().ToString()
 		);
 	}
 	[TestCase( "class" )] // static/selaed come before partial and don't need to show up in the other partials
@@ -171,7 +176,8 @@ public partial {kind} X {{
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\tany text\r\n")
 			),
-			endOfLine: null
+			endOfLine: null,
+			encoding: Encoding.Default
 		);
 
 		Assert.AreEqual( @$"#pragma warning disable CS1572
@@ -180,7 +186,7 @@ public partial {kind} X {{
 partial {kind} X {{
 	any text
 }}",
-			collector.CollectSource()
+			collector.CollectSource().ToString()
 		);
 	}
 
@@ -212,7 +218,8 @@ namespace A.B.C {
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\t\t\t\tany text\r\n")
 			),
-			endOfLine: null
+			endOfLine: null,
+			encoding: Encoding.Default
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
@@ -230,7 +237,7 @@ namespace A.B.C {
 		}
 	}
 }",
-			collector.CollectSource()
+			collector.CollectSource().ToString()
 		);
 	}
 
@@ -295,7 +302,8 @@ namespace Q {
 		var collector = FileCollector.Create(
 			root,
 			myMethodsBefore.ToImmutableArray(),
-			endOfLine: null
+			endOfLine: null,
+			encoding: Encoding.Default
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
@@ -334,7 +342,7 @@ namespace Q {
 	}
 }
 ",
-			collector.CollectSource()
+			collector.CollectSource().ToString()
 		);
 	}
 }

--- a/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/FileCollectorTests.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Async/Generator/FileCollectorTests.cs
@@ -20,12 +20,57 @@ public sealed class Y {
 
 		var collector = FileCollector.Create(
 			root,
-			ImmutableArray<(TypeDeclarationSyntax, string)>.Empty 
+			ImmutableArray<(TypeDeclarationSyntax, string)>.Empty,
+			endOfLine: null
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
 #nullable enable annotations
 ", collector.CollectSource() );
+	}
+
+	[TestCase( "\n" )]
+	[TestCase( "\r\n" )]
+	public void EndOfLine( string endOfLine ) {
+		var source = string.Join( endOfLine, [
+			"",
+			"using Foo;",
+			"",
+			"namespace X;",
+			"",
+			"public sealed class Y {",
+			"	void MyMethodBefore() {",
+			"		Console.WriteLine( \"Hello\" );",
+			"	}",
+			"}",
+		] );
+
+		var root = CSharpSyntaxTree.ParseText( source ).GetCompilationUnitRoot();
+
+		SyntaxNode myMethodBefore = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+
+		var collector = FileCollector.Create(
+			root,
+			ImmutableArray.Create(
+				((TypeDeclarationSyntax)myMethodBefore.Parent, "\tany text" + endOfLine)
+			),
+			endOfLine
+		);
+
+		var expected = string.Join( endOfLine, [
+			"#pragma warning disable CS1572",
+			"#nullable enable annotations",
+			"",
+			"using Foo;",
+			"",
+			"namespace X;",
+			"",
+			"partial class Y {",
+			"	any text",
+			"}",
+		] );
+
+		Assert.AreEqual( expected, collector.CollectSource() );
 	}
 
 	[Test]
@@ -49,7 +94,8 @@ public sealed class Y {
 			root,
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\tany text\r\n")
-			)
+			),
+			endOfLine: null
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
@@ -87,7 +133,8 @@ public sealed class Y<T, U> where T : new where U : T {
 			root,
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\tany text\r\n")
-			)
+			),
+			endOfLine: null
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
@@ -123,7 +170,8 @@ public partial {kind} X {{
 			root,
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\tany text\r\n")
-			)
+			),
+			endOfLine: null
 		);
 
 		Assert.AreEqual( @$"#pragma warning disable CS1572
@@ -163,7 +211,8 @@ namespace A.B.C {
 			root,
 			ImmutableArray.Create(
 				((TypeDeclarationSyntax)myMethodBefore.Parent, "\t\t\t\tany text\r\n")
-			)
+			),
+			endOfLine: null
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572
@@ -245,7 +294,8 @@ namespace Q {
 
 		var collector = FileCollector.Create(
 			root,
-			myMethodsBefore.ToImmutableArray()
+			myMethodsBefore.ToImmutableArray(),
+			endOfLine: null
 		);
 
 		Assert.AreEqual( @"#pragma warning disable CS1572


### PR DESCRIPTION
Depending on the OS, the source generator uses different EOL for these two lines (added using `StringBuilder.AppendLine`):
```
#pragma warning disable CS1572
#nullable enable annotations
```

When the generated code is committed and kept in sync with CI (e.g. in [opensearch-infrastructure][1]), this can cause frequent drifts because dev machines and actions runners use different OSes.

This PR uses `end_of_line` from editorconfig as the source of truth to resolve this issue.

Also added support for charset. Not having this doesn't cause drift, but it's just nice to have, and it's supported in a similar way.

[1]: https://github.com/Brightspace/opensearch-infrastructure/blob/c3890a63295f3b478acac477a67c470e31cf2483/src/D2L.OpenSearch.Client/D2L.OpenSearch.Client.csproj#L45

VUL-1128