### PR TITLE
LFT-3081 - Resolve RS1010

### DIFF
--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzerFixer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/JsonParamBinderAttribute/JsonParamBinderAnalyzerFixer.cs
@@ -34,7 +34,8 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage.JsonParamBinderAttribute {
 			context.RegisterCodeFix( 
 				CodeAction.Create( 
 					Diagnostics.ObsoleteJsonParamBinder.Title.ToString(),
-					ct => SwapAttributes( context.Document, oldAttribute, ct)
+					ct => SwapAttributes( context.Document, oldAttribute, ct),
+					equivalenceKey: nameof( JsonParamBinderAnalyzerFixer )
 				), 
 				diagnostic
 			);

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static D2L.CodeStyle.Analyzers.AnnotationsContext;
 
 namespace D2L.CodeStyle.Analyzers.CommonFixes {
 	// BUG: this doesn't consider multiple partial decls so if the attribute
@@ -73,7 +74,7 @@ namespace D2L.CodeStyle.Analyzers.CommonFixes {
 							attrName: attrName,
 							ct
 						),
-						equivalenceKey: nameof( AddAttributeCodeFix )
+						equivalenceKey: $"{attrName}-{nameof( AddAttributeCodeFix )}"
 					),
 					diagnostic
 				);

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
@@ -72,7 +72,8 @@ namespace D2L.CodeStyle.Analyzers.CommonFixes {
 							usingNs: usingNs,
 							attrName: attrName,
 							ct
-						)
+						),
+						equivalenceKey: nameof( AddAttributeCodeFix )
 					),
 					diagnostic
 				);

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
@@ -74,7 +74,7 @@ namespace D2L.CodeStyle.Analyzers.CommonFixes {
 							attrName: attrName,
 							ct
 						),
-						equivalenceKey: $"{attrName}-{nameof( AddAttributeCodeFix )}"
+						equivalenceKey: attrName
 					),
 					diagnostic
 				);

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/AddAttributeCodeFix.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using static D2L.CodeStyle.Analyzers.AnnotationsContext;
 
 namespace D2L.CodeStyle.Analyzers.CommonFixes {
 	// BUG: this doesn't consider multiple partial decls so if the attribute

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/RemoveAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/RemoveAttributeCodeFix.cs
@@ -40,7 +40,8 @@ namespace D2L.CodeStyle.Analyzers.CommonFixes {
 					CodeAction.Create(
 						title: $"Remove [{attr.Name}]",
 						createChangedDocument: ct =>
-							Task.FromResult( Fix( context.Document, root, attr ) )
+							Task.FromResult( Fix( context.Document, root, attr ) ),
+						equivalenceKey: nameof( RemoveAttributeCodeFix )
 					),
 					diagnostic
 				);

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/RemoveAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/RemoveAttributeCodeFix.cs
@@ -41,7 +41,7 @@ namespace D2L.CodeStyle.Analyzers.CommonFixes {
 						title: $"Remove [{attr.Name}]",
 						createChangedDocument: ct =>
 							Task.FromResult( Fix( context.Document, root, attr ) ),
-						equivalenceKey: $"{attr.Name}-{nameof( RemoveAttributeCodeFix )}"
+						equivalenceKey: attr.Name.ToString()
 					),
 					diagnostic
 				);

--- a/src/D2L.CodeStyle.Analyzers/CommonFixes/RemoveAttributeCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/CommonFixes/RemoveAttributeCodeFix.cs
@@ -41,7 +41,7 @@ namespace D2L.CodeStyle.Analyzers.CommonFixes {
 						title: $"Remove [{attr.Name}]",
 						createChangedDocument: ct =>
 							Task.FromResult( Fix( context.Document, root, attr ) ),
-						equivalenceKey: nameof( RemoveAttributeCodeFix )
+						equivalenceKey: $"{attr.Name}-{nameof( RemoveAttributeCodeFix )}"
 					),
 					diagnostic
 				);

--- a/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.Codefix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/AwaitedTasksAnalyzer.Codefix.cs
@@ -51,7 +51,8 @@ namespace D2L.CodeStyle.Analyzers.Language {
 								awaitExpression: awaitExpression,
 								useSafeAsync: useSafeAsync,
 								cancellationToken: ct
-							)
+							),
+							equivalenceKey: nameof( ConfigureAwaitedTaskCodeFix )
 						),
 						diagnostic
 					);

--- a/src/D2L.CodeStyle.Analyzers/Language/StructShouldBeReadonlyAnalyzer.Codefix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/StructShouldBeReadonlyAnalyzer.Codefix.cs
@@ -47,7 +47,8 @@ namespace D2L.CodeStyle.Analyzers.Language {
 								root: root,
 								declaration: declaration,
 								ct: ct
-							)
+							),
+							equivalenceKey: nameof( AddReadonlyModifierCodefix )
 						),
 						diagnostic
 					);

--- a/src/D2L.CodeStyle.Analyzers/Language/UseNamedArgumentsCodeFix.cs
+++ b/src/D2L.CodeStyle.Analyzers/Language/UseNamedArgumentsCodeFix.cs
@@ -58,8 +58,9 @@ namespace D2L.CodeStyle.Analyzers.Language {
 								args,
 								paramNames,
 								ct
-							)
-                    ),
+							),
+						equivalenceKey: nameof( UseNamedArgumentsCodeFix )
+					),
 					diagnostic
 				);
 			}


### PR DESCRIPTION
-From https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md it seems all fixes registered from the same code fixer should have the same equivalence key