### PR TITLE
LFT-3079 - Resolving NU5128

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -16,6 +16,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeBuildOutput>False</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeSymbols>True</IncludeSymbols>
     <WarningsAsErrors>CA2016,Nullable</WarningsAsErrors>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>


### PR DESCRIPTION
-D2L.CodeStyle.TestAnalyzers already had `<SuppressDependenciesWhenPacking>True</SuppressDependenciesWhenPacking>` 
-D2L.CodeStyle.Analyzers sets `<IncludeBuildOutput>False</IncludeBuildOutput>` 
--The SDK NuGet.Build.Tasks.Pack.targets specifies `<BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">lib</BuildOutputTargetFolder>` 
--So, since the `BuildOutputTargetFolder` is blank, it defines it to `lib`
 --Since `lib` exists, it has a rule to check for the presence of libraries in the folder 
--If there are no files, it evaluates NU5128
--Since we copy nothing to the build output (IncludeBuildOutput = false) we trigger NU5128 
--Since we have no intention of putting things in that folder, `<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>` appears to be the correct solution