### PR TITLE
PatternString: treat null values as non-passing

### DIFF
--- a/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
+++ b/src/Rules/D2L.CodeStyle.Analyzers.Rule.PatternString/PatternStringAttributeAnalyzer.cs
@@ -249,7 +249,7 @@ public sealed class PatternStringAttributeAnalyzer : DiagnosticAnalyzer {
 		// [PatternString] requires the assigned value to be a compile-time
 		// constant so that we can evaluate it here.
 		Optional<object?> constant = valueOperation.ConstantValue;
-		if( !constant.HasValue ) {
+		if( !constant.HasValue || constant.Value is null ) {
 			context.ReportDiagnostic(
 				Diagnostic.Create(
 					descriptor: Diagnostics.PatternStringMustBeConstant,

--- a/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
+++ b/tests/D2L.CodeStyle.Analyzers.Test/Specs/PatternStringAttributeAnalyzer.cs
@@ -98,13 +98,18 @@ namespace SpecTests {
 		}
 
 		void NonConstantValuesAreFlagged() {
-
+			#region Non-constant values are flagged as needing to be constant
 			string variable = "123";
 
-			#region Non-constant values are flagged as needing to be constant
 			Digits _ = new( /* PatternStringMustBeConstant() */ variable /**/ );
 			Digits _ = /* PatternStringMustBeConstant() */ variable /**/;
 			_ = (Digits)/* PatternStringMustBeConstant() */ variable /**/;
+			#endregion
+
+			#region null is treated as non-constant
+			Digits _ = new( /* PatternStringMustBeConstant() */ null /**/ );
+			Digits _ = /* PatternStringMustBeConstant() */ null /**/;
+			_ = (Digits)/* PatternStringMustBeConstant() */ null /**/;
 			#endregion
 		}
 


### PR DESCRIPTION
Currently crashes. Maybe we consider adding an `AllowNull` to the attribute

SPLA-4124