### PR TITLE
fix ConstantAttributeAnalyzer null reference

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ConstantAttributeAnalyzer.cs
@@ -133,7 +133,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 			}
 
 			// Argument was defined as [Constant] already, so trust it
-			var argumentSymbol = argument.SemanticModel.GetSymbolInfo( (argument.Syntax as ArgumentSyntax).Expression, context.CancellationToken ).Symbol;
+			var argumentSymbol = argument.SemanticModel.GetSymbolInfo( argument.Value.Syntax, context.CancellationToken ).Symbol;
 			if( argumentSymbol != null && HasAttribute( argumentSymbol, constantAttribute ) ) {
 				return;
 			}


### PR DESCRIPTION
Fixes a NullReferenceException during analysis of an InterpolatedStringHandler usage.

Possible to add a test, but requires a couple of package updates that I don't want to verify are safe, at the moment.

```csharp
[InterpolatedStringHandler]
public sealed class MyString {
  public MyString( int a, int b ) {}
  public void AppendLiteral( [Constant] string s ) {}
  public void AppendFormatted( [Constant] string s ) {}
}

public sealed class C {
  public void M( bool x ) {

    R(
      $"""
      FOO
      {( x ? "x" : "y" )}
      """
    );
  }

  public void R( MyString s ) {}
}
```

This desugars to

```csharp
  public void M( bool x ) {
    MyString <> = new MyString( 4, 1 );
    <>.AppendLiteral( "FOO\n" );
    <>.AppendFormatted( x ? "x" : "y" );
    R( <> );
  }
```

However, the syntax for the operation of `<>.AppendFormatted( x ? "x" : "y" );` is still from the original interpolated string; both `argument.Syntax` and `argument.Value.Syntax`  are `ConditionalExpressionSyntax` rather than an `ArgumentSyntax`.

SPLA-3693