### PR TITLE
move [PatternString] from the LMS

### DIFF
--- a/D2L.CodeStyle.sln
+++ b/D2L.CodeStyle.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.Analyzers.Rul
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Constant", "Constant", "{FE0449B9-2A7B-48DD-BBDB-B6A0FB19A2A9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2L.CodeStyle.Analyzers.Rule.PatternString", "src\Rules\D2L.CodeStyle.Analyzers.Rule.PatternString\D2L.CodeStyle.Analyzers.Rule.PatternString.csproj", "{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -103,6 +105,14 @@ Global
 		{04534CAC-57B7-4462-BE31-D8C1C6B7BAA7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{04534CAC-57B7-4462-BE31-D8C1C6B7BAA7}.Release|x86.ActiveCfg = Release|Any CPU
 		{04534CAC-57B7-4462-BE31-D8C1C6B7BAA7}.Release|x86.Build.0 = Release|Any CPU
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}.Debug|x86.Build.0 = Debug|Any CPU
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}.Release|x86.ActiveCfg = Release|Any CPU
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,6 +123,7 @@ Global
 		{9F66950B-83B2-4A9E-8C26-ABAC97E55CA9} = {FE0449B9-2A7B-48DD-BBDB-B6A0FB19A2A9}
 		{04534CAC-57B7-4462-BE31-D8C1C6B7BAA7} = {1D7FCA55-CA25-4264-BB5D-331CF09C1A00}
 		{FE0449B9-2A7B-48DD-BBDB-B6A0FB19A2A9} = {1D7FCA55-CA25-4264-BB5D-331CF09C1A00}
+		{C8C9149E-A617-13B8-B0D9-625C7EA2BF26} = {1D7FCA55-CA25-4264-BB5D-331CF09C1A00}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B1068C74-1517-443E-99B8-CB4834D47628}

--- a/src/D2L.CodeStyle.Analyzers/ApiUsage/ConsistentParameterAttributesAnalyzer.cs
+++ b/src/D2L.CodeStyle.Analyzers/ApiUsage/ConsistentParameterAttributesAnalyzer.cs
@@ -60,20 +60,26 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 					var implementedParameterUsage = consistentAttributesContext.GetAttributeUsage( implementedMethod.Parameters[ i ] );
 
 					for( int j = 0; j < thisParameterUsage.Length; ++j ) {
-						var thisParameterUsageAttr = thisParameterUsage[ j ];
-						var implementedParameterUsageAttr = implementedParameterUsage[ j ];
+						(string AttributeName, ImmutableArray<AttributeData> Instances) thisParameterUsageAttr = thisParameterUsage[ j ];
+						(string AttributeName, ImmutableArray<AttributeData> Instances) implementedParameterUsageAttr = implementedParameterUsage[ j ];
 
-						if( thisParameterUsageAttr != implementedParameterUsageAttr ) {
-							ctx.ReportDiagnostic(
-								Diagnostics.InconsistentMethodAttributeApplication,
-								GetLocationOfNthParameter( methodSymbol, i, ctx.CancellationToken ),
-								messageArgs: new[] {
-									thisParameterUsageAttr.AttributeName,
-									$"{ methodSymbol.ContainingType.Name }.{ methodSymbol.Name }",
-									$"{ implementedMethod.ContainingType.Name }.{ implementedMethod.Name }"
-								}
-							);
+						if( thisParameterUsageAttr.Instances.IsDefaultOrEmpty && implementedParameterUsageAttr.Instances.IsDefaultOrEmpty ) {
+							continue;
 						}
+
+						if( thisParameterUsageAttr.Instances.SequenceEqual( implementedParameterUsageAttr.Instances, AttributeDataComparer.Instance ) ) {
+							continue;
+						}
+
+						ctx.ReportDiagnostic(
+							Diagnostics.InconsistentMethodAttributeApplication,
+							GetLocationOfNthParameter( methodSymbol, i, ctx.CancellationToken ),
+							messageArgs: new[] {
+								thisParameterUsageAttr.AttributeName,
+								$"{ methodSymbol.ContainingType.Name }.{ methodSymbol.Name }",
+								$"{ implementedMethod.ContainingType.Name }.{ implementedMethod.Name }"
+							}
+						);
 					}
 				}
 			}
@@ -96,13 +102,16 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 
 			private readonly INamedTypeSymbol m_constantAttribute;
 			private readonly INamedTypeSymbol m_statelessFuncAttribute;
+			private readonly INamedTypeSymbol m_patternStringAttribute;
 
 			private ConsistentAttributesContext(
 				INamedTypeSymbol constantAttribute,
-				INamedTypeSymbol statelessFuncAttribute
+				INamedTypeSymbol statelessFuncAttribute,
+				INamedTypeSymbol patternStringAttribute
 			) {
 				m_constantAttribute = constantAttribute;
 				m_statelessFuncAttribute = statelessFuncAttribute;
+				m_patternStringAttribute = patternStringAttribute;
 			}
 
 			public static bool TryCreate(
@@ -121,22 +130,74 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 					return false;
 				}
 
+				INamedTypeSymbol? patternStringAttribute = compilation.GetTypeByMetadataName( "D2L.CodeStyle.Annotations.Contract.PatternStringAttribute" );
+				if( patternStringAttribute.IsNullOrErrorType() ) {
+					consistentAttributesContext = null;
+					return false;
+				}
+
 				consistentAttributesContext = new(
 					constantAttribute: constantAttribute,
-					statelessFuncAttribute: statelessFuncAttribute
+					statelessFuncAttribute: statelessFuncAttribute,
+					patternStringAttribute: patternStringAttribute
 				);
 				return true;
 			}
 
-			public ImmutableArray<(string AttributeName, bool Applied)> GetAttributeUsage(
+			public ImmutableArray<(string AttributeName, ImmutableArray<AttributeData> Instances)> GetAttributeUsage(
 				ISymbol symbol
 			) => ImmutableArray.Create(
-				("Constant", HasAttribute( symbol, m_constantAttribute )),
-				("StatelessFunc", HasAttribute( symbol, m_statelessFuncAttribute ))
+				("Constant", GetAttributes( symbol, m_constantAttribute )),
+				("StatelessFunc", GetAttributes( symbol, m_statelessFuncAttribute )),
+				("PatternString", GetAttributes( symbol, m_patternStringAttribute ))
 			);
 
-			internal static bool HasAttribute( ISymbol s, INamedTypeSymbol attribute )
-				=> s.GetAttributes().Any( a => SymbolEqualityComparer.Default.Equals( a.AttributeClass, attribute ) );
+			internal static ImmutableArray<AttributeData> GetAttributes( ISymbol s, INamedTypeSymbol attribute )
+				=> s.GetAttributes().Where( a => SymbolEqualityComparer.Default.Equals( a.AttributeClass, attribute ) ).ToImmutableArray();
+		}
+
+		private sealed class AttributeDataComparer : IEqualityComparer<AttributeData> {
+
+			public static readonly AttributeDataComparer Instance = new();
+
+			private AttributeDataComparer() { }
+
+			bool IEqualityComparer<AttributeData>.Equals( AttributeData x, AttributeData y ) {
+				if( x.ConstructorArguments.Length != y.ConstructorArguments.Length ) {
+					return false;
+				}
+
+				if( x.NamedArguments.Length != y.NamedArguments.Length ) {
+					return false;
+				}
+
+				for( int i = 0; i < x.ConstructorArguments.Length; i++ ) {
+					if( !x.ConstructorArguments[ i ].Equals( y.ConstructorArguments[ i ] ) ) {
+						return false;
+					}
+				}
+
+				var namedXArgs = x.NamedArguments.OrderBy( static arg => arg.Key, StringComparer.Ordinal ).ToArray();
+				var namedYArgs = y.NamedArguments.OrderBy( static arg => arg.Key, StringComparer.Ordinal ).ToArray();
+				for( int i = 0; i < namedXArgs.Length; i++ ) {
+					var namedXArg = namedXArgs[ i ];
+					var namedYArg = namedYArgs[ i ];
+
+					if( !StringComparer.Ordinal.Equals( namedXArg.Key, namedYArg.Key ) ) {
+						return false;
+					}
+
+					if( !namedXArg.Value.Equals( namedYArg.Value ) ) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+
+			int IEqualityComparer<AttributeData>.GetHashCode( AttributeData obj ) {
+				throw new NotImplementedException();
+			}
 		}
 	}
 }

--- a/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
+++ b/src/D2L.CodeStyle.Analyzers/D2L.CodeStyle.Analyzers.csproj
@@ -30,11 +30,13 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\$(AssemblyName).Rule.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\$(AssemblyName).Rule.Constant.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).Rule.PatternString.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
   <Target Name="ValidateRequiredFiles" BeforeTargets="Build">
     <Error Condition="!Exists('$(OutputPath)$(AssemblyName).dll')" Text="Required file '$(OutputPath)$(AssemblyName).dll' is missing." />
     <Error Condition="!Exists('$(OutputPath)D2L.CodeStyle.Analyzers.Rule.dll')" Text="Required file '$(OutputPath)D2L.CodeStyle.Analyzers.Rule.dll' is missing." />
     <Error Condition="!Exists('$(OutputPath)D2L.CodeStyle.Analyzers.Rule.Constant.dll')" Text="Required file '$(OutputPath)D2L.CodeStyle.Analyzers.Rule.Constant.dll' is missing." />
+    <Error Condition="!Exists('$(OutputPath)D2L.CodeStyle.Analyzers.Rule.PatternString.dll')" Text="Required file '$(OutputPath)D2L.CodeStyle.Analyzers.Rule.PatternString.dll' is missing." />
   </Target>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
@@ -55,6 +57,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Rules\D2L.CodeStyle.Analyzers.Rule.Constant\D2L.CodeStyle.Analyzers.Rule.Constant\D2L.CodeStyle.Analyzers.Rule.Constant.csproj">
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\Rules\D2L.CodeStyle.Analyzers.Rule.PatternString\D2L.CodeStyle.Analyzers.Rule.PatternString.csproj">
       <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
     <ProjectReference Include="..\Rules\D2L.CodeStyle.Analyzers.Rule\D2L.CodeStyle.Analyzers.Rule\D2L.CodeStyle.Analyzers.Rule.csproj">

--- a/src/D2L.CodeStyle.Annotations/Contract/PatternStringAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/Contract/PatternStringAttribute.cs
@@ -14,12 +14,11 @@ namespace D2L.CodeStyle.Annotations.Contract;
 )]
 public sealed class PatternStringAttribute : Attribute {
 
-	public PatternStringAttribute( string regexPattern, bool expectMatch = true ) {
+	public PatternStringAttribute( string regexPattern ) {
 		RegexPattern = regexPattern;
-		ExpectMatch = expectMatch;
 	}
 
 	public string RegexPattern { get; }
-	public bool ExpectMatch { get; }
+	public bool ExpectMatch { get; set; } = true;
 
 }

--- a/src/D2L.CodeStyle.Annotations/Contract/PatternStringAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/Contract/PatternStringAttribute.cs
@@ -6,12 +6,7 @@ namespace D2L.CodeStyle.Annotations.Contract;
 /// Indicates that a string must be a constant value matching the given regex pattern.
 /// May be specified multiple times to require the value to satisfy every pattern.
 /// </summary>
-[AttributeUsage(
-	AttributeTargets.Property
-		| AttributeTargets.Field
-		| AttributeTargets.Parameter,
-	AllowMultiple = true
-)]
+[AttributeUsage( AttributeTargets.Parameter, AllowMultiple = true )]
 public sealed class PatternStringAttribute : Attribute {
 
 	public PatternStringAttribute( string regexPattern ) {

--- a/src/D2L.CodeStyle.Annotations/Contract/PatternStringAttribute.cs
+++ b/src/D2L.CodeStyle.Annotations/Contract/PatternStringAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace D2L.CodeStyle.Annotations.Contract;
+
+/// <summary>
+/// Indicates that a string must be a constant value matching the given regex pattern.
+/// May be specified multiple times to require the value to satisfy every pattern.
+/// </summary>
+[AttributeUsage(
+	AttributeTargets.Property
+		| AttributeTargets.Field
+		| AttributeTargets.Parameter,
+	AllowMultiple = true
+)]
+public sealed class PatternStringAttribute : Attribute {
+
+	public PatternStringAttribute( string regexPattern, bool expectMatch = true ) {
+		RegexPattern = regexPattern;
+		ExpectMatch = expectMatch;
+	}
+
+	public string RegexPattern { get; }
+	public bool ExpectMatch { get; }
+
+}

--- a/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
+++ b/src/D2L.CodeStyle.TestAnalyzers/D2L.CodeStyle.TestAnalyzers.csproj
@@ -28,12 +28,14 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\D2L.CodeStyle.Analyzers.Rule.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\D2L.CodeStyle.Analyzers.Rule.Constant.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\D2L.CodeStyle.Analyzers.Rule.PatternString.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <Target Name="ValidateRequiredFiles" BeforeTargets="Build">
     <Error Condition="!Exists('$(OutputPath)$(AssemblyName).dll')" Text="Required file '$(OutputPath)$(AssemblyName).dll' is missing." />
     <Error Condition="!Exists('$(OutputPath)D2L.CodeStyle.Analyzers.Rule.dll')" Text="Required file '$(OutputPath)D2L.CodeStyle.Analyzers.Rule.dll' is missing." />
     <Error Condition="!Exists('$(OutputPath)D2L.CodeStyle.Analyzers.Rule.Constant.dll')" Text="Required file '$(OutputPath)D2L.CodeStyle.Analyzers.Rule.Constant.dll' is missing." />
+    <Error Condition="!Exists('$(OutputPath)D2L.CodeStyle.Analyzers.Rule.PatternString.dll')" Text="Required file '$(OutputPath)D2L.CodeStyle.Analyzers.Rule.PatternString.dll' is missing." />
   </Target>
         
   <ItemGroup>
@@ -47,6 +49,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Rules\D2L.CodeStyle.Analyzers.Rule.Constant\D2L.CodeStyle.Analyzers.Rule.Constant\D2L.CodeStyle.Analyzers.Rule.Constant.csproj">
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\Rules\D2L.CodeStyle.Analyzers.Rule.PatternString\D2L.CodeStyle.Analyzers.Rule.PatternString.csproj">
       <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
     <ProjectReference Include="..\Rules\D2L.CodeStyle.Analyzers.Rule\D2L.CodeStyle.Analyzers.Rule\D2L.CodeStyle.Analyzers.Rule.csproj">

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.Constant/D2L.CodeStyle.Analyzers.Rule.Constant/ConstantAttributeAnalyzer.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.Constant/D2L.CodeStyle.Analyzers.Rule.Constant/ConstantAttributeAnalyzer.cs
@@ -15,7 +15,7 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 			ImmutableArray.Create(
 				Diagnostics.NonConstantPassedToConstantParameter,
 				Diagnostics.InvalidConstantType,
-				Diagnostics.ReferenceToMethodWithConstantParameterNotSupport
+				Diagnostics.ReferenceToMethodWithAttributedParameterNotSupported
 			);
 
 		public override void Initialize( AnalysisContext context ) {
@@ -243,8 +243,9 @@ namespace D2L.CodeStyle.Analyzers.ApiUsage {
 				}
 
 				context.ReportDiagnostic(
-					descriptor: Diagnostics.ReferenceToMethodWithConstantParameterNotSupport,
-					location: operation.Syntax.GetLocation()
+					descriptor: Diagnostics.ReferenceToMethodWithAttributedParameterNotSupported,
+					location: operation.Syntax.GetLocation(),
+					messageArgs: ["Constant"]
 				);
 
 				return;

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/D2L.CodeStyle.Analyzers.Rule.PatternString.csproj
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/D2L.CodeStyle.Analyzers.Rule.PatternString.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="All" />
+    <PackageReference Include="Nullable" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\D2L.CodeStyle.Analyzers.Rule\D2L.CodeStyle.Analyzers.Rule\D2L.CodeStyle.Analyzers.Rule.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -456,7 +457,7 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 		AttributeData patternStringData,
 		ConcurrentDictionary<string, Lazy<Regex>> regexCache
 	) {
-		if( !TryGetPatternStringArguments( patternStringData, out string pattern, out bool expectMatch ) ) {
+		if( !TryGetPatternStringArguments( patternStringData, out string? pattern, out bool? expectMatch ) ) {
 			return;
 		}
 
@@ -524,7 +525,7 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 					location: location,
 					messageArgs: [
 						patternStringValue,
-						expectMatch ? "to match" : "to not match",
+						expectMatch.Value ? "to match" : "to not match",
 						pattern
 					]
 				)
@@ -534,28 +535,30 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 
 	private static bool TryGetPatternStringArguments(
 		AttributeData patternStringData,
-		out string pattern,
-		out bool expectMatch
+		[NotNullWhen( true )] out string? pattern,
+		[NotNullWhen( true )] out bool? expectMatch
 	) {
 		ImmutableArray<TypedConstant> arguments = patternStringData.ConstructorArguments;
 
-		// Confirm there are enough arguments
-		string? patternValue = arguments.Length > 0
+		pattern = arguments.Length > 0
 			? arguments[ 0 ].Value as string
 			: null;
-
-		// and confirm the arguments are of the correct type
-		expectMatch = !( arguments.Length > 1 && arguments[ 1 ].Value is bool b )
-			|| b;
-
-		// and confirm the pattern is actually specified
-		if( string.IsNullOrWhiteSpace( patternValue ) ) {
-			pattern = "";
+		if( pattern is null || string.IsNullOrWhiteSpace( pattern ) ) {
+			pattern = null;
+			expectMatch = false;
 			return false;
 		}
 
-		// The above check confirms it's not null, so we can use ! here
-		pattern = patternValue!;
+		expectMatch = true;
+
+		foreach( KeyValuePair<string, TypedConstant> argument in patternStringData.NamedArguments ) {
+			switch( argument.Key ) {
+				case "ExpectMatch":
+					expectMatch = (bool)argument.Value.Value!;
+					break;
+			}
+		}
+
 		return true;
 	}
 

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -70,7 +69,8 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 		context.RegisterSymbolAction(
 			ctx => AnalyzeParameter(
 				ctx, (IParameterSymbol)ctx.Symbol,
-				patternStringAttribute
+				patternStringAttribute,
+				regexCache
 			),
 			SymbolKind.Parameter
 		);
@@ -79,12 +79,10 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 	private static void AnalyzeParameter(
 		SymbolAnalysisContext context,
 		IParameterSymbol parameter,
-		ISymbol patternStringAttribute
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
 	) {
-		// [PatternString] only makes sense on strings.
-		if( parameter.Type.SpecialType == SpecialType.System_String ) {
-			return;
-		}
+		bool reportedNonString = false;
 
 		foreach( AttributeData attribute in parameter.GetAttributes() ) {
 			if( !SymbolEqualityComparer.Default.Equals(
@@ -94,18 +92,40 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 				continue;
 			}
 
-			SyntaxReference? reference = attribute.ApplicationSyntaxReference;
-			Location location = reference is null
-				? parameter.Locations.FirstOrDefault() ?? Location.None
-				: Location.Create( reference.SyntaxTree, reference.Span );
+			// [PatternString] only makes sense on strings.
+			if( parameter.Type.SpecialType != SpecialType.System_String
+				&& !reportedNonString
+			) {
+				Location location = parameter.Locations.FirstOrDefault() ?? Location.None;
 
-			context.ReportDiagnostic(
-				Diagnostic.Create(
-					descriptor: Diagnostics.PatternStringOnNonStringType,
-					location: location,
-					messageArgs: [ parameter.Type.ToDisplayString() ]
-				)
-			);
+				context.ReportDiagnostic(
+					Diagnostic.Create(
+						descriptor: Diagnostics.PatternStringOnNonStringType,
+						location: location,
+						messageArgs: [ parameter.Type.ToDisplayString() ]
+					)
+				);
+
+				reportedNonString = true;
+			}
+
+			if( GetRegexForAttribute( attribute, regexCache, out string? pattern, out string? message ) is null ) {
+				SyntaxReference? reference = attribute.ApplicationSyntaxReference;
+				Location location = reference is null
+					? parameter.Locations.FirstOrDefault() ?? Location.None
+					: Location.Create( reference.SyntaxTree, reference.Span );
+
+				context.ReportDiagnostic(
+					Diagnostic.Create(
+						descriptor: Diagnostics.PatternStringInvalidPattern,
+						location: location,
+						messageArgs: [
+							pattern,
+							message
+						]
+					)
+				);
+			}
 		}
 	}
 
@@ -233,8 +253,75 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 		AttributeData patternStringData,
 		ConcurrentDictionary<string, Lazy<Regex>> regexCache
 	) {
-		if( !TryGetPatternStringArguments( patternStringData, out string? pattern, out bool? expectMatch ) ) {
+		if( GetRegexForAttribute( patternStringData, regexCache ) is not { } regex ) {
 			return;
+		}
+
+		bool expectMatch = true;
+		foreach( KeyValuePair<string, TypedConstant> argument in patternStringData.NamedArguments ) {
+			switch( argument.Key ) {
+				case "ExpectMatch":
+					expectMatch = (bool)argument.Value.Value!;
+					break;
+			}
+		}
+
+		bool matched;
+		try {
+			matched = regex.IsMatch( patternStringValue );
+		} catch( RegexMatchTimeoutException ) {
+			// The evaluation of the pattern against the value exceeded the
+			// allotted time budget.
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					descriptor: Diagnostics.PatternStringEvaluationTimeout,
+					location: location,
+					messageArgs: [
+						regex,
+						patternStringValue,
+						RegexTimeoutMS
+					]
+				)
+			);
+			return;
+		}
+
+		// Check against the expectMatch of the attribute to confirm
+		// the result is what the declaration expected.
+		if( matched != expectMatch ) {
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					descriptor: Diagnostics.PatternStringDoesNotMatch,
+					location: location,
+					messageArgs: [
+						patternStringValue,
+						expectMatch ? "to match" : "to not match",
+						regex
+					]
+				)
+			);
+		}
+	}
+
+	private static Regex? GetRegexForAttribute(
+		AttributeData attributeData,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) => GetRegexForAttribute( attributeData, regexCache, out _, out _ );
+
+	private static Regex? GetRegexForAttribute(
+		AttributeData attributeData,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache,
+		out string? pattern,
+		out string? message 
+	) {
+		ImmutableArray<TypedConstant> arguments = attributeData.ConstructorArguments;
+
+		pattern = arguments.Length > 0
+			? arguments[ 0 ].Value as string
+			: null;
+		if( pattern is null || string.IsNullOrWhiteSpace( pattern ) ) {
+			message = "Pattern is empty";
+			return null;
 		}
 
 		// Get (or lazily construct) the cached regex. Using a Lazy<Regex>
@@ -259,99 +346,11 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 			// The declared pattern is not a valid regex. The exception is
 			// cached by the Lazy, so we don't repeatedly attempt to compile
 			// an invalid pattern.
-			context.ReportDiagnostic(
-				Diagnostic.Create(
-					descriptor: Diagnostics.PatternStringInvalidPattern,
-					location: GetPatternDiagnosticLocation( patternStringData, location ),
-					messageArgs: [
-						pattern,
-						ex.Message
-					]
-				)
-			);
-			return;
+			message = ex.Message;
+			return null;
 		}
 
-		bool matched;
-		try {
-			matched = regex.IsMatch( patternStringValue );
-		} catch( RegexMatchTimeoutException ) {
-			// The evaluation of the pattern against the value exceeded the
-			// allotted time budget.
-			context.ReportDiagnostic(
-				Diagnostic.Create(
-					descriptor: Diagnostics.PatternStringEvaluationTimeout,
-					location: location,
-					messageArgs: [
-						pattern,
-						patternStringValue,
-						RegexTimeoutMS
-					]
-				)
-			);
-			return;
-		}
-
-		// Check against the expectMatch of the attribute to confirm
-		// the result is what the declaration expected.
-		if( matched != expectMatch ) {
-			context.ReportDiagnostic(
-				Diagnostic.Create(
-					descriptor: Diagnostics.PatternStringDoesNotMatch,
-					location: location,
-					messageArgs: [
-						patternStringValue,
-						expectMatch.Value ? "to match" : "to not match",
-						pattern
-					]
-				)
-			);
-		}
-	}
-
-	private static bool TryGetPatternStringArguments(
-		AttributeData patternStringData,
-		[NotNullWhen( true )] out string? pattern,
-		[NotNullWhen( true )] out bool? expectMatch
-	) {
-		ImmutableArray<TypedConstant> arguments = patternStringData.ConstructorArguments;
-
-		pattern = arguments.Length > 0
-			? arguments[ 0 ].Value as string
-			: null;
-		if( pattern is null || string.IsNullOrWhiteSpace( pattern ) ) {
-			pattern = null;
-			expectMatch = false;
-			return false;
-		}
-
-		expectMatch = true;
-
-		foreach( KeyValuePair<string, TypedConstant> argument in patternStringData.NamedArguments ) {
-			switch( argument.Key ) {
-				case "ExpectMatch":
-					expectMatch = (bool)argument.Value.Value!;
-					break;
-			}
-		}
-
-		return true;
-	}
-
-	/// <summary>
-	/// Prefers the location of the [PatternString] attribute application (so the
-	/// invalid pattern is flagged on the declaration) and falls back to the value
-	/// location when the attribute originates from metadata.
-	/// </summary>
-	private static Location GetPatternDiagnosticLocation(
-		AttributeData patternStringData,
-		Location fallback
-	) {
-		SyntaxReference? reference = patternStringData.ApplicationSyntaxReference;
-		if( reference == null ) {
-			return fallback;
-		}
-
-		return Location.Create( reference.SyntaxTree, reference.Span );
+		message = null;
+		return regex;
 	}
 }

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
@@ -68,36 +68,25 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 		// action validates the declaration itself so that applying
 		// [PatternString] to a non-string member is flagged once at its source.
 		context.RegisterSymbolAction(
-			ctx => AnalyzeSymbolDeclaration( ctx, patternStringAttribute ),
-			SymbolKind.Method
+			ctx => AnalyzeParameter(
+				ctx, (IParameterSymbol)ctx.Symbol,
+				patternStringAttribute
+			),
+			SymbolKind.Parameter
 		);
 	}
 
-	private static void AnalyzeSymbolDeclaration(
+	private static void AnalyzeParameter(
 		SymbolAnalysisContext context,
-		ISymbol patternStringAttribute
-	) {
-		switch( context.Symbol ) {
-			case IMethodSymbol method:
-				foreach( IParameterSymbol parameter in method.Parameters ) {
-					ReportIfNonStringTarget( context, parameter, parameter.Type, patternStringAttribute );
-				}
-				break;
-		}
-	}
-
-	private static void ReportIfNonStringTarget(
-		SymbolAnalysisContext context,
-		ISymbol attributedSymbol,
-		ITypeSymbol targetType,
+		IParameterSymbol parameter,
 		ISymbol patternStringAttribute
 	) {
 		// [PatternString] only makes sense on strings.
-		if( targetType.SpecialType == SpecialType.System_String ) {
+		if( parameter.Type.SpecialType == SpecialType.System_String ) {
 			return;
 		}
 
-		foreach( AttributeData attribute in attributedSymbol.GetAttributes() ) {
+		foreach( AttributeData attribute in parameter.GetAttributes() ) {
 			if( !SymbolEqualityComparer.Default.Equals(
 				attribute.AttributeClass,
 				patternStringAttribute
@@ -107,14 +96,14 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 
 			SyntaxReference? reference = attribute.ApplicationSyntaxReference;
 			Location location = reference is null
-				? attributedSymbol.Locations.FirstOrDefault() ?? Location.None
+				? parameter.Locations.FirstOrDefault() ?? Location.None
 				: Location.Create( reference.SyntaxTree, reference.Span );
 
 			context.ReportDiagnostic(
 				Diagnostic.Create(
 					descriptor: Diagnostics.PatternStringOnNonStringType,
 					location: location,
-					messageArgs: [ targetType.ToDisplayString() ]
+					messageArgs: [ parameter.Type.ToDisplayString() ]
 				)
 			);
 		}

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
@@ -18,7 +18,8 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 			Diagnostics.PatternStringDoesNotMatch,
 			Diagnostics.PatternStringInvalidPattern,
 			Diagnostics.PatternStringEvaluationTimeout,
-			Diagnostics.PatternStringOnNonStringType
+			Diagnostics.PatternStringOnNonStringType,
+			Diagnostics.ReferenceToMethodWithAttributedParameterNotSupported
 		);
 
 	public override void Initialize( AnalysisContext context ) {
@@ -74,6 +75,15 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 			),
 			SymbolKind.Parameter
 		);
+
+		context.RegisterOperationAction(
+			ctx => AnalyzeMethodReference(
+				ctx,
+				(IMethodReferenceOperation)ctx.Operation,
+				patternStringAttribute
+			),
+			OperationKind.MethodReference
+		);
 	}
 
 	private static void AnalyzeParameter(
@@ -126,6 +136,26 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 					)
 				);
 			}
+		}
+	}
+
+	private static void AnalyzeMethodReference(
+		OperationAnalysisContext context,
+		IMethodReferenceOperation operation,
+		INamedTypeSymbol PatternStringAttributeT
+	) {
+		foreach( IParameterSymbol parameter in operation.Method.Parameters ) {
+			if( !HasAttribute( parameter, PatternStringAttributeT ) ) {
+				continue;
+			}
+
+			context.ReportDiagnostic(
+				descriptor: Diagnostics.ReferenceToMethodWithAttributedParameterNotSupported,
+				location: operation.Syntax.GetLocation(),
+				messageArgs: ["PatternString"]
+			);
+
+			return;
 		}
 	}
 
@@ -352,5 +382,17 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 
 		message = null;
 		return regex;
+	}
+
+	private static bool HasAttribute(
+		ISymbol symbol,
+		INamedTypeSymbol attributeType
+	) {
+		return symbol.GetAttributes()
+			.Any( attr => SymbolEqualityComparer.Default.Equals(
+					attributeType,
+					attr.AttributeClass
+				)
+			);
 	}
 }

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
@@ -45,36 +45,6 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 		ConcurrentDictionary<string, Lazy<Regex>> regexCache = [];
 
 		context.RegisterOperationAction(
-			ctx => AnalyzeAssignment(
-				ctx,
-				(ISimpleAssignmentOperation)ctx.Operation,
-				patternStringAttribute,
-				regexCache
-			),
-			OperationKind.SimpleAssignment
-		);
-
-		context.RegisterOperationAction(
-			ctx => AnalyzeFieldInitializer(
-				ctx,
-				(IFieldInitializerOperation)ctx.Operation,
-				patternStringAttribute,
-				regexCache
-			),
-			OperationKind.FieldInitializer
-		);
-
-		context.RegisterOperationAction(
-			ctx => AnalyzePropertyInitializer(
-				ctx,
-				(IPropertyInitializerOperation)ctx.Operation,
-				patternStringAttribute,
-				regexCache
-			),
-			OperationKind.PropertyInitializer
-		);
-
-		context.RegisterOperationAction(
 			ctx => AnalyzeArgument(
 				ctx,
 				(IArgumentOperation)ctx.Operation,
@@ -94,23 +64,11 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 			OperationKind.Conversion
 		);
 
-		context.RegisterOperationAction(
-			ctx => AnalyzeDeconstructionAssignment(
-				ctx,
-				(IDeconstructionAssignmentOperation)ctx.Operation,
-				patternStringAttribute,
-				regexCache
-			),
-			OperationKind.DeconstructionAssignment
-		);
-
 		// The above operation actions validate the assigned value; this symbol
 		// action validates the declaration itself so that applying
 		// [PatternString] to a non-string member is flagged once at its source.
 		context.RegisterSymbolAction(
 			ctx => AnalyzeSymbolDeclaration( ctx, patternStringAttribute ),
-			SymbolKind.Field,
-			SymbolKind.Property,
 			SymbolKind.Method
 		);
 	}
@@ -120,12 +78,6 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 		ISymbol patternStringAttribute
 	) {
 		switch( context.Symbol ) {
-			case IFieldSymbol field:
-				ReportIfNonStringTarget( context, field, field.Type, patternStringAttribute );
-				break;
-			case IPropertySymbol property:
-				ReportIfNonStringTarget( context, property, property.Type, patternStringAttribute );
-				break;
 			case IMethodSymbol method:
 				foreach( IParameterSymbol parameter in method.Parameters ) {
 					ReportIfNonStringTarget( context, parameter, parameter.Type, patternStringAttribute );
@@ -164,74 +116,6 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 					location: location,
 					messageArgs: [ targetType.ToDisplayString() ]
 				)
-			);
-		}
-	}
-
-	private static void AnalyzeAssignment(
-		OperationAnalysisContext context,
-		ISimpleAssignmentOperation assignment,
-		INamedTypeSymbol patternStringAttribute,
-		ConcurrentDictionary<string, Lazy<Regex>> regexCache
-	) {
-		ISymbol target;
-		ITypeSymbol targetType;
-
-		switch( assignment.Target ) {
-			case IPropertyReferenceOperation propertyReference:
-				target = propertyReference.Property;
-				targetType = propertyReference.Property.Type;
-				break;
-			case IFieldReferenceOperation fieldReference:
-				target = fieldReference.Field;
-				targetType = fieldReference.Field.Type;
-				break;
-			default:
-				return;
-		}
-
-		HandleAttributedTarget(
-			context,
-			attributedSymbol: target,
-			targetType: targetType,
-			valueOperation: assignment.Value,
-			patternStringAttribute: patternStringAttribute,
-			regexCache: regexCache
-		);
-	}
-
-	private static void AnalyzeFieldInitializer(
-		OperationAnalysisContext context,
-		IFieldInitializerOperation initializer,
-		INamedTypeSymbol patternStringAttribute,
-		ConcurrentDictionary<string, Lazy<Regex>> regexCache
-	) {
-		foreach( IFieldSymbol field in initializer.InitializedFields ) {
-			HandleAttributedTarget(
-				context,
-				attributedSymbol: field,
-				targetType: field.Type,
-				valueOperation: initializer.Value,
-				patternStringAttribute: patternStringAttribute,
-				regexCache: regexCache
-			);
-		}
-	}
-
-	private static void AnalyzePropertyInitializer(
-		OperationAnalysisContext context,
-		IPropertyInitializerOperation initializer,
-		INamedTypeSymbol patternStringAttribute,
-		ConcurrentDictionary<string, Lazy<Regex>> regexCache
-	) {
-		foreach( IPropertySymbol property in initializer.InitializedProperties ) {
-			HandleAttributedTarget(
-				context,
-				attributedSymbol: property,
-				targetType: property.Type,
-				valueOperation: initializer.Value,
-				patternStringAttribute: patternStringAttribute,
-				regexCache: regexCache
 			);
 		}
 	}
@@ -282,103 +166,6 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 		);
 	}
 
-	private static void AnalyzeDeconstructionAssignment(
-		OperationAnalysisContext context,
-		IDeconstructionAssignmentOperation assignment,
-		INamedTypeSymbol patternStringAttribute,
-		ConcurrentDictionary<string, Lazy<Regex>> regexCache
-	) {
-		HandleDeconstruction(
-			context,
-			target: assignment.Target,
-			value: assignment.Value,
-			patternStringAttribute: patternStringAttribute,
-			regexCache: regexCache
-		);
-	}
-
-	// Handle deconstruction operations like (foo.Property, foo.Field) = ("123", "456");
-	// and ensure it carries through to the validation.
-	private static void HandleDeconstruction(
-		OperationAnalysisContext context,
-		IOperation target,
-		IOperation value,
-		INamedTypeSymbol patternStringAttribute,
-		ConcurrentDictionary<string, Lazy<Regex>> regexCache
-	) {
-		// First, on each target/value unwrap them in case they're using implicit
-		// conversions, then confirm that we're going tuple<->tuple
-		if( ( UnwrapConversions( target ) is not ITupleOperation targetTuple )
-			|| ( UnwrapConversions( value ) is not ITupleOperation valueTuple )
-		) {
-			return;
-		}
-
-		// Now confirm we're deconstructing to tuples of the same size
-		// otherwise this doesn't allow us to pair up below.
-		if( targetTuple.Elements.Length != valueTuple.Elements.Length ) {
-			return;
-		}
-
-		for( int i = 0; i < targetTuple.Elements.Length; i++ ) {
-			IOperation elementTarget = UnwrapConversions( targetTuple.Elements[ i ] );
-			IOperation elementValue = valueTuple.Elements[ i ];
-
-			// Nested deconstruction, e.g. ((a, b), c) = ((x, y), z).
-			if( elementTarget is ITupleOperation ) {
-				HandleDeconstruction(
-					context,
-					target: elementTarget,
-					value: elementValue,
-					patternStringAttribute: patternStringAttribute,
-					regexCache: regexCache
-				);
-				continue;
-			}
-
-			// Comb out the member and memberType we're interested in
-			// so HandleAttributedTarget doesn't care where it came from.
-			ISymbol member;
-			ITypeSymbol memberType;
-			switch( elementTarget ) {
-				case IPropertyReferenceOperation propertyReference:
-					member = propertyReference.Property;
-					memberType = propertyReference.Property.Type;
-					break;
-				case IFieldReferenceOperation fieldReference:
-					member = fieldReference.Field;
-					memberType = fieldReference.Field.Type;
-					break;
-				default:
-					continue;
-			}
-
-			HandleAttributedTarget(
-				context,
-				attributedSymbol: member,
-				targetType: memberType,
-				valueOperation: UnwrapConversions( elementValue ),
-				patternStringAttribute: patternStringAttribute,
-				regexCache: regexCache
-			);
-		}
-	}
-
-	private static IOperation UnwrapConversions(
-		IOperation operation
-	) {
-		// Keep peeling away conversions until we get to the underlying operation
-		while( operation is IConversionOperation conversion
-			&& conversion.OperatorMethod is null
-		) {
-			operation = conversion.Operand;
-		}
-
-		return operation;
-	}
-
-	// AnalyzeAssignment, AnalyzeFieldInitializer, AnalyzePropertyInitializer,
-	// and AnalyzeArgument from above all feed in to here to centralize the logic.
 	private static void HandleAttributedTarget(
 		OperationAnalysisContext context,
 		ISymbol attributedSymbol,

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
@@ -1,0 +1,578 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace D2L.CodeStyle.Analyzers.ApiUsage;
+
+[DiagnosticAnalyzer( LanguageNames.CSharp )]
+public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
+
+	public const int RegexTimeoutMS = 750;
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+		ImmutableArray.Create(
+			Diagnostics.PatternStringMustBeConstant,
+			Diagnostics.PatternStringDoesNotMatch,
+			Diagnostics.PatternStringInvalidPattern,
+			Diagnostics.PatternStringEvaluationTimeout,
+			Diagnostics.PatternStringOnNonStringType
+		);
+
+	public override void Initialize( AnalysisContext context ) {
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis( GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics );
+		context.RegisterCompilationStartAction( CompilationStart );
+	}
+
+	public static void CompilationStart(
+		CompilationStartAnalysisContext context
+	) {
+		var patternStringAttribute = context.Compilation.GetTypeByMetadataName(
+			"D2L.CodeStyle.Annotations.Contract.PatternStringAttribute"
+		);
+
+		// If we couldn't find the symbol don't proceed with the evaluation.
+		if( patternStringAttribute is null
+			|| patternStringAttribute.Kind == SymbolKind.ErrorType
+		) {
+			return;
+		}
+
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache = [];
+
+		context.RegisterOperationAction(
+			ctx => AnalyzeAssignment(
+				ctx,
+				(ISimpleAssignmentOperation)ctx.Operation,
+				patternStringAttribute,
+				regexCache
+			),
+			OperationKind.SimpleAssignment
+		);
+
+		context.RegisterOperationAction(
+			ctx => AnalyzeFieldInitializer(
+				ctx,
+				(IFieldInitializerOperation)ctx.Operation,
+				patternStringAttribute,
+				regexCache
+			),
+			OperationKind.FieldInitializer
+		);
+
+		context.RegisterOperationAction(
+			ctx => AnalyzePropertyInitializer(
+				ctx,
+				(IPropertyInitializerOperation)ctx.Operation,
+				patternStringAttribute,
+				regexCache
+			),
+			OperationKind.PropertyInitializer
+		);
+
+		context.RegisterOperationAction(
+			ctx => AnalyzeArgument(
+				ctx,
+				(IArgumentOperation)ctx.Operation,
+				patternStringAttribute,
+				regexCache
+			),
+			OperationKind.Argument
+		);
+
+		context.RegisterOperationAction(
+			ctx => AnalyzeConversion(
+				ctx,
+				(IConversionOperation)ctx.Operation,
+				patternStringAttribute,
+				regexCache
+			),
+			OperationKind.Conversion
+		);
+
+		context.RegisterOperationAction(
+			ctx => AnalyzeDeconstructionAssignment(
+				ctx,
+				(IDeconstructionAssignmentOperation)ctx.Operation,
+				patternStringAttribute,
+				regexCache
+			),
+			OperationKind.DeconstructionAssignment
+		);
+
+		// The above operation actions validate the assigned value; this symbol
+		// action validates the declaration itself so that applying
+		// [PatternString] to a non-string member is flagged once at its source.
+		context.RegisterSymbolAction(
+			ctx => AnalyzeSymbolDeclaration( ctx, patternStringAttribute ),
+			SymbolKind.Field,
+			SymbolKind.Property,
+			SymbolKind.Method
+		);
+	}
+
+	private static void AnalyzeSymbolDeclaration(
+		SymbolAnalysisContext context,
+		ISymbol patternStringAttribute
+	) {
+		switch( context.Symbol ) {
+			case IFieldSymbol field:
+				ReportIfNonStringTarget( context, field, field.Type, patternStringAttribute );
+				break;
+			case IPropertySymbol property:
+				ReportIfNonStringTarget( context, property, property.Type, patternStringAttribute );
+				break;
+			case IMethodSymbol method:
+				foreach( IParameterSymbol parameter in method.Parameters ) {
+					ReportIfNonStringTarget( context, parameter, parameter.Type, patternStringAttribute );
+				}
+				break;
+		}
+	}
+
+	private static void ReportIfNonStringTarget(
+		SymbolAnalysisContext context,
+		ISymbol attributedSymbol,
+		ITypeSymbol targetType,
+		ISymbol patternStringAttribute
+	) {
+		// [PatternString] only makes sense on strings.
+		if( targetType.SpecialType == SpecialType.System_String ) {
+			return;
+		}
+
+		foreach( AttributeData attribute in attributedSymbol.GetAttributes() ) {
+			if( !SymbolEqualityComparer.Default.Equals(
+				attribute.AttributeClass,
+				patternStringAttribute
+			) ) {
+				continue;
+			}
+
+			SyntaxReference? reference = attribute.ApplicationSyntaxReference;
+			Location location = reference is null
+				? attributedSymbol.Locations.FirstOrDefault() ?? Location.None
+				: Location.Create( reference.SyntaxTree, reference.Span );
+
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					descriptor: Diagnostics.PatternStringOnNonStringType,
+					location: location,
+					messageArgs: [ targetType.ToDisplayString() ]
+				)
+			);
+		}
+	}
+
+	private static void AnalyzeAssignment(
+		OperationAnalysisContext context,
+		ISimpleAssignmentOperation assignment,
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		ISymbol target;
+		ITypeSymbol targetType;
+
+		switch( assignment.Target ) {
+			case IPropertyReferenceOperation propertyReference:
+				target = propertyReference.Property;
+				targetType = propertyReference.Property.Type;
+				break;
+			case IFieldReferenceOperation fieldReference:
+				target = fieldReference.Field;
+				targetType = fieldReference.Field.Type;
+				break;
+			default:
+				return;
+		}
+
+		HandleAttributedTarget(
+			context,
+			attributedSymbol: target,
+			targetType: targetType,
+			valueOperation: assignment.Value,
+			patternStringAttribute: patternStringAttribute,
+			regexCache: regexCache
+		);
+	}
+
+	private static void AnalyzeFieldInitializer(
+		OperationAnalysisContext context,
+		IFieldInitializerOperation initializer,
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		foreach( IFieldSymbol field in initializer.InitializedFields ) {
+			HandleAttributedTarget(
+				context,
+				attributedSymbol: field,
+				targetType: field.Type,
+				valueOperation: initializer.Value,
+				patternStringAttribute: patternStringAttribute,
+				regexCache: regexCache
+			);
+		}
+	}
+
+	private static void AnalyzePropertyInitializer(
+		OperationAnalysisContext context,
+		IPropertyInitializerOperation initializer,
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		foreach( IPropertySymbol property in initializer.InitializedProperties ) {
+			HandleAttributedTarget(
+				context,
+				attributedSymbol: property,
+				targetType: property.Type,
+				valueOperation: initializer.Value,
+				patternStringAttribute: patternStringAttribute,
+				regexCache: regexCache
+			);
+		}
+	}
+
+	private static void AnalyzeArgument(
+		OperationAnalysisContext context,
+		IArgumentOperation argument,
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		IParameterSymbol? parameter = argument.Parameter;
+		if( parameter is null ) {
+			return;
+		}
+
+		HandleAttributedTarget(
+			context,
+			attributedSymbol: parameter,
+			targetType: parameter.Type,
+			valueOperation: argument.Value,
+			patternStringAttribute: patternStringAttribute,
+			regexCache: regexCache
+		);
+	}
+
+	private static void AnalyzeConversion(
+		OperationAnalysisContext context,
+		IConversionOperation conversion,
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		// Only user-defined conversion operators can carry a [PatternString]
+		// attribute on their parameter.
+		IMethodSymbol? conversionMethod = conversion.OperatorMethod;
+		if( conversionMethod is null || conversionMethod.Parameters.Length != 1 ) {
+			return;
+		}
+
+		IParameterSymbol parameter = conversionMethod.Parameters[ 0 ];
+
+		HandleAttributedTarget(
+			context,
+			attributedSymbol: parameter,
+			targetType: parameter.Type,
+			valueOperation: conversion.Operand,
+			patternStringAttribute: patternStringAttribute,
+			regexCache: regexCache
+		);
+	}
+
+	private static void AnalyzeDeconstructionAssignment(
+		OperationAnalysisContext context,
+		IDeconstructionAssignmentOperation assignment,
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		HandleDeconstruction(
+			context,
+			target: assignment.Target,
+			value: assignment.Value,
+			patternStringAttribute: patternStringAttribute,
+			regexCache: regexCache
+		);
+	}
+
+	// Handle deconstruction operations like (foo.Property, foo.Field) = ("123", "456");
+	// and ensure it carries through to the validation.
+	private static void HandleDeconstruction(
+		OperationAnalysisContext context,
+		IOperation target,
+		IOperation value,
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		// First, on each target/value unwrap them in case they're using implicit
+		// conversions, then confirm that we're going tuple<->tuple
+		if( ( UnwrapConversions( target ) is not ITupleOperation targetTuple )
+			|| ( UnwrapConversions( value ) is not ITupleOperation valueTuple )
+		) {
+			return;
+		}
+
+		// Now confirm we're deconstructing to tuples of the same size
+		// otherwise this doesn't allow us to pair up below.
+		if( targetTuple.Elements.Length != valueTuple.Elements.Length ) {
+			return;
+		}
+
+		for( int i = 0; i < targetTuple.Elements.Length; i++ ) {
+			IOperation elementTarget = UnwrapConversions( targetTuple.Elements[ i ] );
+			IOperation elementValue = valueTuple.Elements[ i ];
+
+			// Nested deconstruction, e.g. ((a, b), c) = ((x, y), z).
+			if( elementTarget is ITupleOperation ) {
+				HandleDeconstruction(
+					context,
+					target: elementTarget,
+					value: elementValue,
+					patternStringAttribute: patternStringAttribute,
+					regexCache: regexCache
+				);
+				continue;
+			}
+
+			// Comb out the member and memberType we're interested in
+			// so HandleAttributedTarget doesn't care where it came from.
+			ISymbol member;
+			ITypeSymbol memberType;
+			switch( elementTarget ) {
+				case IPropertyReferenceOperation propertyReference:
+					member = propertyReference.Property;
+					memberType = propertyReference.Property.Type;
+					break;
+				case IFieldReferenceOperation fieldReference:
+					member = fieldReference.Field;
+					memberType = fieldReference.Field.Type;
+					break;
+				default:
+					continue;
+			}
+
+			HandleAttributedTarget(
+				context,
+				attributedSymbol: member,
+				targetType: memberType,
+				valueOperation: UnwrapConversions( elementValue ),
+				patternStringAttribute: patternStringAttribute,
+				regexCache: regexCache
+			);
+		}
+	}
+
+	private static IOperation UnwrapConversions(
+		IOperation operation
+	) {
+		// Keep peeling away conversions until we get to the underlying operation
+		while( operation is IConversionOperation conversion
+			&& conversion.OperatorMethod is null
+		) {
+			operation = conversion.Operand;
+		}
+
+		return operation;
+	}
+
+	// AnalyzeAssignment, AnalyzeFieldInitializer, AnalyzePropertyInitializer,
+	// and AnalyzeArgument from above all feed in to here to centralize the logic.
+	private static void HandleAttributedTarget(
+		OperationAnalysisContext context,
+		ISymbol attributedSymbol,
+		ITypeSymbol targetType,
+		IOperation valueOperation,
+		INamedTypeSymbol patternStringAttribute,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		// Non-string targets are reported at their declaration, bail here
+		// so we don't attempt to treat a non-string constant as a string.
+		if( targetType.SpecialType != SpecialType.System_String ) {
+			return;
+		}
+
+		// We only care about targets annotated with [PatternString]. Since
+		// the attribute may be specified multiple times we collect all of them.
+		ImmutableArray<AttributeData> patternStringInstances = attributedSymbol
+			.GetAttributes()
+			.Where( a => SymbolEqualityComparer.Default.Equals( a.AttributeClass, patternStringAttribute ) )
+			.ToImmutableArray();
+		// If it doesn't have the attribute, nothing to do
+		if( patternStringInstances.IsEmpty ) {
+			return;
+		}
+
+		// Once we've determined that we have a [PatternString] target then we
+		// attempt to evaluate the value of the string.
+		ProcessConstantValue(
+			context,
+			valueOperation,
+			patternStringInstances,
+			regexCache
+		);
+	}
+
+	private static void ProcessConstantValue(
+		OperationAnalysisContext context,
+		IOperation valueOperation,
+		ImmutableArray<AttributeData> patternStringInstances,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		// [PatternString] requires the assigned value to be a compile-time
+		// constant so that we can evaluate it here.
+		Optional<object?> constant = valueOperation.ConstantValue;
+		if( !constant.HasValue ) {
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					descriptor: Diagnostics.PatternStringMustBeConstant,
+					location: valueOperation.Syntax.GetLocation(),
+					messageArgs: []
+				)
+			);
+			return;
+		}
+
+		// We can use ! here because the above check ensures there's a value
+		string patternStringValue = (string)constant.Value!;
+
+		// Now that we have the value, we can evaluate it against every declared
+		// regex pattern. A diagnostic is emitted for each pattern that fails.
+		foreach( AttributeData patternStringInstance in patternStringInstances ) {
+			DoPatternMatching(
+				context,
+				patternStringValue,
+				valueOperation.Syntax.GetLocation(),
+				patternStringInstance,
+				regexCache
+			);
+		}
+	}
+
+	private static void DoPatternMatching(
+		OperationAnalysisContext context,
+		string patternStringValue,
+		Location location,
+		AttributeData patternStringData,
+		ConcurrentDictionary<string, Lazy<Regex>> regexCache
+	) {
+		if( !TryGetPatternStringArguments( patternStringData, out string pattern, out bool expectMatch ) ) {
+			return;
+		}
+
+		// Get (or lazily construct) the cached regex. Using a Lazy<Regex>
+		// with GetOrAdd guarantees the regex is compiled exactly once per
+		// pattern, even when multiple threads miss the cache concurrently.
+		Lazy<Regex> lazyRegex = regexCache.GetOrAdd(
+			pattern,
+			static ( string p ) => new Lazy<Regex>(
+				() => new Regex(
+					p,
+					RegexOptions.CultureInvariant,
+					TimeSpan.FromMilliseconds( RegexTimeoutMS )
+				),
+				LazyThreadSafetyMode.ExecutionAndPublication
+			)
+		);
+
+		Regex regex;
+		try {
+			regex = lazyRegex.Value;
+		} catch( ArgumentException ex ) {
+			// The declared pattern is not a valid regex. The exception is
+			// cached by the Lazy, so we don't repeatedly attempt to compile
+			// an invalid pattern.
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					descriptor: Diagnostics.PatternStringInvalidPattern,
+					location: GetPatternDiagnosticLocation( patternStringData, location ),
+					messageArgs: [
+						pattern,
+						ex.Message
+					]
+				)
+			);
+			return;
+		}
+
+		bool matched;
+		try {
+			matched = regex.IsMatch( patternStringValue );
+		} catch( RegexMatchTimeoutException ) {
+			// The evaluation of the pattern against the value exceeded the
+			// allotted time budget.
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					descriptor: Diagnostics.PatternStringEvaluationTimeout,
+					location: location,
+					messageArgs: [
+						pattern,
+						patternStringValue,
+						RegexTimeoutMS
+					]
+				)
+			);
+			return;
+		}
+
+		// Check against the expectMatch of the attribute to confirm
+		// the result is what the declaration expected.
+		if( matched != expectMatch ) {
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					descriptor: Diagnostics.PatternStringDoesNotMatch,
+					location: location,
+					messageArgs: [
+						patternStringValue,
+						expectMatch ? "to match" : "to not match",
+						pattern
+					]
+				)
+			);
+		}
+	}
+
+	private static bool TryGetPatternStringArguments(
+		AttributeData patternStringData,
+		out string pattern,
+		out bool expectMatch
+	) {
+		ImmutableArray<TypedConstant> arguments = patternStringData.ConstructorArguments;
+
+		// Confirm there are enough arguments
+		string? patternValue = arguments.Length > 0
+			? arguments[ 0 ].Value as string
+			: null;
+
+		// and confirm the arguments are of the correct type
+		expectMatch = !( arguments.Length > 1 && arguments[ 1 ].Value is bool b )
+			|| b;
+
+		// and confirm the pattern is actually specified
+		if( string.IsNullOrWhiteSpace( patternValue ) ) {
+			pattern = "";
+			return false;
+		}
+
+		// The above check confirms it's not null, so we can use ! here
+		pattern = patternValue!;
+		return true;
+	}
+
+	/// <summary>
+	/// Prefers the location of the [PatternString] attribute application (so the
+	/// invalid pattern is flagged on the declaration) and falls back to the value
+	/// location when the attribute originates from metadata.
+	/// </summary>
+	private static Location GetPatternDiagnosticLocation(
+		AttributeData patternStringData,
+		Location fallback
+	) {
+		SyntaxReference? reference = patternStringData.ApplicationSyntaxReference;
+		if( reference == null ) {
+			return fallback;
+		}
+
+		return Location.Create( reference.SyntaxTree, reference.Span );
+	}
+}

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule/D2L.CodeStyle.Analyzers.Rule/Diagnostics.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule/D2L.CodeStyle.Analyzers.Rule/Diagnostics.cs
@@ -783,5 +783,50 @@ namespace D2L.CodeStyle.Analyzers {
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true
 		 );
+
+		public static readonly DiagnosticDescriptor PatternStringMustBeConstant = new DiagnosticDescriptor(
+			id: "D2L0106",
+			title: "The value assigned to a member marked with [PatternString] must be a compile-time constant",
+			messageFormat: "The value assigned to a member marked with [PatternString] must be a compile-time constant",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		 );
+
+		public static readonly DiagnosticDescriptor PatternStringDoesNotMatch = new DiagnosticDescriptor(
+			id: "D2L0107",
+			title: "A [PatternString] value does not satisfy its required regex pattern",
+			messageFormat: "The constant string \"{0}\" was expected {1} the pattern \"{2}\"",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		 );
+
+		public static readonly DiagnosticDescriptor PatternStringInvalidPattern = new DiagnosticDescriptor(
+			id: "D2L0108",
+			title: "The [PatternString] regex pattern is not a valid regular expression",
+			messageFormat: "The [PatternString] regex pattern \"{0}\" is not a valid regular expression: {1}",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		 );
+
+		public static readonly DiagnosticDescriptor PatternStringEvaluationTimeout = new DiagnosticDescriptor(
+			id: "D2L0109",
+			title: "The [PatternString] regex pattern could not be evaluated in time",
+			messageFormat: "The [PatternString] regex pattern \"{0}\" could not be evaluated against the constant string \"{1}\" within {2}ms",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		);
+
+		public static readonly DiagnosticDescriptor PatternStringOnNonStringType = new DiagnosticDescriptor(
+			id: "D2L0110",
+			title: "[PatternString] can only be applied to string members",
+			messageFormat: "[PatternString] can only be applied to string members, but was applied to a member of type \"{0}\"",
+			category: "Correctness",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true
+		 );
 	}
 }

--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule/D2L.CodeStyle.Analyzers.Rule/Diagnostics.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule/D2L.CodeStyle.Analyzers.Rule/Diagnostics.cs
@@ -748,10 +748,10 @@ namespace D2L.CodeStyle.Analyzers {
 			isEnabledByDefault: true
 		);
 
-		public static readonly DiagnosticDescriptor ReferenceToMethodWithConstantParameterNotSupport = new DiagnosticDescriptor(
+		public static readonly DiagnosticDescriptor ReferenceToMethodWithAttributedParameterNotSupported = new DiagnosticDescriptor(
 			id: "D2L0102",
-			title: "References to methods with parameters marked as [Constant] is not supported",
-			messageFormat: "References to methods with parameters marked as [Constant] is currently not supported",
+			title: "References to methods with parameters marked as [{0}] is not supported",
+			messageFormat: "References to methods with parameters marked as [{0}] is currently not supported",
 			category: "Correctness",
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true

--- a/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
+++ b/tests/D2L.CodeStyle.Analyzers.Test/D2L.CodeStyle.Analyzers.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\D2L.CodeStyle.Annotations\D2L.CodeStyle.Annotations.csproj" />
     <ProjectReference Include="..\..\src\D2L.CodeStyle.SpecTests\D2L.CodeStyle.SpecTests.csproj" />
     <ProjectReference Include="..\..\src\Rules\D2L.CodeStyle.Analyzers.Rule.Constant\D2L.CodeStyle.Analyzers.Rule.Constant\D2L.CodeStyle.Analyzers.Rule.Constant.csproj" />
+    <ProjectReference Include="..\..\src\Rules\D2L.CodeStyle.Analyzers.Rule.PatternString\D2L.CodeStyle.Analyzers.Rule.PatternString.csproj" />
     <ProjectReference Include="..\..\src\Rules\D2L.CodeStyle.Analyzers.Rule\D2L.CodeStyle.Analyzers.Rule\D2L.CodeStyle.Analyzers.Rule.csproj" />
   </ItemGroup>
 

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConsistentParameterAttributesAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConsistentParameterAttributesAnalyzer.cs
@@ -9,12 +9,14 @@ namespace SpecTests {
 		void EmptyMethod();
 		void MethodA( string foo, Func<string> bar );
 		void MethodB( [Constant] string foo, [StatelessFunc] Func<string> bar );
+		void MethodC( [PatternString( "^a$" )][PatternString( "^b$", ExpectMatch = false )] string foo );
 	}
 
 	class SomeBaseClass {
 		public abstract void EmptyMethod();
 		public abstract void MethodA( string foo, Func<string> bar );
 		public abstract void MethodB( [Constant] string foo, [StatelessFunc] Func<string> bar );
+		public abstract void MethodC( [PatternString( "^a$" )][PatternString( "^b$", ExpectMatch = false )] string foo );
 	}
 
 	class ImplicitClassOkay : SomeBaseClass, SomeInterface {
@@ -22,7 +24,7 @@ namespace SpecTests {
 		public override void EmptyMethod() => throw new NotImplementedException();
 		public override void MethodA( string foo, Func<string> bar ) => throw new NotImplementedException();
 		public override void MethodB( [Constant] string foo, [StatelessFunc] Func<string> bar ) => throw new NotImplementedException();
-
+		public override void MethodC( [PatternString( "^a$" )][PatternString( "^b$", ExpectMatch = false )] string foo ) => throw new NotImplementedException();
 	}
 
 	class ExplicitClassOkay : SomeInterface {
@@ -30,6 +32,7 @@ namespace SpecTests {
 		void SomeInterface.EmptyMethod() => throw new NotImplementedException();
 		void SomeInterface.MethodA( string foo, Func<string> bar ) => throw new NotImplementedException();
 		void SomeInterface.MethodB( [Constant] string foo, [StatelessFunc] Func<string> bar ) => throw new NotImplementedException();
+		void SomeInterface.MethodC( [PatternString( "^a$" )][PatternString( "^b$", ExpectMatch = false )] string foo ) => throw new NotImplementedException();
 
 	}
 
@@ -44,6 +47,9 @@ namespace SpecTests {
 			/* InconsistentMethodAttributeApplication(Constant, ImplicitClassBad.MethodB, SomeBaseClass.MethodB) | InconsistentMethodAttributeApplication(Constant, ImplicitClassBad.MethodB, SomeInterface.MethodB) */ string foo /**/,
 			/* InconsistentMethodAttributeApplication(StatelessFunc, ImplicitClassBad.MethodB, SomeBaseClass.MethodB) | InconsistentMethodAttributeApplication(StatelessFunc, ImplicitClassBad.MethodB, SomeInterface.MethodB) */ Func<string> bar /**/
 		) => throw new NotImplementedException();
+		public override void MethodC(
+			/* InconsistentMethodAttributeApplication(PatternString, ImplicitClassBad.MethodC, SomeBaseClass.MethodC) | InconsistentMethodAttributeApplication(PatternString, ImplicitClassBad.MethodC, SomeInterface.MethodC) */ string foo /**/
+		) => throw new NotImplementedException();
 
 	}
 
@@ -57,6 +63,9 @@ namespace SpecTests {
 		void SomeInterface.MethodB(
 			/* InconsistentMethodAttributeApplication(Constant, ExplicitClassBad.SpecTests.SomeInterface.MethodB, SomeInterface.MethodB) */ string foo /**/,
 			/* InconsistentMethodAttributeApplication(StatelessFunc, ExplicitClassBad.SpecTests.SomeInterface.MethodB, SomeInterface.MethodB) */ Func<string> bar /**/
+		) => throw new NotImplementedException();
+		void SomeInterface.MethodC(
+			/* InconsistentMethodAttributeApplication(PatternString, ExplicitClassBad.SpecTests.SomeInterface.MethodC, SomeInterface.MethodC) */ [PatternString( "^a$" )][PatternString( "^b$" )] string foo /**/
 		) => throw new NotImplementedException();
 
 	}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConstantAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/ConstantAttributeAnalyzer.cs
@@ -324,10 +324,10 @@ namespace SpecTests {
 		void MethodReferenceTests() {
 
 			{ Action<int> action = Types.SomeMethodWithParameter<int>; }
-			{ Action<int> action = /* ReferenceToMethodWithConstantParameterNotSupport */ Types.SomeMethodWithConstantParameter<int> /**/; }
-			{ Action<int, int> action = /* ReferenceToMethodWithConstantParameterNotSupport */ Types.SomeMethodWithOneConstantParameter<int> /**/; }
-			{ Action<int, int> action = /* ReferenceToMethodWithConstantParameterNotSupport */ Types.SomeMethodWithOneOtherConstantParameter<int> /**/; }
-			{ Action<int, int> action = /* ReferenceToMethodWithConstantParameterNotSupport */ Types.SomeMethodWithTwoConstantParameters<int> /**/; }
+			{ Action<int> action = /* ReferenceToMethodWithAttributedParameterNotSupported(Constant) */ Types.SomeMethodWithConstantParameter<int> /**/; }
+			{ Action<int, int> action = /* ReferenceToMethodWithAttributedParameterNotSupported(Constant) */ Types.SomeMethodWithOneConstantParameter<int> /**/; }
+			{ Action<int, int> action = /* ReferenceToMethodWithAttributedParameterNotSupported(Constant) */ Types.SomeMethodWithOneOtherConstantParameter<int> /**/; }
+			{ Action<int, int> action = /* ReferenceToMethodWithAttributedParameterNotSupported(Constant) */ Types.SomeMethodWithTwoConstantParameters<int> /**/; }
 		}
 
 		#endregion

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
@@ -17,7 +17,7 @@ namespace SpecTests {
 		public string Field;
 
 		// Requires a constant string that does NOT contain whitespace.
-		[PatternString( "\\s", expectMatch: false )]
+		[PatternString( "\\s", ExpectMatch = false )]
 		public string NoWhitespace { get; set; }
 
 		// A const declaration is evaluated at its initializer.
@@ -102,7 +102,7 @@ namespace SpecTests {
 			good.Field = /* PatternStringDoesNotMatch(12a, to match, ^[0-9]+$) */ "12a" /**/;
 			#endregion
 
-			#region expectMatch: false semantics (must NOT contain whitespace)
+			#region ExpectMatch = false semantics (must NOT contain whitespace)
 			good.NoWhitespace = "no-whitespace";
 			good.NoWhitespace = /* PatternStringDoesNotMatch(has space, to not match, \s) */ "has space" /**/;
 			#endregion

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
@@ -6,222 +6,111 @@ namespace SpecTests {
 
 	using D2L.CodeStyle.Annotations.Contract;
 
-	public sealed class Model {
+	public readonly struct Digits {
+		private Digits( string s, bool @private ) {}
 
-		// Requires a constant string consisting solely of digits.
-		// [Constant] is no longer required alongside [PatternString].
-		[PatternString( "^[0-9]+$" )]
-		public string Property { get; set; }
+		public Digits( [PatternString( "^[0-9]+$" )] string s ) : this( s, true ) {}
 
-		[PatternString( "^[0-9]+$" )]
-		public string Field;
-
-		// Requires a constant string that does NOT contain whitespace.
-		[PatternString( "\\s", ExpectMatch = false )]
-		public string NoWhitespace { get; set; }
-
-		// A const declaration is evaluated at its initializer.
-		[PatternString( "^[0-9]+$" )]
-		public const string GoodConst = "123";
-
-		[PatternString( "^[0-9]+$" )]
-		public const string BadConst = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
-
-		// A static field declaration is evaluated at its initializer.
-		[PatternString( "^[0-9]+$" )]
-		public static readonly string GoodStaticField = "123";
-
-		[PatternString( "^[0-9]+$" )]
-		public static readonly string BadStaticField = /* PatternStringDoesNotMatch(xyz, to match, ^[0-9]+$) */ "xyz" /**/;
-
-		// Multiple [PatternString] attributes require the value to satisfy every
-		// pattern: must be digits AND must be exactly 3 characters long.
-		[PatternString( "^[0-9]+$" )]
-		[PatternString( "^.{3}$" )]
-		public string MultiPattern { get; set; }
-
-		[PatternString( "^[0-9]+$" )]
-		[PatternString( "^.{3}$" )]
-		public const string GoodMultiConst = "123";
+		public static implicit operator Digits( [PatternString( "^[0-9]+$" )] string s )
+			=> new( s, true );
 	}
 
-	public sealed class NonStringModel {
+	// Multiple [PatternString] attributes require the value to satisfy every pattern
+	public readonly struct ThreeDigits {
+		private ThreeDigits( string s, bool @private ) { }
 
-		// [PatternString] on a non-string member is flagged at the declaration.
-		[/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/]
-		public int NonStringProperty { get; set; }
+		public ThreeDigits( [PatternString( "^[0-9]+$" )][PatternString( "^.{3}$" )] string s ) : this( s, true ) { }
 
-		[/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/]
-		public int NonStringField;
-
-		// Every [PatternString] on a non-string member is flagged.
-		[/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/]
-		[/* PatternStringOnNonStringType(int) */ PatternString( "^.{3}$" ) /**/]
-		public int MultiNonString { get; set; }
-
-		// [PatternString] on a non-string parameter is flagged too.
-		public static void NonStringParameter( [/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/] int value ) { }
+		public static implicit operator ThreeDigits( [PatternString( "^[0-9]+$" )][PatternString( "^.{3}$" )] string s )
+			=> new( s, true );
 	}
 
-	public sealed class FieldList {
+	// ExpectMatch = false requires a constatns tring that does NOT match
+	public readonly struct NoDigits {
+		private NoDigits( string s, bool @private ) { }
 
-		// [PatternString] on a parameter validates the argument at the call site.
-		public FieldList( [PatternString( "^[0-9]+$" )] string fields ) { }
+		public NoDigits( [PatternString( "^[0-9]+$", ExpectMatch = false )] string s ) : this( s, true ) { }
 
-		public static implicit operator FieldList( [PatternString( "^[0-9]+$" )] string fields ) {
-			return null;
-		}
+		public static implicit operator NoDigits( [PatternString( "^[0-9]+$", ExpectMatch = false )] string s )
+			=> new( s, true );
+	}
 
-		// [PatternString] may coexist with [Constant] on the same parameter.
-		public static FieldList Create( [Constant][PatternString( "^[0-9]+$" )] string fields ) {
-			return null;
-		}
+	public sealed class NonString {
+		public static void M( [/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/] int value ) { }
 	}
 
 	public sealed class Tests {
 
-		void PropertyAndFieldTests() {
+		void SinglePatternTests() {
 
 			const string DIGITS = "123";
 			const string LETTERS = "abc";
 
 			#region Matching values are fine
-			var good = new Model {
-				Property = "123",
-				Field = DIGITS
-			};
+			Digits _ = DIGITS;
+			Digits _ = new( DIGITS );
+			_ = (Digits)DIGITS;
 
-			good.Property = "123";
-			good.Property = DIGITS;
-			good.Field = DIGITS + "456";
+			Digits _ = "123";
+			Digits _ = new( "123" );
+			_ = (DIGITS)"123";
+
+			Digits _ = DIGITS + "456";
+			Digits _ = new( DIGITS + "456" );
+			_ = (Digits)( DIGITS + "456" );
 			#endregion
 
 			#region Non-matching values are flagged
-			good.Property = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
-			good.Property = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ LETTERS /**/;
-			good.Field = /* PatternStringDoesNotMatch(12a, to match, ^[0-9]+$) */ "12a" /**/;
+			Digits _ = /* PatternStringDoesNotMatch(12a, to match, ^[0-9]+$) */ "12a" /**/;
+			Digits _ = new( /* PatternStringDoesNotMatch(12a, to match, ^[0-9]+$) */ "12a" /**/ );
+			_ = (Digits) /* PatternStringDoesNotMatch(12a, to match, ^[0-9]+$) */ "12a" /**/;
 			#endregion
 
-			#region ExpectMatch = false semantics (must NOT contain whitespace)
-			good.NoWhitespace = "no-whitespace";
-			good.NoWhitespace = /* PatternStringDoesNotMatch(has space, to not match, \s) */ "has space" /**/;
+			#region ExpectMatch = false semantics
+			NoDigits _ = "abc";
+			NoDigits _ = new( "abc" );
+			_ = (NoDigits)"abc";
+			NoDigits _ = /* PatternStringDoesNotMatch(123, to not match, ^[0-9]+$) */ "123" /**/;
+			NoDigits _ = new( /* PatternStringDoesNotMatch(123, to not match, ^[0-9]+$) */ "123" /**/ );
+			_ = (NoDigits) /* PatternStringDoesNotMatch(123, to not match, ^[0-9]+$) */ "123" /**/
 			#endregion
 		}
 
 		void NonConstantValuesAreFlagged() {
 
 			string variable = "123";
-			var good = new Model();
 
 			#region Non-constant values are flagged as needing to be constant
-			good.Property = /* PatternStringMustBeConstant() */ variable /**/;
-			good.Field = /* PatternStringMustBeConstant() */ Guid.NewGuid().ToString() /**/;
-
-			var built = new Model {
-				Property = /* PatternStringMustBeConstant() */ variable /**/
-			};
-			#endregion
-		}
-
-		void InitializerTests() {
-
-			#region Non-matching initializers are flagged
-			var bad = new Model {
-				Property = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/,
-				Field = /* PatternStringDoesNotMatch(xyz, to match, ^[0-9]+$) */ "xyz" /**/
-			};
+			Digits _ = new( /* PatternStringMustBeConstant() */ variable /**/ );
+			Digits _ = /* PatternStringMustBeConstant() */ variable /**/;
+			_ = (Digits)/* PatternStringMustBeConstant() */ variable /**/;
 			#endregion
 		}
 
 		void MultiplePatternTests() {
 
-			var model = new Model();
-
 			#region A value satisfying every pattern is fine
-			model.MultiPattern = "123";
+			ThreeDigits _ = "123";
+			ThreeDigits _ = new( "123" );
+			_ = (ThreeDigits)"123";
 			#endregion
 
 			#region Failing the first pattern (not digits) is flagged
-			model.MultiPattern = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
+			ThreeDigits _ = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
+			ThreeDigits _ = new( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/ );
+			_ = (ThreeDigits) /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
 			#endregion
 
 			#region Failing the second pattern (wrong length) is flagged
-			model.MultiPattern = /* PatternStringDoesNotMatch(12, to match, ^.{3}$) */ "12" /**/;
+			ThreeDigits _ = /* PatternStringDoesNotMatch(12, to match, ^.{3}$) */ "12" /**/;
+			ThreeDigits _ = new( /* PatternStringDoesNotMatch(12, to match, ^.{3}$) */ "12" /**/ );
+			_ = (ThreeDigits) /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
 			#endregion
 
 			#region Failing both patterns is flagged once per pattern
-			model.MultiPattern = /* PatternStringDoesNotMatch(ab, to match, ^[0-9]+$) | PatternStringDoesNotMatch(ab, to match, ^.{3}$) */ "ab" /**/;
-			#endregion
-		}
-
-		void ParameterTests() {
-
-			const string DIGITS = "123";
-			string variable = "123";
-
-			#region Matching constant arguments are fine
-			var a = new FieldList( "123" );
-			var b = new FieldList( DIGITS );
-			var d = FieldList.Create( "123" );
-			#endregion
-
-			#region Non-matching constant arguments are flagged
-			var e = new FieldList( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/ );
-			var g = FieldList.Create( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/ );
-			#endregion
-
-			#region Non-constant arguments are flagged as needing to be constant
-			var h = new FieldList( /* PatternStringMustBeConstant() */ variable /**/ );
-			var i = new FieldList( /* PatternStringMustBeConstant() */ Guid.NewGuid().ToString() /**/ );
-			#endregion
-		}
-
-		void ConversionTests() {
-
-			const string DIGITS = "123";
-			string variable = "123";
-
-			#region Matching conversion operands are fine
-			FieldList a = "123";
-			FieldList b = DIGITS;
-			var c = (FieldList)"123";
-			#endregion
-
-			#region Non-matching implicit conversion operands are flagged
-			FieldList d = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
-			#endregion
-
-			#region Non-matching explicit conversion operands are flagged
-			var e = (FieldList)( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/ );
-			#endregion
-
-			#region Non-constant conversion operands are flagged as needing to be constant
-			FieldList f = /* PatternStringMustBeConstant() */ variable /**/;
-			#endregion
-		}
-
-		void DeconstructionTests() {
-
-			var good = new Model();
-			int number;
-			string variable = "123";
-
-			#region Matching values in a deconstruction are fine
-			(good.Property, number) = ("123", 5);
-			(good.Property, good.Field) = ("123", "456");
-			#endregion
-
-			#region Non-matching values in a deconstruction are flagged
-			(good.Property, number) = ( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/, 5);
-			(good.Property, good.Field) = ( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/, /* PatternStringDoesNotMatch(xyz, to match, ^[0-9]+$) */ "xyz" /**/ );
-			#endregion
-
-			#region Non-constant values in a deconstruction are flagged as needing to be constant
-			(good.Property, number) = ( /* PatternStringMustBeConstant() */ variable /**/, 5);
-			#endregion
-
-			#region Nested deconstruction values are flagged
-			((good.Property, number), good.Field) = (( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/, 5), "123");
+			ThreeDigits _  = /* PatternStringDoesNotMatch(ab, to match, ^[0-9]+$) | PatternStringDoesNotMatch(ab, to match, ^.{3}$) */ "ab" /**/;
+			ThreeDigits _  = new( /* PatternStringDoesNotMatch(ab, to match, ^[0-9]+$) | PatternStringDoesNotMatch(ab, to match, ^.{3}$) */ "ab" /**/ );
+			_ = (ThreeDigits) /* PatternStringDoesNotMatch(ab, to match, ^[0-9]+$) | PatternStringDoesNotMatch(ab, to match, ^.{3}$) */ "ab" /**/;
 			#endregion
 		}
 	}

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
@@ -36,7 +36,14 @@ namespace SpecTests {
 	}
 
 	public sealed class NonString {
-		public static void M( [/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/] int value ) { }
+		public static void M( [PatternString( "^[0-9]+$" )] int /* PatternStringOnNonStringType(int) */ value /**/ ) { }
+	}
+
+	public sealed class InvalidRegex {
+		public static void M1( [/* PatternStringInvalidPattern(^[0-9+$,parsing "^[0-9+$" - Unterminated [] set.) */ PatternString( "^[0-9+$" ) /**/] string s ) { }
+		public static void M2( [/* PatternStringInvalidPattern(,Pattern is empty) */ PatternString( null ) /**/] string s ) { }
+		public static void M3( [/* PatternStringInvalidPattern(,Pattern is empty) */ PatternString( "" ) /**/] string s ) { }
+		public static void M4( [/* PatternStringInvalidPattern(  ,Pattern is empty) */ PatternString( " " ) /**/] string s ) { }
 	}
 
 	public sealed class Tests {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
@@ -46,6 +46,20 @@ namespace SpecTests {
 		public static void M4( [/* PatternStringInvalidPattern(  ,Pattern is empty) */ PatternString( " " ) /**/] string s ) { }
 	}
 
+	public sealed class MethodReferenceTests {
+		void M1( string s ) { }
+		void M2( [PatternString( "^[0-9]+$" )] string s ) { }
+		void M3( [PatternString( "^[0-9]+$" )] string s, string s2 ) { }
+		void M4( [PatternString( "^[0-9]+$" )] string s, [PatternString( "^[0-9]+$" )] string s2 ) { }
+
+		void M2() {
+			Action<string> _ = M1;
+			Action<string> _ = /* ReferenceToMethodWithAttributedParameterNotSupported(PatternString) */ M2 /**/;
+			Action<string, string> _ = /* ReferenceToMethodWithAttributedParameterNotSupported(PatternString) */ M3 /**/;
+			Action<string, string> _ = /* ReferenceToMethodWithAttributedParameterNotSupported(PatternString) */ M4 /**/;
+		}
+	}
+
 	public sealed class Tests {
 
 		void SinglePatternTests() {

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
@@ -1,0 +1,229 @@
+﻿// analyzer: D2L.CodeStyle.Analyzers.ApiUsage.PatternStringAttributeAnalyzer, D2L.CodeStyle.Analyzers.Rule.PatternString
+
+using System;
+
+namespace SpecTests {
+
+	using D2L.CodeStyle.Annotations.Contract;
+
+	public sealed class Model {
+
+		// Requires a constant string consisting solely of digits.
+		// [Constant] is no longer required alongside [PatternString].
+		[PatternString( "^[0-9]+$" )]
+		public string Property { get; set; }
+
+		[PatternString( "^[0-9]+$" )]
+		public string Field;
+
+		// Requires a constant string that does NOT contain whitespace.
+		[PatternString( "\\s", expectMatch: false )]
+		public string NoWhitespace { get; set; }
+
+		// A const declaration is evaluated at its initializer.
+		[PatternString( "^[0-9]+$" )]
+		public const string GoodConst = "123";
+
+		[PatternString( "^[0-9]+$" )]
+		public const string BadConst = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
+
+		// A static field declaration is evaluated at its initializer.
+		[PatternString( "^[0-9]+$" )]
+		public static readonly string GoodStaticField = "123";
+
+		[PatternString( "^[0-9]+$" )]
+		public static readonly string BadStaticField = /* PatternStringDoesNotMatch(xyz, to match, ^[0-9]+$) */ "xyz" /**/;
+
+		// Multiple [PatternString] attributes require the value to satisfy every
+		// pattern: must be digits AND must be exactly 3 characters long.
+		[PatternString( "^[0-9]+$" )]
+		[PatternString( "^.{3}$" )]
+		public string MultiPattern { get; set; }
+
+		[PatternString( "^[0-9]+$" )]
+		[PatternString( "^.{3}$" )]
+		public const string GoodMultiConst = "123";
+	}
+
+	public sealed class NonStringModel {
+
+		// [PatternString] on a non-string member is flagged at the declaration.
+		[/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/]
+		public int NonStringProperty { get; set; }
+
+		[/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/]
+		public int NonStringField;
+
+		// Every [PatternString] on a non-string member is flagged.
+		[/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/]
+		[/* PatternStringOnNonStringType(int) */ PatternString( "^.{3}$" ) /**/]
+		public int MultiNonString { get; set; }
+
+		// [PatternString] on a non-string parameter is flagged too.
+		public static void NonStringParameter( [/* PatternStringOnNonStringType(int) */ PatternString( "^[0-9]+$" ) /**/] int value ) { }
+	}
+
+	public sealed class FieldList {
+
+		// [PatternString] on a parameter validates the argument at the call site.
+		public FieldList( [PatternString( "^[0-9]+$" )] string fields ) { }
+
+		public static implicit operator FieldList( [PatternString( "^[0-9]+$" )] string fields ) {
+			return null;
+		}
+
+		// [PatternString] may coexist with [Constant] on the same parameter.
+		public static FieldList Create( [Constant][PatternString( "^[0-9]+$" )] string fields ) {
+			return null;
+		}
+	}
+
+	public sealed class Tests {
+
+		void PropertyAndFieldTests() {
+
+			const string DIGITS = "123";
+			const string LETTERS = "abc";
+
+			#region Matching values are fine
+			var good = new Model {
+				Property = "123",
+				Field = DIGITS
+			};
+
+			good.Property = "123";
+			good.Property = DIGITS;
+			good.Field = DIGITS + "456";
+			#endregion
+
+			#region Non-matching values are flagged
+			good.Property = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
+			good.Property = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ LETTERS /**/;
+			good.Field = /* PatternStringDoesNotMatch(12a, to match, ^[0-9]+$) */ "12a" /**/;
+			#endregion
+
+			#region expectMatch: false semantics (must NOT contain whitespace)
+			good.NoWhitespace = "no-whitespace";
+			good.NoWhitespace = /* PatternStringDoesNotMatch(has space, to not match, \s) */ "has space" /**/;
+			#endregion
+		}
+
+		void NonConstantValuesAreFlagged() {
+
+			string variable = "123";
+			var good = new Model();
+
+			#region Non-constant values are flagged as needing to be constant
+			good.Property = /* PatternStringMustBeConstant() */ variable /**/;
+			good.Field = /* PatternStringMustBeConstant() */ Guid.NewGuid().ToString() /**/;
+
+			var built = new Model {
+				Property = /* PatternStringMustBeConstant() */ variable /**/
+			};
+			#endregion
+		}
+
+		void InitializerTests() {
+
+			#region Non-matching initializers are flagged
+			var bad = new Model {
+				Property = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/,
+				Field = /* PatternStringDoesNotMatch(xyz, to match, ^[0-9]+$) */ "xyz" /**/
+			};
+			#endregion
+		}
+
+		void MultiplePatternTests() {
+
+			var model = new Model();
+
+			#region A value satisfying every pattern is fine
+			model.MultiPattern = "123";
+			#endregion
+
+			#region Failing the first pattern (not digits) is flagged
+			model.MultiPattern = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
+			#endregion
+
+			#region Failing the second pattern (wrong length) is flagged
+			model.MultiPattern = /* PatternStringDoesNotMatch(12, to match, ^.{3}$) */ "12" /**/;
+			#endregion
+
+			#region Failing both patterns is flagged once per pattern
+			model.MultiPattern = /* PatternStringDoesNotMatch(ab, to match, ^[0-9]+$) | PatternStringDoesNotMatch(ab, to match, ^.{3}$) */ "ab" /**/;
+			#endregion
+		}
+
+		void ParameterTests() {
+
+			const string DIGITS = "123";
+			string variable = "123";
+
+			#region Matching constant arguments are fine
+			var a = new FieldList( "123" );
+			var b = new FieldList( DIGITS );
+			var d = FieldList.Create( "123" );
+			#endregion
+
+			#region Non-matching constant arguments are flagged
+			var e = new FieldList( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/ );
+			var g = FieldList.Create( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/ );
+			#endregion
+
+			#region Non-constant arguments are flagged as needing to be constant
+			var h = new FieldList( /* PatternStringMustBeConstant() */ variable /**/ );
+			var i = new FieldList( /* PatternStringMustBeConstant() */ Guid.NewGuid().ToString() /**/ );
+			#endregion
+		}
+
+		void ConversionTests() {
+
+			const string DIGITS = "123";
+			string variable = "123";
+
+			#region Matching conversion operands are fine
+			FieldList a = "123";
+			FieldList b = DIGITS;
+			var c = (FieldList)"123";
+			#endregion
+
+			#region Non-matching implicit conversion operands are flagged
+			FieldList d = /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/;
+			#endregion
+
+			#region Non-matching explicit conversion operands are flagged
+			var e = (FieldList)( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/ );
+			#endregion
+
+			#region Non-constant conversion operands are flagged as needing to be constant
+			FieldList f = /* PatternStringMustBeConstant() */ variable /**/;
+			#endregion
+		}
+
+		void DeconstructionTests() {
+
+			var good = new Model();
+			int number;
+			string variable = "123";
+
+			#region Matching values in a deconstruction are fine
+			(good.Property, number) = ("123", 5);
+			(good.Property, good.Field) = ("123", "456");
+			#endregion
+
+			#region Non-matching values in a deconstruction are flagged
+			(good.Property, number) = ( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/, 5);
+			(good.Property, good.Field) = ( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/, /* PatternStringDoesNotMatch(xyz, to match, ^[0-9]+$) */ "xyz" /**/ );
+			#endregion
+
+			#region Non-constant values in a deconstruction are flagged as needing to be constant
+			(good.Property, number) = ( /* PatternStringMustBeConstant() */ variable /**/, 5);
+			#endregion
+
+			#region Nested deconstruction values are flagged
+			((good.Property, number), good.Field) = (( /* PatternStringDoesNotMatch(abc, to match, ^[0-9]+$) */ "abc" /**/, 5), "123");
+			#endregion
+		}
+	}
+
+}


### PR DESCRIPTION
Brings in the `[PatternString]` attribute from the LMS (so it can be used outside the LMS), with edits to the analysis being done.

* Only only application to parameters, thus only analyze arguments (and conversions which are implicit arguments. This works more similarly to `[Constant]`, where holding an analyzed value in a property/field can be done via a wrapper struct. The previous analysis was quite heavy (top 3 analyzers) even without any usage of the attribute.
* Move diagnostic reporting of "invalid regex" to the attribute usage, vs consumers. Previously a bad regex wouldn't be reported unless and API was used, and you would get a diagnostic per usage (including in projects not defining the API).
* Add other familiar checks such as preventing MethodReferences (where we'd lose knowledge of the attribute, and wouldn't be able to enforce the regex), and enforcing consistent application between interface/base class implementation/override.

SPLA-4124